### PR TITLE
fix(deps): patch python-dotenv CVE-2026-28684 in agent-mastery-course

### DIFF
--- a/python/llm/agents/agent-mastery-course/backend/requirements.txt
+++ b/python/llm/agents/agent-mastery-course/backend/requirements.txt
@@ -17,6 +17,6 @@ langchain>=0.3.7
 langchain-openai>=0.2.10
 langchain-community>=0.3.5
 litellm
-python-dotenv>=1.0.0
+python-dotenv>=1.2.2
 requests>=2.31.0
 pandas>=2.0.0


### PR DESCRIPTION
Bumps python-dotenv minimum from 1.0.0 to 1.2.2 to fix CVE-2026-28684.

Note: litellm>=1.83.7 (GHSA-xqmj-j6mv-4862, critical RCE) cannot be applied simultaneously — litellm 1.83.7+ pins python-dotenv==1.0.1, creating a resolution conflict. Tracked as an upstream issue in litellm.