### PR TITLE
Add quickstart tutorial notebook

### DIFF
--- a/python/quickstart/tutorial-notebook.ipynb
+++ b/python/quickstart/tutorial-notebook.ipynb
@@ -1,0 +1,458 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Arize AX Get Started Tutorial\n",
+    "\n",
+    "This notebook accompanies the [Arize AX Get Started guide](https://arize.com/docs/ax/get-started). It builds a simple airline customer-service RAG chatbot called **SkyServe** and walks you through the full AX development workflow:\n",
+    "\n",
+    "1. **Tracing** - Instrument your app and send traces to Arize AX\n",
+    "2. **Evaluations** - Automatically measure response quality\n",
+    "3. **Prompt Playground & Prompt Hub** - Iterate on prompts using real data\n",
+    "4. **Datasets & Experiments** - Prove your changes work\n",
+    "5. **Dashboards & Monitors** - Stay on top of production\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- An [Arize AX account](https://app.arize.com/auth/join) (free)\n",
+    "- An [OpenAI API key](https://platform.openai.com/api-keys)\n",
+    "- Python 3.9+"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install the required packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install arize-otel openai openinference-instrumentation-openai chromadb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set your API keys. You can find your Arize Space ID and API Key on the **Settings** page in Arize AX."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = getpass(\"OpenAI API Key: \")\n",
+    "\n",
+    "ARIZE_SPACE_ID = getpass(\"Arize Space ID: \")\n",
+    "ARIZE_API_KEY = getpass(\"Arize API Key: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "# Part 1: Tracing\n",
+    "\n",
+    "In this section we build the SkyServe chatbot and instrument it so every request is traced in Arize AX.\n",
+    "\n",
+    "## 1.1 Create the airline policy documents\n",
+    "\n",
+    "These are the knowledge-base documents that our RAG chatbot will retrieve from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AIRLINE_POLICIES = [\n",
+    "    {\n",
+    "        \"title\": \"Refund Policy\",\n",
+    "        \"content\": (\n",
+    "            \"SkyServe Airlines Refund Policy:\\n\"\n",
+    "            \"- Full refund: Tickets canceled within 24 hours of purchase, regardless of fare type.\\n\"\n",
+    "            \"- Refundable tickets: Can be canceled anytime for a full refund minus a $25 processing fee.\\n\"\n",
+    "            \"- Non-refundable tickets: No cash refund. A travel credit is issued minus a $75 change fee. \"\n",
+    "            \"Credits expire 12 months from the original purchase date.\\n\"\n",
+    "            \"- Flights canceled by SkyServe: Passengers receive a full refund automatically within 7 business days.\\n\"\n",
+    "            \"- Refund requests must be submitted through the website or by calling customer support.\"\n",
+    "        ),\n",
+    "    },\n",
+    "    {\n",
+    "        \"title\": \"Baggage Allowance\",\n",
+    "        \"content\": (\n",
+    "            \"SkyServe Airlines Baggage Policy:\\n\"\n",
+    "            \"- Personal item (e.g., purse, laptop bag): Free on all fares. Must fit under the seat.\\n\"\n",
+    "            \"- Carry-on bag: Free on Plus and Premium fares. $35 per bag on Basic fares. \"\n",
+    "            \"Max dimensions: 22 x 14 x 9 inches.\\n\"\n",
+    "            \"- First checked bag: Free on Premium fares. $30 on Plus fares. $40 on Basic fares.\\n\"\n",
+    "            \"- Second checked bag: $45 on all fare types.\\n\"\n",
+    "            \"- Overweight bags (51-70 lbs): Additional $50 surcharge.\\n\"\n",
+    "            \"- Oversized bags (63-80 linear inches): Additional $75 surcharge.\\n\"\n",
+    "            \"- Bags over 70 lbs or 80 linear inches are not accepted.\"\n",
+    "        ),\n",
+    "    },\n",
+    "    {\n",
+    "        \"title\": \"Rebooking and Change Policy\",\n",
+    "        \"content\": (\n",
+    "            \"SkyServe Airlines Rebooking Policy:\\n\"\n",
+    "            \"- Premium and Plus fares: Free unlimited changes up to 1 hour before departure.\\n\"\n",
+    "            \"- Basic fares: $75 change fee per change, plus any fare difference.\\n\"\n",
+    "            \"- Same-day standby: Available for Plus and Premium passengers at no charge. \"\n",
+    "            \"Basic fare passengers pay $50.\\n\"\n",
+    "            \"- No-shows: Basic fare tickets are forfeited. Plus tickets receive travel credit minus $75. \"\n",
+    "            \"Premium tickets receive travel credit with no penalty.\\n\"\n",
+    "            \"- Schedule changes by SkyServe of more than 2 hours: Free rebooking or full refund offered.\"\n",
+    "        ),\n",
+    "    },\n",
+    "    {\n",
+    "        \"title\": \"Loyalty Program - SkyMiles\",\n",
+    "        \"content\": (\n",
+    "            \"SkyServe SkyMiles Loyalty Program:\\n\"\n",
+    "            \"- Earn 1 SkyMile per dollar spent on Basic fares, 2 on Plus, 3 on Premium.\\n\"\n",
+    "            \"- Tier levels: Silver (10,000 miles/year), Gold (25,000), Platinum (50,000), Diamond (100,000).\\n\"\n",
+    "            \"- Silver benefits: Priority boarding, free carry-on on Basic fares.\\n\"\n",
+    "            \"- Gold benefits: Silver perks + free first checked bag, lounge access 2x/year.\\n\"\n",
+    "            \"- Platinum benefits: Gold perks + free changes on all fares, unlimited lounge access.\\n\"\n",
+    "            \"- Diamond benefits: Platinum perks + complimentary upgrades when available, dedicated phone line.\\n\"\n",
+    "            \"- Miles expire after 24 months of account inactivity.\"\n",
+    "        ),\n",
+    "    },\n",
+    "    {\n",
+    "        \"title\": \"Flight Delay and Cancellation Compensation\",\n",
+    "        \"content\": (\n",
+    "            \"SkyServe Airlines Delay & Cancellation Compensation:\\n\"\n",
+    "            \"- Delays under 2 hours: No compensation provided.\\n\"\n",
+    "            \"- Delays of 2-4 hours: $50 travel voucher for future SkyServe flights.\\n\"\n",
+    "            \"- Delays over 4 hours: Rebooking on next available flight or full refund. \"\n",
+    "            \"Meal voucher ($15) provided at the airport.\\n\"\n",
+    "            \"- Overnight delays: Hotel accommodation arranged by SkyServe if the delay is within airline control. \"\n",
+    "            \"Transportation to/from hotel included.\\n\"\n",
+    "            \"- Cancellations: Full refund or rebooking on next available flight. \"\n",
+    "            \"If cancellation is within airline control, $100 travel voucher issued in addition.\\n\"\n",
+    "            \"- Weather-related disruptions: Rebooking at no charge, but no additional compensation.\"\n",
+    "        ),\n",
+    "    },\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.2 Build the vector store\n",
+    "\n",
+    "We use ChromaDB as a lightweight in-memory vector store. OpenAI embeddings convert our policy documents into vectors so the chatbot can find the most relevant policy for each question."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import chromadb\n",
+    "\n",
+    "chroma_client = chromadb.Client()\n",
+    "collection = chroma_client.create_collection(name=\"airline_policies\")\n",
+    "\n",
+    "collection.add(\n",
+    "    documents=[doc[\"content\"] for doc in AIRLINE_POLICIES],\n",
+    "    metadatas=[{\"title\": doc[\"title\"]} for doc in AIRLINE_POLICIES],\n",
+    "    ids=[f\"policy_{i}\" for i in range(len(AIRLINE_POLICIES))],\n",
+    ")\n",
+    "\n",
+    "print(f\"Indexed {collection.count()} policy documents.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.3 Set up Arize AX tracing\n",
+    "\n",
+    "These few lines are all it takes to send every OpenAI call to Arize AX as a trace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from arize.otel import register, Endpoint\n",
+    "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
+    "\n",
+    "tracer_provider = register(\n",
+    "    space_id=ARIZE_SPACE_ID,\n",
+    "    api_key=ARIZE_API_KEY,\n",
+    "    project_name=\"skyserve-chatbot\",\n",
+    "    endpoint=Endpoint.ARIZE,\n",
+    ")\n",
+    "\n",
+    "OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)\n",
+    "\n",
+    "print(\"Tracing enabled! All OpenAI calls will now appear in Arize AX.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.4 Build the RAG chatbot\n",
+    "\n",
+    "Our `ask_skyserve` function:\n",
+    "1. Retrieves the most relevant policy document from ChromaDB\n",
+    "2. Sends the question + context to OpenAI\n",
+    "3. Returns the response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openai\n",
+    "\n",
+    "oai_client = openai.OpenAI()\n",
+    "\n",
+    "SYSTEM_PROMPT = \"\"\"You are SkyServe Airlines' customer service assistant. \n",
+    "Answer the customer's question based on the provided policy documents. \n",
+    "Be friendly and helpful.\"\"\"\n",
+    "\n",
+    "\n",
+    "def ask_skyserve(question: str) -> str:\n",
+    "    \"\"\"Answer a customer question using RAG over airline policy documents.\"\"\"\n",
+    "    # Step 1: Retrieve relevant policy\n",
+    "    results = collection.query(query_texts=[question], n_results=2)\n",
+    "    context = \"\\n\\n\".join(results[\"documents\"][0])\n",
+    "\n",
+    "    # Step 2: Generate response\n",
+    "    response = oai_client.chat.completions.create(\n",
+    "        model=\"gpt-4o-mini\",\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": SYSTEM_PROMPT},\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": f\"Policy documents:\\n{context}\\n\\nCustomer question: {question}\",\n",
+    "            },\n",
+    "        ],\n",
+    "        temperature=0.3,\n",
+    "    )\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.5 Generate traces\n",
+    "\n",
+    "Let's run a set of customer questions through the chatbot. These include straightforward questions, edge cases, and some tricky ones where the chatbot might struggle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SAMPLE_QUESTIONS = [\n",
+    "    \"Can I get a refund on my Basic fare ticket I bought 3 days ago?\",\n",
+    "    \"How much does a carry-on bag cost?\",\n",
+    "    \"I'm a Gold SkyMiles member. Do I get free checked bags?\",\n",
+    "    \"My flight was delayed 5 hours. What am I entitled to?\",\n",
+    "    \"Can I change my Basic fare flight for free?\",\n",
+    "    \"What happens if I don't show up for my flight?\",\n",
+    "    \"How many SkyMiles do I earn on a Premium ticket?\",\n",
+    "    \"Is there a weight limit for checked bags?\",\n",
+    "    \"My flight was canceled due to weather. Do I get a hotel?\",\n",
+    "    \"I bought a non-refundable ticket yesterday. Can I still get my money back?\",\n",
+    "    \"What are the dimensions for carry-on bags?\",\n",
+    "    \"I'm a Silver member flying Basic. Do I get a free carry-on?\",\n",
+    "    \"Can I get a refund if SkyServe cancels my flight?\",\n",
+    "    \"How do I avoid paying for a carry-on bag?\",\n",
+    "    \"When do my SkyMiles expire?\",\n",
+    "]\n",
+    "\n",
+    "print(\"Sending questions to SkyServe chatbot...\\n\")\n",
+    "for q in SAMPLE_QUESTIONS:\n",
+    "    answer = ask_skyserve(q)\n",
+    "    print(f\"Q: {q}\")\n",
+    "    print(f\"A: {answer}\\n\")\n",
+    "    print(\"---\\n\")\n",
+    "\n",
+    "print(\"Done! Check your Arize AX project 'skyserve-chatbot' to see the traces.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "# Part 2: Evaluations\n",
+    "\n",
+    "Now that traces are flowing into Arize AX, set up **online evaluations** in the UI to automatically score every response. Follow the steps in the [Evaluations guide](https://arize.com/docs/ax/get-started/get-started-evaluations) to:\n",
+    "\n",
+    "1. Create an LLM-as-a-Judge evaluator for **Helpfulness**\n",
+    "2. Create a code-based evaluator to check for **empty responses**\n",
+    "3. View evaluation scores on your traces\n",
+    "\n",
+    "These evaluations are configured entirely in the AX UI - no code required."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "# Part 3: Prompt Playground & Prompt Hub\n",
+    "\n",
+    "With evaluation scores on your traces, you can now identify low-scoring responses and improve them. Follow the steps in the [Prompts guide](https://arize.com/docs/ax/get-started/get-started-prompts) to:\n",
+    "\n",
+    "1. Replay a low-scoring trace in the Prompt Playground\n",
+    "2. Improve the system prompt\n",
+    "3. Save the improved prompt to Prompt Hub\n",
+    "\n",
+    "Once you've saved an improved prompt, you can pull it into your app code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# After saving your improved prompt to Prompt Hub (see the Prompts guide),\n",
+    "# you can pull it into your app like this:\n",
+    "\n",
+    "from arize.experimental.prompt_hub import ArizePromptClient\n",
+    "\n",
+    "prompt_client = ArizePromptClient(\n",
+    "    space_id=ARIZE_SPACE_ID,\n",
+    "    api_key=ARIZE_API_KEY,\n",
+    ")\n",
+    "\n",
+    "# Pull the latest version of your prompt\n",
+    "saved_prompt = prompt_client.get_prompt(name=\"skyserve-support\")\n",
+    "print(\"Loaded prompt from Prompt Hub:\")\n",
+    "print(saved_prompt.messages)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "# Part 4: Datasets & Experiments\n",
+    "\n",
+    "Experiments let you prove that prompt changes actually improve quality across a representative set of queries - not just the one you noticed.\n",
+    "\n",
+    "Follow the steps in the [Experiments guide](https://arize.com/docs/ax/get-started/get-started-experiments) to create a dataset, run your old and new prompts as experiments, and compare results.\n",
+    "\n",
+    "Below is a sample CSV you can use to create your test dataset. Save it as `skyserve_test_cases.csv` and upload it in the AX UI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "test_cases = pd.DataFrame({\n",
+    "    \"input\": [\n",
+    "        \"Can I get a refund on my non-refundable ticket?\",\n",
+    "        \"How much does a second checked bag cost?\",\n",
+    "        \"I'm a Platinum member. Can I change my Basic fare for free?\",\n",
+    "        \"My flight was delayed 3 hours. What compensation do I get?\",\n",
+    "        \"What happens if I miss my flight with a Plus ticket?\",\n",
+    "        \"How big can my carry-on be?\",\n",
+    "        \"Do Silver members get lounge access?\",\n",
+    "        \"My flight was canceled due to a mechanical issue. What do I get?\",\n",
+    "        \"Can I get same-day standby on a Basic fare?\",\n",
+    "        \"How long do travel credits last?\",\n",
+    "    ],\n",
+    "    \"expected_output\": [\n",
+    "        \"No cash refund, but a travel credit is issued minus a $75 change fee. Credits expire in 12 months.\",\n",
+    "        \"$45 on all fare types.\",\n",
+    "        \"Yes, Platinum members get free changes on all fares.\",\n",
+    "        \"A $50 travel voucher for future SkyServe flights.\",\n",
+    "        \"Plus ticket no-shows receive travel credit minus $75.\",\n",
+    "        \"Maximum 22 x 14 x 9 inches.\",\n",
+    "        \"No, lounge access starts at Gold tier (2 visits/year).\",\n",
+    "        \"Full refund or rebooking, plus a $100 travel voucher since it was within airline control.\",\n",
+    "        \"Yes, for a $50 fee.\",\n",
+    "        \"Travel credits expire 12 months from the original purchase date.\",\n",
+    "    ],\n",
+    "})\n",
+    "\n",
+    "test_cases.to_csv(\"skyserve_test_cases.csv\", index=False)\n",
+    "print(\"Saved skyserve_test_cases.csv - upload this in the Arize AX UI.\")\n",
+    "test_cases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "# Part 5: Dashboards & Monitors\n",
+    "\n",
+    "With your app improved and tested, set up production monitoring. Follow the steps in the [Production guide](https://arize.com/docs/ax/get-started/get-started-production) to:\n",
+    "\n",
+    "1. Create a dashboard for the SkyServe project\n",
+    "2. Set up managed monitors for latency and errors\n",
+    "3. Create an eval-based monitor for quality alerts\n",
+    "4. Connect alerts to Slack or email\n",
+    "\n",
+    "All of this is done in the AX UI.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## What you've accomplished\n",
+    "\n",
+    "You've completed the full Arize AX development workflow:\n",
+    "\n",
+    "- **Tracing**: Full visibility into every chatbot request\n",
+    "- **Evaluations**: Automated quality scoring on every response\n",
+    "- **Prompts**: Data-driven prompt iteration with version control\n",
+    "- **Experiments**: Proof that your changes improve quality\n",
+    "- **Monitoring**: Alerts that catch regressions before your users do\n",
+    "\n",
+    "For deeper dives into any of these features, visit the [Arize AX documentation](https://arize.com/docs/ax)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- Adds a new quickstart tutorial notebook at `python/quickstart/tutorial-notebook.ipynb`

## Test plan
- [ ] Open the notebook and verify it runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)