### PR TITLE
feat: Add Ollama Support to Agent Mastery Course

### DIFF
--- a/python/llm/agents/agent-mastery-course/backend/.env.example
+++ b/python/llm/agents/agent-mastery-course/backend/.env.example
@@ -3,14 +3,16 @@
 # Do not commit real secrets.
 
 # Choose ONE provider
-OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_API_KEY=#your_openai_api_key_here
 # Or use OpenRouter (OpenAI-compatible)
 # OPENROUTER_API_KEY=your_openrouter_api_key_here
 # OPENROUTER_MODEL=openai/gpt-4o-mini
+# Or use local model (Ollama)
+# OLLAMA_MODEL=#your_ollama_model_identification
 
 # Observability with Arize (https://app.arize.com)
-ARIZE_SPACE_ID=your_arize_space_id_here
-ARIZE_API_KEY=your_arize_api_key_here
+ARIZE_SPACE_ID=#your_arize_space_id_here
+ARIZE_API_KEY=#your_arize_api_key_here
 
 # Optional: Deterministic dev mode (no external LLM calls)
 # TEST_MODE=1

--- a/python/llm/agents/agent-mastery-course/backend/requirements.txt
+++ b/python/llm/agents/agent-mastery-course/backend/requirements.txt
@@ -20,3 +20,4 @@ litellm
 python-dotenv>=1.0.0
 requests>=2.31.0
 pandas>=2.0.0
+ollama>=0.6.1

--- a/python/llm/agents/agent-mastery-course/frontend/index.html
+++ b/python/llm/agents/agent-mastery-course/frontend/index.html
@@ -320,7 +320,8 @@
       renderIcons();
 
       try {
-        const resp = await fetch('/plan-trip', {
+        var url = 'http://localhost:8000/plan-trip'
+        const resp = await fetch(url, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ destination, duration, budget, interests })


### PR DESCRIPTION
Add support for local models run with Ollama for Python implementation of Agent Mastery Course.

Reason: While ArizeAI cannot be supported this way, this allows for local usage of workflow without requiring cloud subscriptions. Support for local models should enable more users to learn from the existing course.