### PR TITLE
chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.ipynb_checkpoints/
+__pycache__/
+*.pyc
+.DS_Store
+.env
+node_modules/


### PR DESCRIPTION
## Summary
- Adds .gitignore for common Python/Jupyter/Node artifacts (.ipynb_checkpoints, __pycache__, .env, node_modules, etc.)
