### PR TITLE
fix(deps): patch langchain-openai SSRF vulnerability (GHSA-r7w7-9xr2-…

### DIFF
--- a/python/cookbooks/code_gen_agent_ax/requirements.txt
+++ b/python/cookbooks/code_gen_agent_ax/requirements.txt
@@ -1,7 +1,7 @@
 arize==8.5.0
 arize-otel==0.11.0
 gradio==6.9.0
-langchain-openai==1.1.11
+langchain-openai==1.1.14
 langgraph==1.1.0
 openinference.instrumentation.langchain==0.1.61
 openinference.instrumentation.openai==0.1.41


### PR DESCRIPTION
…qq2r)

Bumps langchain-openai from 1.1.11 to 1.1.14 to fix a DNS rebinding SSRF window in _url_to_size() that could allow blind probing of internal hosts.