### PR TITLE
Add Arize AX Airflow example DAGs

### DIFF
--- a/python/cookbooks/airflow_example_dags/README.md
+++ b/python/cookbooks/airflow_example_dags/README.md
@@ -1,0 +1,170 @@
+# Arize AX Airflow Example DAGs
+
+A collection of 19 example DAGs demonstrating the [`arize-ax-airflow-provider`](https://github.com/Arize-ai/arize-ax-airflow) — the official Apache Airflow provider for [Arize AX](https://arize.com/docs/ax/).
+
+Each DAG illustrates a real LLMOps workflow you can adapt for your own pipelines: CI/CD evaluation gates, prompt lifecycle management, drift detection with auto-rollback, RAG evaluation, dataset curation from production traces, fine-tuning data pipelines, behavioral regression checks, evaluator calibration, and more.
+
+> **Last Updated:** 2026-05-15
+
+---
+
+## Prerequisites
+
+- **Python** 3.10+
+- **Apache Airflow** 2.4+ (works on Airflow 3.x as well — DAGs use the modern `schedule=` and `from __future__ import annotations` style)
+- An **Arize AX account** with an API key — sign up at [arize.com](https://arize.com/) and grab a key from **Settings → API Keys**
+
+---
+
+## Install
+
+```bash
+pip install arize-ax-airflow-provider
+```
+
+Some DAGs need optional extras:
+
+| DAG | Extra | Why |
+|-----|-------|-----|
+| `example_arize_ax_prompt_optimization_with_feedback_dag.py` | `prompt_learning` | Uses the Prompt Learning SDK for meta-prompt optimization |
+| `example_arize_ax_admin_dag.py` (prompt tasks) | `PromptHub` | Requires the Arize `[PromptHub]` extra |
+
+```bash
+pip install 'arize-ax-airflow-provider[prompt_learning]'
+pip install 'arize[PromptHub]'
+```
+
+---
+
+## Set up the Airflow connection
+
+The DAGs all use a single connection named **`arize_ax_default`**.
+
+**Airflow UI** → **Admin → Connections → Add**:
+
+| Field | Value |
+|---|---|
+| Connection Id | `arize_ax_default` |
+| Connection Type | `Arize AX` |
+| Password | _your Arize API key_ |
+| Extra (optional) | `{"space_id": "U3BhY2U6...", "region": "us"}` |
+
+Or via the CLI:
+
+```bash
+airflow connections add arize_ax_default \
+    --conn-type arize_ax \
+    --conn-password "$ARIZE_AX_API_KEY" \
+    --conn-extra '{"space_id": "U3BhY2U6..."}'
+```
+
+If you set `space_id` in **Extra**, you can omit `space_id=` on individual operators and skip the `arize_ax_space_id` Variable below.
+
+---
+
+## Configure Airflow Variables
+
+The DAGs read configuration from Airflow Variables so you can run them without editing source. **Admin → Variables** (or `airflow variables set <key> <value>`):
+
+### Common (used by most DAGs)
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `arize_ax_space_id` | If not set in connection Extra | — | Target Arize space (global ID or name) |
+
+### Per-DAG
+
+| DAG | Variable | Required | Purpose |
+|---|---|---|---|
+| `annotation_queues_dag` | `arize_annotator_email` | ✅ | Comma-separated reviewer email(s), e.g. `alice@example.com,bob@example.com` |
+| `annotation_queues_dag` | `arize_queue_name` | optional | Demo queue name (default: `airflow-demo-queue`) |
+| `dataset_curation_dag` | `arize_ax_dataset_id` | ✅ | Target dataset to append curated examples to |
+| `drift_detection_dag` | `arize_ax_baseline_experiment_id` | ✅ | Baseline experiment for drift comparison |
+| `drift_detection_dag` | `arize_ax_candidate_experiment_id` | ✅ | Candidate experiment for drift comparison |
+| `llm_cicd_gate_dag` | `arize_ax_baseline_experiment_id` | ✅ | Baseline to gate releases against |
+| `prompt_lifecycle_dag` | `arize_ax_prompt_name` | ✅ | Prompt to promote staging → production |
+| `prompt_ab_test_dag` | `arize_ax_prompt_names` | optional | JSON list or CSV of prompt names to compare |
+| `prompt_optimization_with_feedback_dag` | `arize_ax_lookback_days` | optional | Days of production feedback to learn from |
+| `tasks_dag` / `evaluators_dag` | `ARIZE_AI_INTEGRATION_ID`, `ARIZE_EVALUATOR_MODEL` | ✅ | OpenAI/Anthropic integration UUID + model name for LLM-as-judge |
+
+The required values are documented in each DAG's module docstring — open the file and check the `**Required**` / `**Optional Airflow Variables**` sections.
+
+---
+
+## Drop the DAGs into your Airflow instance
+
+Copy the files into your Airflow `dags/` folder:
+
+```bash
+cp python/cookbooks/airflow_example_dags/*.py $AIRFLOW_HOME/dags/
+```
+
+Or symlink the directory so updates propagate:
+
+```bash
+ln -s "$(pwd)/python/cookbooks/airflow_example_dags" $AIRFLOW_HOME/dags/arize_ax_examples
+```
+
+Refresh the Airflow UI — all 19 DAGs should appear under the `arize_ax` tag.
+
+---
+
+## Run your first DAG
+
+Start with a small, self-contained one to verify your setup:
+
+```bash
+airflow dags trigger example_arize_ax_dataset
+```
+
+This DAG lists datasets, creates a tiny demo dataset, and fetches it back — a 10-second round-trip that confirms the connection, API key, and space are wired correctly.
+
+From there, work up to the workflow that matches your use case. The table below maps patterns to DAGs:
+
+| Pattern | DAG |
+|---|---|
+| Smoke test (datasets) | `example_arize_ax_dataset_dag.py` |
+| Run an experiment with a task + evaluator | `example_arize_ax_experiment_dag.py` |
+| LLM CI/CD gate (fail on regression) | `example_arize_ax_llm_cicd_gate_dag.py` |
+| Prompt lifecycle: staging → production | `example_arize_ax_prompt_lifecycle_dag.py` |
+| Prompt A/B testing | `example_arize_ax_prompt_ab_test_dag.py` |
+| Drift detection with auto-rollback | `example_arize_ax_drift_detection_dag.py` |
+| Behavioral regression detection | `example_arize_ax_behavioral_regression_dag.py` |
+| Evaluator calibration vs human labels | `example_arize_ax_evaluator_calibration_dag.py` |
+| RAG evaluation pipeline | `example_arize_ax_rag_evaluation_dag.py` |
+| Curate production spans into a dataset | `example_arize_ax_dataset_curation_dag.py` |
+| Fine-tuning data pipeline | `example_arize_ax_finetune_data_pipeline_dag.py` |
+| Continuous evaluation tasks (Eval Hub) | `example_arize_ax_tasks_dag.py` |
+| Human-in-the-loop annotation queues | `example_arize_ax_annotation_queues_dag.py` |
+| Multi-model experiment matrix | `example_arize_ax_llm_experiments_dag.py` |
+| Self-learning prompt optimization | `example_arize_ax_prompt_optimization_with_feedback_dag.py` |
+| Inventory / admin (list spaces, projects) | `example_arize_ax_admin_dag.py` |
+| Span export & metrics | `example_arize_ax_spans_dag.py` |
+| Custom evaluator creation | `example_arize_ax_evaluators_dag.py` |
+| ML (batch logging) | `example_arize_ax_ml_dag.py` |
+
+---
+
+## Adapting a DAG for your environment
+
+These are demo DAGs — `schedule=None` and `catchup=False` so they only run on manual trigger. To productionize one:
+
+1. **Set a schedule** — `schedule="@daily"` or a cron expression.
+2. **Replace demo seeds** — the small inline example lists (e.g. `{"query": "What is 2+2?", ...}`) are placeholders; point the DAG at your real dataset by setting the appropriate Variable.
+3. **Tighten cleanup tasks** — most demos delete the resources they create (via `trigger_rule="all_done"` cleanup tasks). Remove those if you want the resources to persist across runs.
+4. **Add alerting** — wire `on_failure_callback` / `on_retry_callback` to your Slack/PagerDuty hook for the gate DAGs (`llm_cicd_gate`, `drift_detection`, `behavioral_regression`).
+
+---
+
+## Further reading
+
+- **Provider guide:** [arize.com/docs/ax/integrations/orchestration/airflow/airflow-provider](https://arize.com/docs/ax/integrations/orchestration/airflow/airflow-provider)
+- **Operator reference:** [arize.com/docs/ax/integrations/orchestration/airflow/airflow-operators](https://arize.com/docs/ax/integrations/orchestration/airflow/airflow-operators)
+- **Provider source & issues:** [github.com/Arize-ai/arize-ax-airflow](https://github.com/Arize-ai/arize-ax-airflow)
+- **Arize AX docs:** [arize.com/docs/ax](https://arize.com/docs/ax/)
+
+---
+
+## 💬 Questions or feedback?
+
+Reach out via the **[Arize community Slack](https://arize-ai.slack.com/)** or [support](https://arize.com/support/).

--- a/python/cookbooks/airflow_example_dags/README.md
+++ b/python/cookbooks/airflow_example_dags/README.md
@@ -160,7 +160,6 @@ These are demo DAGs — `schedule=None` and `catchup=False` so they only run on 
 
 - **Provider guide:** [arize.com/docs/ax/integrations/orchestration/airflow/airflow-provider](https://arize.com/docs/ax/integrations/orchestration/airflow/airflow-provider)
 - **Operator reference:** [arize.com/docs/ax/integrations/orchestration/airflow/airflow-operators](https://arize.com/docs/ax/integrations/orchestration/airflow/airflow-operators)
-- **Provider source & issues:** [github.com/Arize-ai/arize-ax-airflow](https://github.com/Arize-ai/arize-ax-airflow)
 - **Arize AX docs:** [arize.com/docs/ax](https://arize.com/docs/ax/)
 
 ---

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_admin_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_admin_dag.py
@@ -1,0 +1,61 @@
+"""
+Example DAG: Arize AX admin / discovery operators.
+
+Lists projects, spaces, annotation configs, and prompts.  Useful for
+inventory audits, drift detection on annotation schemas, or syncing
+prompt versions across environments.
+
+Requires:
+- Airflow connection ``arize_ax_default`` with API key.
+- Airflow variable ``arize_ax_space_id``.
+- For prompt tasks: ``pip install 'arize[PromptHub]'``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.arize_ax.operators.annotations import (
+    ArizeAxListAnnotationConfigsOperator,
+)
+from airflow.providers.arize_ax.operators.projects import (
+    ArizeAxCreateProjectOperator,
+    ArizeAxListProjectsOperator,
+)
+from airflow.providers.arize_ax.operators.spaces import (
+    ArizeAxListSpacesOperator,
+)
+
+with DAG(
+    dag_id="example_arize_ax_admin",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "example", "admin"],
+    catchup=False,
+) as dag:
+    list_spaces = ArizeAxListSpacesOperator(
+        task_id="list_spaces",
+        limit=20,
+    )
+
+    list_projects = ArizeAxListProjectsOperator(
+        task_id="list_projects",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        limit=20,
+    )
+
+    list_annotation_configs = ArizeAxListAnnotationConfigsOperator(
+        task_id="list_annotation_configs",
+        limit=50,
+    )
+
+    create_project = ArizeAxCreateProjectOperator(
+        task_id="create_project",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        name="airflow-managed-project-{{ ds }}",
+        if_exists="skip",
+    )
+
+    list_spaces >> [list_projects, list_annotation_configs]
+    list_projects >> create_project

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_annotation_queues_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_annotation_queues_dag.py
@@ -1,0 +1,182 @@
+"""
+Example DAG: Arize AX Annotation Queues demo (alpha).
+
+This DAG demonstrates a fully self-contained Human-in-the-Loop (HITL) workflow.
+It creates its own annotation config, builds a queue against that config, inspects
+it, then cleans up — no pre-existing Arize resources are required.
+
+**Flow**
+
+1. ``create_annotation_config`` — create a freeform annotation config used by the queue.
+2. ``create_queue`` — create an annotation queue, pulling the config ID from XCom.
+3. ``get_queue`` — fetch the queue details to confirm creation.
+4. ``list_queues`` — list all annotation queues in the space.
+5. ``list_records`` — list records pending human review (empty after fresh create).
+6. ``cleanup_queue`` — delete the demo queue (runs regardless of upstream success).
+7. ``cleanup_config`` — delete the demo annotation config (runs regardless of upstream success).
+
+**Required**
+
+- Airflow connection ``arize_ax_default`` with API key (password or extra ``api_key``).
+  The ``default_space`` extra (or ``arize_ax_space_id`` Airflow Variable) must resolve
+  to a valid space; the hook will raise a clear error if neither is set.
+- Arize Python SDK >= 8.11.0 (``client.annotation_queues`` and
+  ``client.annotation_configs`` sub-clients).
+
+**Optional Airflow Variables**
+
+- ``arize_ax_space_id``     — space global ID or name; SDK infers from API key when absent.
+- ``arize_queue_name``      — name for the demo queue (default: ``"airflow-demo-queue"``).
+
+**Required Airflow Variable**
+
+- ``arize_annotator_email`` — comma-separated reviewer email(s) for the queue.
+  The task fails fast with a clear error if this Variable is unset.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.exceptions import AirflowException
+from airflow.models import Variable
+from airflow.providers.arize_ax.hooks.arize_ax import ArizeAxHook
+from airflow.providers.arize_ax.operators.annotations import (
+    ArizeAxCreateAnnotationConfigOperator,
+    ArizeAxDeleteAnnotationConfigOperator,
+    ArizeAxDeleteAnnotationQueueOperator,
+    ArizeAxGetAnnotationQueueOperator,
+    ArizeAxListAnnotationQueueRecordsOperator,
+    ArizeAxListAnnotationQueuesOperator,
+)
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator
+
+try:
+    from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
+except ImportError:
+    from airflow.sensors.time_delta import TimeDeltaSensor
+
+log = logging.getLogger(__name__)
+
+_CONFIG_NAME = "airflow-demo-annotation-config"
+
+
+def _resolve_annotator_emails() -> list[str]:
+    """Read reviewer emails from the ``arize_annotator_email`` Variable.
+
+    Fails fast (AirflowException) if the Variable is unset so the DAG doesn't
+    silently fall back to a hardcoded address.
+    """
+    raw = Variable.get("arize_annotator_email", default_var=None)
+    if not raw:
+        raise AirflowException(
+            "Set the 'arize_annotator_email' Airflow Variable to one or more "
+            "reviewer email addresses (comma-separated) before running this DAG."
+        )
+    emails = [e.strip() for e in str(raw).split(",") if e.strip()]
+    if not emails:
+        raise AirflowException(
+            "'arize_annotator_email' Variable is set but resolved to no addresses."
+        )
+    return emails
+
+
+def _create_queue(**context):
+    config_id = context["ti"].xcom_pull(task_ids="create_annotation_config")
+    space = Variable.get("arize_ax_space_id", default_var=None)
+    queue_name = Variable.get("arize_queue_name", default_var="airflow-demo-queue")
+    log.info("Using annotation config ID: %s", config_id)
+    hook = ArizeAxHook()
+    return hook.create_annotation_queue(
+        name=queue_name,
+        space=space,
+        annotation_config_ids=[config_id],
+        annotator_emails=_resolve_annotator_emails(),
+        instructions="Review LLM responses for accuracy and tone.",
+        assignment_method="all",
+    )
+
+
+with DAG(
+    dag_id="arize_ax_annotation_queues_demo",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "example", "annotations", "hitl"],
+    catchup=False,
+    doc_md=__doc__,
+) as dag:
+
+    _space_jinja = "{{ var.value.get('arize_ax_space_id', '') or None }}"
+    _queue_name_jinja = "{{ var.value.get('arize_queue_name', 'airflow-demo-queue') }}"
+
+    create_annotation_config = ArizeAxCreateAnnotationConfigOperator(
+        task_id="create_annotation_config",
+        name=_CONFIG_NAME,
+        space=_space_jinja,
+        config_type="freeform",
+    )
+
+    create_queue = PythonOperator(
+        task_id="create_queue",
+        python_callable=_create_queue,
+    )
+
+    get_queue = ArizeAxGetAnnotationQueueOperator(
+        task_id="get_queue",
+        annotation_queue=_queue_name_jinja,
+        space=_space_jinja,
+    )
+
+    list_queues = ArizeAxListAnnotationQueuesOperator(
+        task_id="list_queues",
+        space=_space_jinja,
+        limit=25,
+    )
+
+    list_records = ArizeAxListAnnotationQueueRecordsOperator(
+        task_id="list_records",
+        annotation_queue=_queue_name_jinja,
+        space=_space_jinja,
+        limit=50,
+    )
+
+    # Pause for manual inspection in the Arize AX UI. ``mode="reschedule"``
+    # releases the worker slot during the wait — unlike time.sleep which
+    # would hold a slot for the full 5 minutes.
+    inspect_pause = TimeDeltaSensor(
+        task_id="inspect_pause",
+        delta=timedelta(minutes=5),
+        mode="reschedule",
+        trigger_rule="all_done",
+    )
+
+    cleanup_queue = ArizeAxDeleteAnnotationQueueOperator(
+        task_id="cleanup_queue",
+        annotation_queue=_queue_name_jinja,
+        space=_space_jinja,
+        trigger_rule="all_done",
+    )
+
+    cleanup_config = ArizeAxDeleteAnnotationConfigOperator(
+        task_id="cleanup_config",
+        annotation_config=_CONFIG_NAME,
+        space=_space_jinja,
+        trigger_rule="all_done",
+    )
+
+    (
+        create_annotation_config
+        >> create_queue
+        >> get_queue
+        >> list_queues
+        >> list_records
+        >> inspect_pause
+        >> cleanup_queue
+        >> cleanup_config
+    )

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_behavioral_regression_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_behavioral_regression_dag.py
@@ -1,0 +1,277 @@
+"""
+Behavioral Regression Testing DAG (self-contained, server-side).
+
+Creates a small demo dataset, runs **two server-side experiment tasks** (Arize
+makes the LLM calls — no Python task callable runs on the Airflow worker),
+then compares the two experiment runs with
+``ArizeAxBehavioralRegressionOperator`` to detect output-length, refusal-rate,
+or eval-score-distribution drift between baseline and candidate. When the
+candidate diverges beyond ``significance_threshold`` the operator raises
+``AirflowException`` (``fail_on_regression=True``) to block downstream
+promotion in a real pipeline.
+
+Baseline and candidate share the same ``RunConfiguration`` so the demo ends
+green. To watch the gate fire, edit ``_build_candidate_run_config`` to use a
+different model, system prompt, or invocation parameters.
+
+Required configuration
+----------------------
+- Airflow connection ``arize_ax_default`` with a valid API key. ``space_id``
+  is read from the connection's ``extra.default_space`` if present, else from
+  the ``arize_ax_space_id`` Variable.
+- ``ARIZE_AI_INTEGRATION_ID`` Airflow Variable (or worker env var) — the
+  Arize AI Integration ID identifying the LLM provider/credentials used by
+  the server-side experiment tasks. If absent, ``check_ai_integration``
+  short-circuits cleanly and the rest of the DAG is skipped.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from typing import Any
+
+from airflow import DAG
+from airflow.models import Variable
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+try:
+    from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
+except ImportError:
+    from airflow.sensors.time_delta import TimeDeltaSensor
+
+try:
+    from airflow.task.trigger_rule import TriggerRule
+except ImportError:
+    from airflow.utils.trigger_rule import TriggerRule
+
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxCreateDatasetOperator,
+    ArizeAxDeleteDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.experiments import (
+    ArizeAxBehavioralRegressionOperator,
+    ArizeAxDeleteExperimentOperator,
+)
+from airflow.providers.arize_ax.operators.tasks import (
+    ArizeAxCreateRunExperimentTaskOperator,
+    ArizeAxGetTaskRunOperator,
+    ArizeAxTriggerTaskRunOperator,
+)
+from airflow.providers.arize_ax.sensors.arize_ax import ArizeAxTaskRunSensor
+
+_SPACE_ID = "{{ var.value.get('arize_ax_space_id', '') or None }}"
+
+_DEMO_EXAMPLES = [
+    {"input": "What is 2+2?", "expected_output": "4"},
+    {"input": "Capital of France?", "expected_output": "Paris"},
+    {"input": "First president of the United States?", "expected_output": "George Washington"},
+    {"input": "Chemical symbol for water?", "expected_output": "H2O"},
+    {"input": "How many continents are there?", "expected_output": "7"},
+    {"input": "Largest planet in the solar system?", "expected_output": "Jupiter"},
+    {"input": "Speed of light in km/s (approx.)?", "expected_output": "300000"},
+    {"input": "Who wrote Hamlet?", "expected_output": "William Shakespeare"},
+]
+
+
+def _get_ai_integration_id() -> str:
+    """Worker env ``ARIZE_AI_INTEGRATION_ID`` wins; else Airflow Variable."""
+    v = os.environ.get("ARIZE_AI_INTEGRATION_ID", "").strip()
+    if v:
+        return v
+    return Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
+
+
+def _check_ai_integration(**_ctx) -> bool:
+    if not _get_ai_integration_id():
+        print(
+            "ARIZE_AI_INTEGRATION_ID is not set in worker env or Airflow Variables — "
+            "skipping behavioral-regression demo. Set it to your Arize AI Integration "
+            "ID to enable."
+        )
+        return False
+    return True
+
+
+def _build_baseline_run_config(**_ctx) -> dict[str, Any]:
+    """Build the server-side run config for the baseline experiment.
+
+    Returns a plain dict matching the ``LlmGenerationRunConfig`` schema; the
+    hook wraps it in the ``RunConfiguration`` SDK type before forwarding.
+    Arize makes the LLM calls — no Python task runs on the Airflow worker.
+    """
+    return {
+        "experiment_type": "llm_generation",
+        "ai_integration_id": _get_ai_integration_id(),
+        "model_name": "gpt-4o-mini",
+        "messages": [
+            {"role": "user", "content": "Answer in as few words as possible: {{input}}"},
+        ],
+        "input_variable_format": "mustache",
+        "invocation_parameters": {"temperature": 0},
+        "provider_parameters": {},
+    }
+
+
+def _build_candidate_run_config(**_ctx) -> dict[str, Any]:
+    """Build the server-side run config for the candidate experiment.
+
+    Identical to the baseline by default so the demo DAG ends green. To watch
+    ``ArizeAxBehavioralRegressionOperator`` fire, change the model name, the
+    prompt, or invocation parameters here.
+    """
+    return _build_baseline_run_config()
+
+
+def _extract_experiment_id(task_id: str) -> str:
+    """Pull ``experiment_id`` from an ``ArizeAxGetTaskRunOperator`` XCom payload."""
+    return "{{ ti.xcom_pull(task_ids='" + task_id + "')['experiment_id'] }}"
+
+
+with DAG(
+    dag_id="arize_ax_behavioral_regression",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "regression", "behavioral", "llmops"],
+    catchup=False,
+    doc_md=__doc__,
+    render_template_as_native_obj=True,
+    params={"significance_threshold": 0.05},
+) as dag:
+
+    check_ai_integration = ShortCircuitOperator(
+        task_id="check_ai_integration",
+        python_callable=_check_ai_integration,
+    )
+
+    create_demo_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_demo_dataset",
+        name="behavioral-regression-demo-{{ ts_nodash }}",
+        space_id=_SPACE_ID,
+        examples=_DEMO_EXAMPLES,
+        if_exists="skip",
+    )
+
+    build_baseline_run_config = PythonOperator(
+        task_id="build_baseline_run_config",
+        python_callable=_build_baseline_run_config,
+    )
+
+    create_baseline_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_baseline_task",
+        name="behavioral-regression-baseline-{{ ts_nodash }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_demo_dataset') }}",
+        run_configuration="{{ ti.xcom_pull(task_ids='build_baseline_run_config') }}",
+        space_id=_SPACE_ID,
+        if_exists="skip",
+    )
+
+    trigger_baseline_run = ArizeAxTriggerTaskRunOperator(
+        task_id="trigger_baseline_run",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_baseline_task') }}",
+        space_id=_SPACE_ID,
+        experiment_name="baseline-{{ ts_nodash }}",
+    )
+
+    wait_for_baseline_run = ArizeAxTaskRunSensor(
+        task_id="wait_for_baseline_run",
+        run_id="{{ ti.xcom_pull(task_ids='trigger_baseline_run') }}",
+        poke_interval=15,
+        timeout=900,
+        mode="reschedule",
+    )
+
+    get_baseline_run_result = ArizeAxGetTaskRunOperator(
+        task_id="get_baseline_run_result",
+        run_id="{{ ti.xcom_pull(task_ids='trigger_baseline_run') }}",
+    )
+
+    build_candidate_run_config = PythonOperator(
+        task_id="build_candidate_run_config",
+        python_callable=_build_candidate_run_config,
+    )
+
+    create_candidate_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_candidate_task",
+        name="behavioral-regression-candidate-{{ ts_nodash }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_demo_dataset') }}",
+        run_configuration="{{ ti.xcom_pull(task_ids='build_candidate_run_config') }}",
+        space_id=_SPACE_ID,
+        if_exists="skip",
+    )
+
+    trigger_candidate_run = ArizeAxTriggerTaskRunOperator(
+        task_id="trigger_candidate_run",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_candidate_task') }}",
+        space_id=_SPACE_ID,
+        experiment_name="candidate-{{ ts_nodash }}",
+    )
+
+    wait_for_candidate_run = ArizeAxTaskRunSensor(
+        task_id="wait_for_candidate_run",
+        run_id="{{ ti.xcom_pull(task_ids='trigger_candidate_run') }}",
+        poke_interval=15,
+        timeout=900,
+        mode="reschedule",
+    )
+
+    get_candidate_run_result = ArizeAxGetTaskRunOperator(
+        task_id="get_candidate_run_result",
+        run_id="{{ ti.xcom_pull(task_ids='trigger_candidate_run') }}",
+    )
+
+    behavioral_regression_check = ArizeAxBehavioralRegressionOperator(
+        task_id="behavioral_regression_check",
+        baseline_experiment_id=_extract_experiment_id("get_baseline_run_result"),
+        candidate_experiment_id=_extract_experiment_id("get_candidate_run_result"),
+        significance_threshold="{{ params.significance_threshold }}",
+        fail_on_regression=True,
+    )
+
+    # Pause so users can inspect both experiments side-by-side in the Arize
+    # UI before cleanup. ``mode="reschedule"`` releases the worker slot for
+    # the duration of the wait. Runs regardless of whether the regression
+    # check passed or failed.
+    inspect_pause = TimeDeltaSensor(
+        task_id="inspect_pause",
+        delta=timedelta(minutes=5),
+        mode="reschedule",
+        trigger_rule="all_done",
+    )
+
+    cleanup_baseline_experiment = ArizeAxDeleteExperimentOperator(
+        task_id="cleanup_baseline_experiment",
+        experiment_id=_extract_experiment_id("get_baseline_run_result"),
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    cleanup_candidate_experiment = ArizeAxDeleteExperimentOperator(
+        task_id="cleanup_candidate_experiment",
+        experiment_id=_extract_experiment_id("get_candidate_run_result"),
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    cleanup_demo_dataset = ArizeAxDeleteDatasetOperator(
+        task_id="cleanup_demo_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_demo_dataset') }}",
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    check_ai_integration >> create_demo_dataset
+    create_demo_dataset >> build_baseline_run_config >> create_baseline_task
+    create_baseline_task >> trigger_baseline_run >> wait_for_baseline_run
+    wait_for_baseline_run >> get_baseline_run_result
+    create_demo_dataset >> build_candidate_run_config >> create_candidate_task
+    create_candidate_task >> trigger_candidate_run >> wait_for_candidate_run
+    wait_for_candidate_run >> get_candidate_run_result
+    [get_baseline_run_result, get_candidate_run_result] >> behavioral_regression_check
+    behavioral_regression_check >> inspect_pause
+    inspect_pause >> [
+        cleanup_baseline_experiment,
+        cleanup_candidate_experiment,
+        cleanup_demo_dataset,
+    ]

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_dataset_curation_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_dataset_curation_dag.py
@@ -1,0 +1,138 @@
+"""
+Automated Dataset Curation DAG: filter, deduplicate, and append
+high-quality production spans into an Arize evaluation dataset on a
+daily schedule.
+
+Pipeline stages
+---------------
+1. **curate_high_quality_spans** — export spans with correctness > 0.85,
+   deduplicate on the ``input`` column, and append up to 500 examples to the
+   target dataset (ArizeAxCurateSpansToDatasetOperator).
+2. **check_curated** — short-circuit if no new examples were appended.
+3. **get_dataset_stats** — list current dataset examples to get the total
+   count (ArizeAxListDatasetExamplesOperator).
+4. **log_curation_summary** — log total examples, appended today, dedup rate.
+
+Schedule: ``@daily`` — curate new high-quality spans every day.
+
+Variables
+---------
+- ``arize_ax_project_id`` — Arize project ID (base64).
+- ``arize_ax_dataset_id`` — ID of the target Arize dataset.
+
+Requires:
+  - Airflow connection ``arize_ax_default`` with a valid API key.
+  - Project ``arize_ax_project_id`` must have spans with eval scores.
+  - Dataset ``arize_ax_dataset_id`` must already exist; create it first with
+    ``ArizeAxCreateDatasetOperator`` if needed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxListDatasetExamplesOperator,
+)
+from airflow.providers.arize_ax.operators.spans import (
+    ArizeAxCurateSpansToDatasetOperator,
+)
+
+
+def _check_curated(**ctx) -> bool:
+    """Return True iff at least one example was appended."""
+    result = ctx["ti"].xcom_pull(task_ids="curate_high_quality_spans")
+    if not isinstance(result, dict):
+        print(f"[check_curated] unexpected XCom type: {type(result).__name__!r}")
+        return False
+    count = result.get("appended_count", 0)
+    print(f"[check_curated] appended_count={count}")
+    return count > 0
+
+
+def _log_curation_summary(**ctx) -> dict[str, Any]:
+    """Log dataset curation summary: total, appended, dedup rate."""
+    curate_result = ctx["ti"].xcom_pull(task_ids="curate_high_quality_spans") or {}
+    stats_result = ctx["ti"].xcom_pull(task_ids="get_dataset_stats") or {}
+
+    appended = curate_result.get("appended_count", 0)
+    deduped = curate_result.get("deduplicated_count", 0)
+    dataset_id = curate_result.get("dataset_id", "N/A")
+    total_in_dataset = stats_result.get("count", "N/A")
+
+    total_before_dedup = appended + deduped
+    dedup_rate = (deduped / total_before_dedup * 100) if total_before_dedup > 0 else 0.0
+
+    data_interval_start = ctx.get("data_interval_start", "N/A")
+    data_interval_end = ctx.get("data_interval_end", "N/A")
+
+    print("=" * 60)
+    print("DATASET CURATION SUMMARY")
+    print(f"  Date range    : {data_interval_start} → {data_interval_end}")
+    print(f"  Dataset ID    : {dataset_id}")
+    print(f"  Total in ds   : {total_in_dataset}")
+    print(f"  Appended today: {appended}")
+    print(f"  Dedup removed : {deduped} ({dedup_rate:.1f}%)")
+    print("=" * 60)
+    return {
+        "appended": appended,
+        "deduplicated": deduped,
+        "dedup_rate_pct": round(dedup_rate, 2),
+        "total_in_dataset": total_in_dataset,
+    }
+
+
+with DAG(
+    dag_id="arize_ax_dataset_curation",
+    start_date=datetime(2025, 1, 1),
+    schedule="@daily",
+    tags=["arize_ax", "spans", "dataset", "curation"],
+    catchup=False,
+    doc_md=__doc__,
+) as dag:
+
+    # Stage 1 — Curate spans into dataset
+    curate_high_quality_spans = ArizeAxCurateSpansToDatasetOperator(
+        task_id="curate_high_quality_spans",
+        project_id="{{ var.value.get('arize_ax_project_id', '') }}",
+        dataset_id="{{ var.value.get('arize_ax_dataset_id', '') }}",
+        where="evals['correctness'].score > 0.85",
+        # Manual triggers leave data_interval_start == data_interval_end (both
+        # equal logical_date), and the SDK's exporter validates start < end
+        # strictly. Compute a 24h window off logical_date so manual triggers
+        # work; scheduled runs still see (close to) one schedule interval.
+        start_time="{{ (logical_date - macros.timedelta(hours=24)).isoformat() }}",
+        end_time="{{ logical_date.isoformat() }}",
+        deduplicate_on="input",
+        max_examples=500,
+    )
+
+    # Stage 2 — Gate: skip if nothing was appended
+    check_curated = ShortCircuitOperator(
+        task_id="check_curated",
+        python_callable=_check_curated,
+    )
+
+    # Stage 3 — Get current dataset stats
+    get_dataset_stats = ArizeAxListDatasetExamplesOperator(
+        task_id="get_dataset_stats",
+        dataset_id="{{ var.value.get('arize_ax_dataset_id', '') }}",
+        limit=1,
+    )
+
+    # Stage 4 — Log summary
+    log_curation_summary = PythonOperator(
+        task_id="log_curation_summary",
+        python_callable=_log_curation_summary,
+    )
+
+    # Wiring
+    curate_high_quality_spans >> check_curated >> get_dataset_stats >> log_curation_summary

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_dataset_curation_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_dataset_curation_dag.py
@@ -104,7 +104,7 @@ with DAG(
         task_id="curate_high_quality_spans",
         project_id="{{ var.value.get('arize_ax_project_id', '') }}",
         dataset_id="{{ var.value.get('arize_ax_dataset_id', '') }}",
-        where="evals['correctness'].score > 0.85",
+        where="eval.user_frustration.score > 0.85",
         # Manual triggers leave data_interval_start == data_interval_end (both
         # equal logical_date), and the SDK's exporter validates start < end
         # strictly. Compute a 24h window off logical_date so manual triggers

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_dataset_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_dataset_dag.py
@@ -1,0 +1,51 @@
+"""
+Example DAG demonstrating Arize AX dataset operators.
+
+Requires an Airflow connection of type `arize_ax` with:
+- Password (API key)
+- Optional: Host (API host override), Extra JSON: space_id, region
+
+Set the ``arize_ax_space_id`` Airflow Variable (or use connection extra) and ensure the connection exists.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxCreateDatasetOperator,
+    ArizeAxGetDatasetOperator,
+    ArizeAxListDatasetsOperator,
+)
+
+with DAG(
+    dag_id="example_arize_ax_dataset",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "example"],
+    catchup=False,
+) as dag:
+    list_datasets = ArizeAxListDatasetsOperator(
+        task_id="list_datasets",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        limit=10,
+    )
+
+    create_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_dataset",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        name="airflow-example-dataset",
+        examples=[
+            {"query": "What is 2+2?", "expected_output": "4"},
+            {"query": "Capital of France?", "expected_output": "Paris"},
+        ],
+        if_exists="skip",
+    )
+
+    get_dataset = ArizeAxGetDatasetOperator(
+        task_id="get_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+    )
+
+    list_datasets >> create_dataset >> get_dataset

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_drift_detection_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_drift_detection_dag.py
@@ -1,0 +1,228 @@
+"""
+Drift Detection & Auto-Rollback DAG: scheduled evaluation watchdog with prompt
+rollback when drift is detected.
+
+This DAG runs daily to guard against degradation in LLM evaluation scores.  It
+creates a fresh "current" experiment, waits for it to complete, then compares
+it against a known-good baseline experiment.  When drift is detected the
+ArizeAxDetectEvalDriftOperator raises AirflowException (``fail_on_drift=True``)
+causing the task to fail (red), making the drift event visible and preventing
+downstream promotion.  A separate ``rollback_prompt`` branch is triggered by
+catching the failure with an Airflow trigger rule, or can be wired as a
+separate monitoring pipeline.
+
+Pipeline stages
+---------------
+1. **run_current_eval** — run a daily evaluation experiment against a shared
+   eval dataset (ArizeAxRunExperimentOperator).
+2. **wait_for_current** — block until the experiment has enough completed runs
+   (ArizeAxExperimentRunCountSensor).
+3. **detect_drift** — compare the current experiment against the configured
+   baseline and raise AirflowException if drift is found
+   (ArizeAxDetectEvalDriftOperator with ``fail_on_drift=True``).
+4. **rollback_prompt** — re-promote the known-stable prompt version to the
+   ``"production"`` label (ArizeAxPromotePromptOperator).  Runs only when
+   detect_drift fails, via ``trigger_rule="all_failed"``.
+5. **notify_rollback** — log rollback confirmation; placeholder for
+   Slack/email integration.
+
+Schedule: ``@daily``
+
+Variables
+---------
+- ``arize_ax_space_id`` — Arize space ID (required).
+- ``arize_ax_eval_dataset_id`` — dataset ID to run evaluations against.
+- ``arize_ax_baseline_experiment_id`` — experiment ID of the known-good
+  baseline to compare against.
+- ``arize_ax_prompt_name`` — name of the prompt to roll back.
+- ``arize_ax_stable_prompt_version_id`` — version ID of the stable prompt
+  version to promote back to ``"production"``.
+
+Constants (edit in this file or override via Variables):
+- ``DRIFT_MIN_RUNS`` — minimum runs before scoring (default 5).
+- ``DRIFT_THRESHOLD`` — absolute score drop that triggers rollback (default 0.1).
+
+Requires:
+  - Airflow connection ``arize_ax_default`` with a valid API key.
+  - Variables ``arize_ax_space_id``, ``arize_ax_eval_dataset_id``,
+    ``arize_ax_baseline_experiment_id``, ``arize_ax_prompt_name``,
+    ``arize_ax_stable_prompt_version_id``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+from airflow.models import Variable
+
+try:
+    from airflow.task.trigger_rule import TriggerRule
+except ImportError:
+    from airflow.utils.trigger_rule import TriggerRule
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+from airflow.providers.arize_ax.operators.experiments import (
+    ArizeAxDetectEvalDriftOperator,
+    ArizeAxRunExperimentOperator,
+)
+from airflow.providers.arize_ax.operators.prompts import (
+    ArizeAxPromotePromptOperator,
+)
+from airflow.providers.arize_ax.sensors.arize_ax import (
+    ArizeAxExperimentRunCountSensor,
+)
+
+# ---------------------------------------------------------------------------
+# Constants — adjust to your environment
+# ---------------------------------------------------------------------------
+DRIFT_MIN_RUNS = 5
+DRIFT_THRESHOLD = 0.1  # flag metrics that dropped more than 10 points
+
+
+
+def _check_pipeline_configured(**ctx) -> bool:
+    """Return True only when all required Variables are set for drift detection."""
+    required = {
+        "arize_ax_eval_dataset_id": "an evaluation dataset ID",
+        "arize_ax_baseline_experiment_id": "a baseline experiment ID",
+        "arize_ax_prompt_name": "the prompt name to roll back",
+        "arize_ax_stable_prompt_version_id": "the stable prompt version ID",
+    }
+    missing = []
+    for key, description in required.items():
+        val = Variable.get(key, default_var=None)
+        if not val or val.strip() in ("", f"your-{key.split('_', 2)[-1].replace('_', '-')}"):
+            missing.append(f"  - {key}: set to {description}")
+    if missing:
+        print(
+            "The following Variables must be set to run the drift detection pipeline:\n"
+            + "\n".join(missing)
+        )
+        return False
+    return True
+
+
+def _eval_task(dataset_row: dict) -> dict:
+    """Evaluation task: echo the expected output as a stub.
+
+    Replace with a real LLM call in production, e.g.::
+
+        response = openai.chat.completions.create(...)
+        return {"output": response.choices[0].message.content}
+    """
+    return {"output": dataset_row.get("expected_output", "")}
+
+
+def _accuracy_evaluator(dataset_row: dict, output: Any) -> Any:
+    """Simple exact-match accuracy evaluator."""
+    from arize.experiments import EvaluationResult
+
+    if output is None:
+        return EvaluationResult(score=0.0, label="error", explanation="no output")
+    actual = output.get("output", "") if isinstance(output, dict) else str(output)
+    expected = dataset_row.get("expected_output", "")
+    match = str(actual).strip().lower() == str(expected).strip().lower()
+    return EvaluationResult(
+        score=1.0 if match else 0.0,
+        label="correct" if match else "incorrect",
+        explanation=f"expected={expected!r}, got={actual!r}",
+    )
+
+
+def _notify_rollback(**ctx) -> dict[str, Any]:
+    """Log rollback confirmation.
+
+    In production, add a Slack/email notification here, e.g.::
+
+        import slack_sdk
+        client = slack_sdk.WebClient(token=os.environ["SLACK_BOT_TOKEN"])
+        client.chat_postMessage(
+            channel="#ops-alerts",
+            text=f"Prompt rolled back: {prompt_name} -> stable version",
+        )
+    """
+    rollback_result = ctx["ti"].xcom_pull(task_ids="rollback_prompt") or {}
+    prompt_id = rollback_result.get("prompt_id")
+    label = rollback_result.get("label")
+
+    print("=" * 60)
+    print("PROMPT ROLLBACK COMPLETE")
+    print(f"  Prompt ID : {prompt_id}")
+    print(f"  Label     : {label}")
+    print("  Action    : notification sent (replace stub with Slack/email/webhook).")
+    print("=" * 60)
+    return {"notified": True, "prompt_id": prompt_id, "label": label}
+
+
+with DAG(
+    dag_id="arize_ax_drift_detection",
+    start_date=datetime(2025, 1, 1),
+    schedule="@daily",
+    tags=["arize_ax", "drift", "experiments", "prompts", "rollback"],
+    catchup=False,
+    doc_md=__doc__,
+) as dag:
+
+    # Stage 0 — Guard: skip DAG if required Variables are not configured
+    check_pipeline_configured = ShortCircuitOperator(
+        task_id="check_pipeline_configured",
+        python_callable=_check_pipeline_configured,
+    )
+
+    # Stage 1 — Run today's evaluation experiment
+    run_current_eval = ArizeAxRunExperimentOperator(
+        task_id="run_current_eval",
+        name="drift-check-current-{{ ds }}",
+        dataset_id="{{ var.value.get('arize_ax_eval_dataset_id', '') }}",
+        task=_eval_task,
+        evaluators=[_accuracy_evaluator],
+        concurrency=4,
+    )
+
+    # Stage 2 — Wait for runs to complete
+    wait_for_current = ArizeAxExperimentRunCountSensor(
+        task_id="wait_for_current",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_current_eval') }}",
+        min_runs=DRIFT_MIN_RUNS,
+        poke_interval=15,
+        timeout=600,
+        mode="poke",
+        soft_fail=True,
+    )
+
+    # Stage 3 — Detect drift vs baseline (raises on drift)
+    detect_drift = ArizeAxDetectEvalDriftOperator(
+        task_id="detect_drift",
+        current_experiment_id="{{ ti.xcom_pull(task_ids='run_current_eval') }}",
+        baseline_experiment_id="{{ var.value.get('arize_ax_baseline_experiment_id', '') }}",
+        drift_threshold=DRIFT_THRESHOLD,
+        aggregation="mean",
+        fail_on_drift=True,
+    )
+
+    # Stage 4 — Roll back prompt when drift was detected (task failed)
+    rollback_prompt = ArizeAxPromotePromptOperator(
+        task_id="rollback_prompt",
+        prompt_name="{{ var.value.get('arize_ax_prompt_name', '') }}",
+        label="production",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        version_id="{{ var.value.get('arize_ax_stable_prompt_version_id', None) }}",
+        trigger_rule=TriggerRule.ALL_FAILED,
+    )
+
+    # Stage 5 — Notify (Slack/email placeholder)
+    notify_rollback = PythonOperator(
+        task_id="notify_rollback",
+        python_callable=_notify_rollback,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    # Wiring
+    check_pipeline_configured >> run_current_eval >> wait_for_current >> detect_drift
+    detect_drift >> rollback_prompt >> notify_rollback

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_evaluator_calibration_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_evaluator_calibration_dag.py
@@ -1,0 +1,120 @@
+"""
+Evaluator Calibration DAG
+
+Runs an evaluator experiment against a dataset that has human annotations, then
+measures how well the LLM evaluator's scores correlate with the ground truth.
+When calibration quality is poor, ArizeAxEvaluatorCalibrationOperator raises
+AirflowException (``fail_on_poor_calibration=True``) making the task fail (red)
+and logs a detailed report.
+
+Requires:
+  - Airflow Variable ``arize_ax_space_id``
+  - Airflow Variable ``arize_ax_eval_dataset_id``
+  - Airflow Variable ``arize_ax_metric_name``
+  - Airflow Variable ``arize_ax_annotation_name``
+  - Airflow connection ``arize_ax_default`` with valid API key
+
+Operators exercised:
+  ArizeAxRunExperimentOperator, ArizeAxExperimentRunCountSensor,
+  ArizeAxEvaluatorCalibrationOperator
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+from airflow.models import Variable
+
+try:
+    from airflow.providers.standard.operators.python import ShortCircuitOperator
+except ImportError:
+    from airflow.operators.python import ShortCircuitOperator
+
+from airflow.providers.arize_ax.operators.experiments import (
+    ArizeAxEvaluatorCalibrationOperator,
+    ArizeAxRunExperimentOperator,
+)
+from airflow.providers.arize_ax.sensors.arize_ax import ArizeAxExperimentRunCountSensor
+
+
+def _check_dataset_configured(**ctx) -> bool:
+    """Return True only if arize_ax_eval_dataset_id Variable is set to a real value."""
+    dataset_id = Variable.get("arize_ax_eval_dataset_id", default_var=None)
+    if not dataset_id or dataset_id.strip() in ("", "your-dataset-id"):
+        print(
+            "Set the arize_ax_eval_dataset_id Variable to a real dataset ID to run this pipeline."
+        )
+        return False
+    return True
+
+
+def _simple_task(dataset_row: dict) -> dict:
+    """Echo task: return expected_output as the model response."""
+    return {"output": dataset_row.get("expected_output", dataset_row.get("output", "no-answer"))}
+
+
+def _simple_evaluator(dataset_row: dict, output: dict) -> Any:
+    """Correctness evaluator: 1.0 if output matches expected, else 0.0."""
+    from arize.experiments import EvaluationResult
+
+    actual = (output or {}).get("output", "")
+    expected = dataset_row.get("expected_output", "")
+    match = str(actual).strip().lower() == str(expected).strip().lower()
+    return EvaluationResult(
+        score=1.0 if match else 0.0,
+        label="correct" if match else "incorrect",
+        explanation=f"expected={expected!r}, got={actual!r}",
+    )
+
+
+
+with DAG(
+    dag_id="arize_ax_evaluator_calibration",
+    start_date=datetime(2025, 1, 1),
+    schedule="@monthly",
+    tags=["arize_ax", "evaluator", "calibration", "llmops"],
+    catchup=False,
+    doc_md=__doc__,
+    render_template_as_native_obj=True,
+    params={
+        "min_samples": 10,
+    },
+) as dag:
+
+    check_dataset_configured = ShortCircuitOperator(
+        task_id="check_dataset_configured",
+        python_callable=_check_dataset_configured,
+    )
+
+    run_calibration_experiment = ArizeAxRunExperimentOperator(
+        task_id="run_calibration_experiment",
+        name="calibration-run-{{ ts_nodash }}",
+        dataset_id="{{ var.value.get('arize_ax_eval_dataset_id', '') }}",
+        task=_simple_task,
+        evaluators=[_simple_evaluator],
+        concurrency=4,
+    )
+
+    wait_for_runs = ArizeAxExperimentRunCountSensor(
+        task_id="wait_for_runs",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_calibration_experiment') }}",
+        min_runs=1,
+        poke_interval=15,
+        timeout=600,
+        mode="poke",
+    )
+
+    calibrate_evaluator = ArizeAxEvaluatorCalibrationOperator(
+        task_id="calibrate_evaluator",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_calibration_experiment') }}",
+        annotation_name="{{ var.value.get('arize_ax_annotation_name', 'human_quality') }}",
+        metric_name="{{ var.value.get('arize_ax_metric_name', 'correctness') }}",
+        min_samples="{{ params.min_samples }}",
+        fail_on_poor_calibration=True,
+    )
+
+    # Wiring
+    check_dataset_configured >> run_calibration_experiment >> wait_for_runs
+    wait_for_runs >> calibrate_evaluator

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_evaluator_calibration_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_evaluator_calibration_dag.py
@@ -5,7 +5,19 @@ Runs an evaluator experiment against a dataset that has human annotations, then
 measures how well the LLM evaluator's scores correlate with the ground truth.
 When calibration quality is poor, ArizeAxEvaluatorCalibrationOperator raises
 AirflowException (``fail_on_poor_calibration=True``) making the task fail (red)
-and logs a detailed report.
+and logs a detailed report.  A downstream ``notify_on_calibration_failure``
+task fires only on failure (``trigger_rule=ONE_FAILED``) and is the place to
+plug in Slack / PagerDuty / email alerts.
+
+The bundled ``_simple_task`` and ``_simple_evaluator`` callables are *demo
+stubs* — they just echo ``expected_output`` and do an exact-match score.
+**For production**: replace them with a real LLM call (``openai.chat``,
+``anthropic.messages.create``, ``litellm.completion``, etc.) and the
+real evaluator you want to recalibrate.  The DAG shape stays the same.
+
+Schedule defaults to ``@monthly``.  To change cadence, edit the
+``schedule=`` argument below — DAG-level schedules can't be Variable-driven
+in Airflow because they're parsed at module load time.
 
 Requires:
   - Airflow Variable ``arize_ax_space_id``
@@ -28,9 +40,17 @@ from airflow import DAG
 from airflow.models import Variable
 
 try:
-    from airflow.providers.standard.operators.python import ShortCircuitOperator
+    from airflow.providers.standard.operators.python import (
+        PythonOperator,
+        ShortCircuitOperator,
+    )
 except ImportError:
-    from airflow.operators.python import ShortCircuitOperator
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+try:
+    from airflow.utils.trigger_rule import TriggerRule
+except ImportError:  # Airflow 3.x sdk path
+    from airflow.sdk.definitions._internal.trigger_rule import TriggerRule
 
 from airflow.providers.arize_ax.operators.experiments import (
     ArizeAxEvaluatorCalibrationOperator,
@@ -50,13 +70,23 @@ def _check_dataset_configured(**ctx) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# DEMO STUBS — replace for production use
+# ---------------------------------------------------------------------------
+# In production, ``_simple_task`` should call your real LLM (OpenAI, Anthropic,
+# Bedrock, Vertex, LiteLLM, etc.) with the dataset row as input, and
+# ``_simple_evaluator`` should compute the metric you actually want to
+# recalibrate against the human annotations (LLM-as-judge, ROUGE, exact match,
+# fuzzy match, hallucination score, etc.).  The Airflow + Arize operator
+# wiring around them stays exactly the same.
+# ---------------------------------------------------------------------------
 def _simple_task(dataset_row: dict) -> dict:
-    """Echo task: return expected_output as the model response."""
+    """[DEMO STUB] Echoes ``expected_output`` — replace with a real LLM call."""
     return {"output": dataset_row.get("expected_output", dataset_row.get("output", "no-answer"))}
 
 
 def _simple_evaluator(dataset_row: dict, output: dict) -> Any:
-    """Correctness evaluator: 1.0 if output matches expected, else 0.0."""
+    """[DEMO STUB] Exact-match scorer — replace with the real evaluator under test."""
     from arize.experiments import EvaluationResult
 
     actual = (output or {}).get("output", "")
@@ -67,6 +97,28 @@ def _simple_evaluator(dataset_row: dict, output: dict) -> Any:
         label="correct" if match else "incorrect",
         explanation=f"expected={expected!r}, got={actual!r}",
     )
+
+
+def _notify_on_calibration_failure(**ctx) -> None:
+    """Demo alert hook — fires only when calibrate_evaluator failed.
+
+    Replace this stub with a real alerting integration (Slack webhook,
+    PagerDuty trigger, email via EmailOperator, etc.).  This task uses
+    ``trigger_rule=ONE_FAILED`` so it only runs when calibration regressed.
+
+    Alternative: for DAG-wide failure alerts, set ``on_failure_callback`` at
+    the DAG level instead — both approaches are valid.
+    """
+    experiment_id = ctx["ti"].xcom_pull(task_ids="run_calibration_experiment")
+    metric = Variable.get("arize_ax_metric_name", default_var="<unset>")
+    annotation = Variable.get("arize_ax_annotation_name", default_var="<unset>")
+    print("=" * 60)
+    print("EVALUATOR CALIBRATION REGRESSED")
+    print(f"  Experiment ID  : {experiment_id}")
+    print(f"  Metric         : {metric}")
+    print(f"  Annotation     : {annotation}")
+    print("  Next step      : trigger alerting (not implemented in this stub).")
+    print("=" * 60)
 
 
 
@@ -115,6 +167,12 @@ with DAG(
         fail_on_poor_calibration=True,
     )
 
+    notify_on_calibration_failure = PythonOperator(
+        task_id="notify_on_calibration_failure",
+        python_callable=_notify_on_calibration_failure,
+        trigger_rule=TriggerRule.ONE_FAILED,
+    )
+
     # Wiring
     check_dataset_configured >> run_calibration_experiment >> wait_for_runs
-    wait_for_runs >> calibrate_evaluator
+    wait_for_runs >> calibrate_evaluator >> notify_on_calibration_failure

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_evaluators_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_evaluators_dag.py
@@ -1,0 +1,197 @@
+"""
+Example DAG: Arize AX Eval Hub (LLM template evaluators).
+
+This DAG exercises **all evaluator operators**:
+
+- :class:`~airflow.providers.arize_ax.operators.evaluators.ArizeAxListEvaluatorsOperator`
+  twice: a baseline list, then a filtered list after mutations.
+- :class:`~airflow.providers.arize_ax.operators.evaluators.ArizeAxCreateEvaluatorOperator`
+- :class:`~airflow.providers.arize_ax.operators.evaluators.ArizeAxUpdateEvaluatorOperator`
+- :class:`~airflow.providers.arize_ax.operators.evaluators.ArizeAxAddEvaluatorVersionOperator`
+
+**Flow**
+
+1. ``list_evaluators_baseline`` — always runs; lists evaluators in the space (read-only).
+2. ``check_ai_integration`` — ``ShortCircuitOperator``; if the integration ID is unset
+   (neither worker env nor Airflow Variable ``ARIZE_AI_INTEGRATION_ID``), downstream
+   tasks are **skipped** (no API mutations).
+3. When integration is configured: build template configs (Python) → create evaluator →
+   update description → add a second template version → ``list_evaluators_verify`` with
+   ``name_search`` matching the created evaluator name prefix.
+
+Requires:
+- Airflow connection ``arize_ax_default`` with API key (and optional host/extra).
+- Airflow variable ``arize_ax_space_id`` (space global ID) for templated tasks.
+- For the mutation chain: **AI integration global ID** — set either
+  ``ARIZE_AI_INTEGRATION_ID`` in the **worker environment** (Docker/Kubernetes) **or**
+  an Airflow **Variable** with key ``ARIZE_AI_INTEGRATION_ID`` (Admin → Variables).
+  Optional model: env or Variable ``ARIZE_EVALUATOR_MODEL`` (default ``gpt-4o-mini``).
+
+The Evaluators REST API is **alpha**. See:
+https://arize.com/docs/api-reference/evaluators/list-evaluators
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+from airflow.models import Variable
+
+try:
+    from airflow.providers.standard.operators.python import (
+        PythonOperator,
+        ShortCircuitOperator,
+    )
+except ImportError:
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+from airflow.providers.arize_ax.operators.evaluators import (
+    ArizeAxAddEvaluatorVersionOperator,
+    ArizeAxCreateEvaluatorOperator,
+    ArizeAxListEvaluatorsOperator,
+    ArizeAxUpdateEvaluatorOperator,
+)
+
+
+def _get_ai_integration_id() -> str:
+    """Worker env ``ARIZE_AI_INTEGRATION_ID`` wins; else Airflow Variable of the same key."""
+    v = os.environ.get("ARIZE_AI_INTEGRATION_ID", "").strip()
+    if v:
+        return v
+    return Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
+
+
+def _get_evaluator_model() -> str:
+    """Optional judge model: env or Variable ``ARIZE_EVALUATOR_MODEL``."""
+    v = os.environ.get("ARIZE_EVALUATOR_MODEL", "").strip()
+    if v:
+        return v
+    return (
+        Variable.get("ARIZE_EVALUATOR_MODEL", default_var="gpt-4o-mini").strip()
+        or "gpt-4o-mini"
+    )
+
+
+def _has_ai_integration(**_context: Any) -> bool:
+    """Return True when mutation tasks should run (integration ID present)."""
+    return bool(_get_ai_integration_id())
+
+
+def _build_evaluator_template_config_v1(**_context: Any) -> dict[str, Any]:
+    """Build initial ``template_config`` for ``ArizeAxCreateEvaluatorOperator``."""
+    integration_id = _get_ai_integration_id()
+    if not integration_id:
+        raise RuntimeError(
+            "ARIZE_AI_INTEGRATION_ID must be set in the worker environment or as an "
+            "Airflow Variable (Admin → Variables)."
+        )
+    model = _get_evaluator_model()
+    return {
+        "template_config": {
+            "name": "airflow_example",
+            "template": (
+                "You are an LLM judge. Given input and output, respond with a JSON object "
+                "with keys label (correct or incorrect) and reason. "
+                "Input: {input} Output: {output}"
+            ),
+            "include_explanations": True,
+            "use_function_calling_if_available": False,
+            "classification_choices": {"incorrect": 0, "correct": 1},
+            "llm_config": {
+                "ai_integration_id": integration_id,
+                "model_name": model,
+                "invocation_parameters": {"temperature": 0},
+                "provider_parameters": {},
+            },
+        },
+    }
+
+
+def _build_evaluator_template_config_v2(**context: Any) -> dict[str, Any]:
+    """Second template version (slightly different prompt) for add-version task."""
+    ti = context["ti"]
+    payload = ti.xcom_pull(task_ids="build_evaluator_template_v1") or {}
+    cfg = dict(payload.get("template_config") or {})
+    cfg["template"] = (cfg.get("template") or "") + " Prefer concise reasons."
+    return {"template_config": cfg}
+
+
+# Name prefix for created evaluators; list_evaluators_verify uses the same prefix via name_search.
+_EVAL_NAME_PREFIX = "airflow-example-eval"
+
+
+with DAG(
+    dag_id="example_arize_ax_evaluators",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "example", "evaluators"],
+    catchup=False,
+    doc_md=__doc__,
+) as dag:
+    list_evaluators_baseline = ArizeAxListEvaluatorsOperator(
+        task_id="list_evaluators_baseline",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        limit=25,
+    )
+
+    check_ai_integration = ShortCircuitOperator(
+        task_id="check_ai_integration",
+        python_callable=_has_ai_integration,
+    )
+
+    build_evaluator_template_v1 = PythonOperator(
+        task_id="build_evaluator_template_v1",
+        python_callable=_build_evaluator_template_config_v1,
+    )
+
+    build_evaluator_template_v2 = PythonOperator(
+        task_id="build_evaluator_template_v2",
+        python_callable=_build_evaluator_template_config_v2,
+    )
+
+    create_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_evaluator",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        name=f"{_EVAL_NAME_PREFIX}-{{{{ ts_nodash }}}}",
+        commit_message="Initial version from example_arize_ax_evaluators DAG",
+        description="Example LLM-as-judge evaluator created by Airflow",
+        template_config_task_id="build_evaluator_template_v1",
+        template_config_key="template_config",
+    )
+
+    update_evaluator_metadata = ArizeAxUpdateEvaluatorOperator(
+        task_id="update_evaluator_metadata",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_evaluator') }}",
+        description="Metadata updated by example_arize_ax_evaluators DAG",
+    )
+
+    add_evaluator_version = ArizeAxAddEvaluatorVersionOperator(
+        task_id="add_evaluator_version",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_evaluator') }}",
+        commit_message="Second template from example DAG",
+        template_config_task_id="build_evaluator_template_v2",
+        template_config_key="template_config",
+    )
+
+    # Second list call: exercises ListEvaluatorsOperator with name filter (API `name` param).
+    # Matches evaluators whose name contains this prefix (same prefix as create_evaluator).
+    list_evaluators_verify = ArizeAxListEvaluatorsOperator(
+        task_id="list_evaluators_verify",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        limit=50,
+        name_search=_EVAL_NAME_PREFIX,
+    )
+
+    (
+        list_evaluators_baseline
+        >> check_ai_integration
+        >> build_evaluator_template_v1
+        >> create_evaluator
+        >> update_evaluator_metadata
+        >> build_evaluator_template_v2
+        >> add_evaluator_version
+        >> list_evaluators_verify
+    )

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_experiment_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_experiment_dag.py
@@ -1,0 +1,78 @@
+"""
+Example DAG: Arize AX experiment workflow.
+
+Creates a dataset, runs an experiment with a task + evaluator, and retrieves
+the experiment results.  Demonstrates the ArizeAxRunExperimentOperator.
+
+Requires:
+- Airflow connection ``arize_ax_default`` with API key.
+- Airflow variable ``arize_ax_space_id``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxCreateDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.experiments import (
+    ArizeAxListExperimentsOperator,
+    ArizeAxRunExperimentOperator,
+)
+
+
+def _example_task(dataset_row: dict) -> dict:
+    """Trivial task that echoes the expected output."""
+    return {"output": dataset_row.get("expected_output", "")}
+
+
+def _exact_match_evaluator(dataset_row: dict, output: dict):
+    """Simple evaluator that checks if output matches expected."""
+    from arize.experiments import EvaluationResult
+
+    match = output.get("output") == dataset_row.get("expected_output")
+    return EvaluationResult(
+        score=1.0 if match else 0.0,
+        label="correct" if match else "incorrect",
+        explanation=f"expected={dataset_row.get('expected_output')!r}, "
+                    f"got={output.get('output')!r}",
+    )
+
+
+with DAG(
+    dag_id="example_arize_ax_experiment",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "example", "experiment"],
+    catchup=False,
+) as dag:
+    create_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_dataset",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        name="airflow-experiment-dataset",
+        examples=[
+            {"query": "What is 2+2?", "expected_output": "4"},
+            {"query": "Capital of France?", "expected_output": "Paris"},
+            {"query": "Largest planet?", "expected_output": "Jupiter"},
+        ],
+        if_exists="skip",
+    )
+
+    run_experiment = ArizeAxRunExperimentOperator(
+        task_id="run_experiment",
+        name="airflow-nightly-eval-{{ ds }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        task=_example_task,
+        evaluators=[_exact_match_evaluator],
+        concurrency=2,
+    )
+
+    list_experiments = ArizeAxListExperimentsOperator(
+        task_id="list_experiments",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        limit=5,
+    )
+
+    create_dataset >> run_experiment >> list_experiments

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_finetune_data_pipeline_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_finetune_data_pipeline_dag.py
@@ -184,7 +184,7 @@ with DAG(
         project_id="{{ var.value.get('arize_ax_project_id', '') }}",
         output_path="/tmp/finetune_{{ ds }}.jsonl",
         output_format="openai_jsonl",
-        where="evals['correctness'].score > 0.8",
+        where="eval.user_frustration.score > 0.8",
         start_time="{{ (logical_date - macros.timedelta(days=7)).isoformat() }}",
         end_time="{{ logical_date.isoformat() }}",
         system_prompt=SYSTEM_PROMPT,

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_finetune_data_pipeline_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_finetune_data_pipeline_dag.py
@@ -1,0 +1,237 @@
+"""
+Fine-tuning Data Pipeline DAG: export high-quality production spans and build
+a fine-tuning dataset for LLM improvement.
+
+This DAG implements the observe→curate→fine-tune loop:
+1. Observe: production LLM calls are traced and stored in Arize.
+2. Curate: spans with high evaluation scores are exported as fine-tuning data.
+3. Fine-tune: the curated file is staged in Arize as a dataset, ready to
+   trigger an OpenAI fine-tune job (or equivalent).
+
+Pipeline stages
+---------------
+1. **export_high_quality_spans** — export spans with correctness > 0.8 as
+   OpenAI JSONL format (ArizeAxExportSpansToFineTuningOperator). Raises
+   AirflowException if ``arize_ax_project_id`` Variable is absent or empty.
+   OpenAI JSONL format (ArizeAxExportSpansToFineTuningOperator).
+2. **check_has_examples** — short-circuit if no examples were exported.
+3. **validate_finetune_file** — count lines, validate JSONL structure, and
+   log a summary.
+4. **create_finetune_dataset** — create (or skip) an Arize dataset to hold
+   the fine-tuning examples.
+5. **prepare_arize_examples** — parse the JSONL file and convert to Arize
+   dataset example format.
+6. **append_to_arize_dataset** — append the examples to the Arize dataset.
+7. **notify_ready** — log the output path and count; placeholder for
+   triggering an OpenAI fine-tune job.
+
+Schedule: ``@weekly`` — re-run every week to accumulate new high-quality spans.
+
+Variables
+---------
+- ``arize_ax_project_id`` — Arize project ID (base64). **Required.**
+  Set this Variable to a real project ID that has spans with eval scores.
+  ArizeAxExportSpansToFineTuningOperator raises AirflowException when unset.
+- ``arize_ax_space_id`` — Arize space ID. Optional; falls back to connection
+  ``default_space`` when absent.
+
+Requires:
+  - Airflow connection ``arize_ax_default`` with a valid API key.
+  - Project ``arize_ax_project_id`` must exist and have spans with eval scores.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxAppendDatasetExamplesOperator,
+    ArizeAxCreateDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.spans import (
+    ArizeAxExportSpansToFineTuningOperator,
+)
+
+SYSTEM_PROMPT = (
+    "You are a helpful, accurate assistant. Answer concisely and factually."
+)
+
+
+def _check_has_examples(**ctx) -> bool:
+    """Return True iff the export produced at least one example."""
+    result = ctx["ti"].xcom_pull(task_ids="export_high_quality_spans")
+    if not isinstance(result, dict):
+        print(f"[check_has_examples] unexpected XCom type: {type(result).__name__!r}")
+        return False
+    count = result.get("count", 0)
+    print(f"[check_has_examples] exported {count} examples.")
+    return count > 0
+
+
+def _validate_finetune_file(**ctx) -> dict[str, Any]:
+    """Validate JSONL structure and log a summary."""
+    import json
+
+    result = ctx["ti"].xcom_pull(task_ids="export_high_quality_spans")
+    path = result.get("path", "") if isinstance(result, dict) else ""
+    if not path:
+        raise ValueError("No output path in export_high_quality_spans XCom.")
+
+    valid_count = 0
+    invalid_count = 0
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for lineno, line in enumerate(fh, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                    if "messages" in obj or "input" in obj:
+                        valid_count += 1
+                    else:
+                        invalid_count += 1
+                        print(f"  [validate] line {lineno}: missing 'messages' key")
+                except json.JSONDecodeError as exc:
+                    invalid_count += 1
+                    print(f"  [validate] line {lineno}: invalid JSON: {exc}")
+    except FileNotFoundError:
+        raise ValueError(f"Fine-tune file not found: {path!r}")
+
+    total = valid_count + invalid_count
+    print(f"[validate] total={total}  valid={valid_count}  invalid={invalid_count}")
+    if invalid_count > 0:
+        print(f"[validate] WARNING: {invalid_count} invalid lines detected.")
+    return {"path": path, "valid": valid_count, "invalid": invalid_count}
+
+
+def _prepare_arize_examples(**ctx) -> list[dict[str, Any]]:
+    """Load the JSONL file and convert to Arize dataset examples format."""
+    import json
+
+    result = ctx["ti"].xcom_pull(task_ids="export_high_quality_spans")
+    path = result.get("path", "") if isinstance(result, dict) else ""
+    if not path:
+        return []
+
+    examples: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            # Handle openai_jsonl format ({"messages": [...]})
+            if "messages" in obj:
+                messages = obj["messages"]
+                user_msg = next(
+                    (m.get("content", "") for m in messages if m.get("role") == "user"),
+                    "",
+                )
+                assistant_msg = next(
+                    (m.get("content", "") for m in messages if m.get("role") == "assistant"),
+                    "",
+                )
+                examples.append({"input": user_msg, "output": assistant_msg})
+            else:
+                # raw jsonl — pass through
+                examples.append(obj)
+    print(f"[prepare_arize_examples] prepared {len(examples)} examples.")
+    return examples
+
+
+def _notify_ready(**ctx) -> dict[str, Any]:
+    """Log the ready file and provide a placeholder for triggering fine-tune."""
+    result = ctx["ti"].xcom_pull(task_ids="export_high_quality_spans") or {}
+    path = result.get("path", "N/A")
+    count = result.get("count", 0)
+    ds_id = ctx["ti"].xcom_pull(task_ids="create_finetune_dataset")
+    print("=" * 60)
+    print("FINE-TUNE DATASET READY")
+    print(f"  Output JSONL  : {path}")
+    print(f"  Examples      : {count}")
+    print(f"  Arize dataset : {ds_id}")
+    print("  Next step     : trigger OpenAI fine-tune job (not implemented).")
+    print("  Example CLI   : openai api fine_tuning.jobs.create -t <file_id> -m gpt-4o-mini")
+    print("=" * 60)
+    return {"path": path, "count": count, "dataset_id": ds_id}
+
+
+with DAG(
+    dag_id="arize_ax_finetune_data_pipeline",
+    start_date=datetime(2025, 1, 1),
+    schedule="@weekly",
+    tags=["arize_ax", "spans", "finetune", "dataset"],
+    catchup=False,
+    doc_md=__doc__,
+    render_template_as_native_obj=True,
+) as dag:
+
+    # Stage 1 — Export high-quality spans
+    export_high_quality_spans = ArizeAxExportSpansToFineTuningOperator(
+        task_id="export_high_quality_spans",
+        project_id="{{ var.value.get('arize_ax_project_id', '') }}",
+        output_path="/tmp/finetune_{{ ds }}.jsonl",
+        output_format="openai_jsonl",
+        where="evals['correctness'].score > 0.8",
+        start_time="{{ (logical_date - macros.timedelta(days=7)).isoformat() }}",
+        end_time="{{ logical_date.isoformat() }}",
+        system_prompt=SYSTEM_PROMPT,
+    )
+
+    # Stage 2 — Gate: skip if no examples
+    check_has_examples = ShortCircuitOperator(
+        task_id="check_has_examples",
+        python_callable=_check_has_examples,
+    )
+
+    # Stage 3 — Validate
+    validate_finetune_file = PythonOperator(
+        task_id="validate_finetune_file",
+        python_callable=_validate_finetune_file,
+    )
+
+    # Stage 4 — Create Arize dataset
+    create_finetune_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_finetune_dataset",
+        space_id="{{ var.value.get('arize_ax_space_id', '') or None }}",
+        name="finetune-{{ ds }}",
+        # SDK 8.25+ rejects empty examples list at create time. Seed with a
+        # single placeholder; real examples are loaded dynamically later.
+        examples=[{"input": "_seed_", "expected": "_seed_"}],
+        if_exists="skip",
+    )
+
+    # Stage 5 — Prepare and append examples
+    prepare_arize_examples = PythonOperator(
+        task_id="prepare_arize_examples",
+        python_callable=_prepare_arize_examples,
+    )
+
+    append_to_arize_dataset = ArizeAxAppendDatasetExamplesOperator(
+        task_id="append_to_arize_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_finetune_dataset') }}",
+        examples="{{ ti.xcom_pull(task_ids='prepare_arize_examples') }}",
+    )
+
+    # Stage 6 — Notify
+    notify_ready = PythonOperator(
+        task_id="notify_ready",
+        python_callable=_notify_ready,
+    )
+
+    # Wiring
+    export_high_quality_spans >> check_has_examples >> validate_finetune_file
+    validate_finetune_file >> create_finetune_dataset >> prepare_arize_examples
+    prepare_arize_examples >> append_to_arize_dataset >> notify_ready

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_llm_cicd_gate_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_llm_cicd_gate_dag.py
@@ -24,8 +24,14 @@ Pipeline stages
 7. **compare_experiments** — compute per-metric deltas and an overall pass/
    fail verdict (ArizeAxCompareExperimentsOperator).  Raises AirflowException
    when ``fail_on_regression=True`` and the candidate did not improve.
-8. **promote_notification** — placeholder for a real deployment hook; logs a
-   promotion message to the Airflow task log.
+8. **check_prompt_configured** — short-circuit the promotion path if no
+   ``arize_ax_prompt_name`` Variable is set (gate-only mode).
+9. **promote_prompt** — tag the configured prompt version with the
+   ``arize_ax_prompt_label`` label (ArizeAxPromotePromptOperator).  Only
+   runs when the gate passed *and* a prompt name is configured.
+10. **promote_notification** — placeholder for a real deployment hook; logs
+    the promotion outcome (and which label was applied) to the Airflow task
+    log.
 
 Variables
 ---------
@@ -33,6 +39,10 @@ Variables
   ``default_space`` when absent.
 - ``arize_ax_baseline_experiment_id`` — experiment ID of the production
   baseline to compare against. **Required.** The DAG skips when not set.
+- ``arize_ax_prompt_name`` — name of the prompt to promote on gate pass.
+  Optional. When unset the DAG runs in gate-only mode (no promotion).
+- ``arize_ax_prompt_label`` — label to apply to the promoted prompt version
+  (default ``"production"``).
 
 Requires:
   - Airflow connection ``arize_ax_default`` with a valid API key.
@@ -60,6 +70,9 @@ from airflow.providers.arize_ax.operators.experiments import (
     ArizeAxCompareExperimentsOperator,
     ArizeAxGetExperimentScoreOperator,
     ArizeAxRunExperimentOperator,
+)
+from airflow.providers.arize_ax.operators.prompts import (
+    ArizeAxPromotePromptOperator,
 )
 from airflow.providers.arize_ax.sensors.arize_ax import (
     ArizeAxExperimentRunCountSensor,
@@ -89,6 +102,23 @@ def _check_baseline_configured(**ctx) -> bool:
         print(
             "Set the arize_ax_baseline_experiment_id Variable to a real experiment ID "
             "to run this CI/CD gate pipeline."
+        )
+        return False
+    return True
+
+
+def _check_prompt_configured(**ctx) -> bool:
+    """Return True only if arize_ax_prompt_name Variable is set.
+
+    When unset, the DAG runs in gate-only mode: the regression gate still
+    fires (compare_experiments raises on regression) but no prompt is
+    promoted.  The promote_prompt and promote_notification tasks are skipped.
+    """
+    prompt_name = Variable.get("arize_ax_prompt_name", default_var=None)
+    if not prompt_name or prompt_name.strip() in ("", "your-prompt-name"):
+        print(
+            "arize_ax_prompt_name Variable is not set — running in gate-only mode. "
+            "Set it to a real prompt name to enable automatic promotion on pass."
         )
         return False
     return True
@@ -127,13 +157,26 @@ def _promote_notification(**ctx) -> dict[str, Any]:
     """
     candidate_id = ctx["ti"].xcom_pull(task_ids="run_candidate_experiment")
     scores = ctx["ti"].xcom_pull(task_ids="score_candidate") or {}
+    promoted_version_id = ctx["ti"].xcom_pull(task_ids="promote_prompt")
+    prompt_name = Variable.get("arize_ax_prompt_name", default_var=None)
+    prompt_label = Variable.get("arize_ax_prompt_label", default_var="production")
     print("=" * 60)
     print("CANDIDATE PROMOTED")
     print(f"  Experiment ID : {candidate_id}")
     print(f"  Scores        : {scores}")
+    print(f"  Prompt name   : {prompt_name}")
+    print(f"  Prompt label  : {prompt_label}")
+    print(f"  Prompt verId  : {promoted_version_id}")
     print("  Next step     : trigger deployment pipeline (not implemented in this stub).")
     print("=" * 60)
-    return {"promoted": True, "experiment_id": candidate_id, "scores": scores}
+    return {
+        "promoted": True,
+        "experiment_id": candidate_id,
+        "scores": scores,
+        "prompt_name": prompt_name,
+        "prompt_label": prompt_label,
+        "prompt_version_id": promoted_version_id,
+    }
 
 
 with DAG(
@@ -213,7 +256,21 @@ with DAG(
         fail_on_regression=True,
     )
 
-    # Stage 6 — Promotion (only reached if compare_experiments passes)
+    # Stage 6a — Short-circuit promotion path if no prompt is configured
+    check_prompt_configured = ShortCircuitOperator(
+        task_id="check_prompt_configured",
+        python_callable=_check_prompt_configured,
+    )
+
+    # Stage 6b — Promote the prompt version with the configured label
+    promote_prompt = ArizeAxPromotePromptOperator(
+        task_id="promote_prompt",
+        prompt_name="{{ var.value.get('arize_ax_prompt_name', '') }}",
+        label="{{ var.value.get('arize_ax_prompt_label', 'production') }}",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+    )
+
+    # Stage 7 — Promotion notification (only reached on gate-pass + promote)
     promote_notification = PythonOperator(
         task_id="promote_notification",
         python_callable=_promote_notification,
@@ -223,4 +280,5 @@ with DAG(
     check_baseline_configured >> create_candidate_dataset >> append_candidate_examples >> run_candidate_experiment
     run_candidate_experiment >> wait_for_candidate
     wait_for_candidate >> [score_candidate, score_baseline]
-    [score_candidate, score_baseline] >> compare_experiments >> promote_notification
+    [score_candidate, score_baseline] >> compare_experiments
+    compare_experiments >> check_prompt_configured >> promote_prompt >> promote_notification

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_llm_cicd_gate_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_llm_cicd_gate_dag.py
@@ -1,0 +1,226 @@
+"""
+LLM CI/CD Gate DAG: automated evaluation-gated promotion for LLM changes.
+
+This DAG implements a CI/CD gate pattern for LLM-powered applications.  It
+runs a candidate experiment against a held-out evaluation dataset, scores both
+the candidate and an established baseline experiment, then raises AirflowException
+if the candidate does not meet the improvement threshold.
+
+Pipeline stages
+---------------
+0. **check_baseline_configured** — short-circuit if
+   ``arize_ax_baseline_experiment_id`` Variable is not set.
+1. **create_candidate_dataset** — create (or skip if exists) the evaluation
+   dataset for this run.
+2. **append_candidate_examples** — load evaluation examples into the dataset.
+3. **run_candidate_experiment** — run the candidate LLM task against the
+   dataset with Python evaluators; returns a scalar experiment ID on XCom.
+4. **wait_for_candidate** — block until the experiment has at least
+   ``CICD_MIN_RUNS`` completed runs (ArizeAxExperimentRunCountSensor).
+5. **score_candidate** — aggregate evaluation scores for the candidate
+   (ArizeAxGetExperimentScoreOperator).
+6. **score_baseline** — aggregate evaluation scores for the baseline
+   experiment (same operator, different experiment ID).
+7. **compare_experiments** — compute per-metric deltas and an overall pass/
+   fail verdict (ArizeAxCompareExperimentsOperator).  Raises AirflowException
+   when ``fail_on_regression=True`` and the candidate did not improve.
+8. **promote_notification** — placeholder for a real deployment hook; logs a
+   promotion message to the Airflow task log.
+
+Variables
+---------
+- ``arize_ax_space_id`` — Arize space ID. Optional; falls back to connection
+  ``default_space`` when absent.
+- ``arize_ax_baseline_experiment_id`` — experiment ID of the production
+  baseline to compare against. **Required.** The DAG skips when not set.
+
+Requires:
+  - Airflow connection ``arize_ax_default`` with a valid API key.
+  - Variable ``arize_ax_baseline_experiment_id`` set to a real experiment ID.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+from airflow.models import Variable
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxAppendDatasetExamplesOperator,
+    ArizeAxCreateDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.experiments import (
+    ArizeAxCompareExperimentsOperator,
+    ArizeAxGetExperimentScoreOperator,
+    ArizeAxRunExperimentOperator,
+)
+from airflow.providers.arize_ax.sensors.arize_ax import (
+    ArizeAxExperimentRunCountSensor,
+)
+
+# ---------------------------------------------------------------------------
+# Constants — override via Airflow Variables in production
+# ---------------------------------------------------------------------------
+CICD_DATASET_NAME = "cicd-eval-dataset"
+CICD_MIN_RUNS = 5
+CICD_PASS_THRESHOLD = 0.0  # candidate score must be >= baseline + threshold
+
+# Evaluation examples shared across all CI/CD gate runs.
+CICD_EVAL_EXAMPLES = [
+    {"query": "What is the capital of France?", "expected_output": "Paris"},
+    {"query": "What is 7 multiplied by 8?", "expected_output": "56"},
+    {"query": "Who wrote Hamlet?", "expected_output": "William Shakespeare"},
+    {"query": "What element has atomic number 1?", "expected_output": "Hydrogen"},
+    {"query": "How many continents are there?", "expected_output": "7"},
+]
+
+
+def _check_baseline_configured(**ctx) -> bool:
+    """Return True only if arize_ax_baseline_experiment_id Variable is set."""
+    baseline_id = Variable.get("arize_ax_baseline_experiment_id", default_var=None)
+    if not baseline_id or baseline_id.strip() in ("", "your-baseline-experiment-id"):
+        print(
+            "Set the arize_ax_baseline_experiment_id Variable to a real experiment ID "
+            "to run this CI/CD gate pipeline."
+        )
+        return False
+    return True
+
+
+def _candidate_task(dataset_row: dict) -> dict:
+    """Candidate LLM task.
+
+    Replace this with a real LLM call in production (e.g. ``openai.chat``).
+    This stub echoes the expected output to demonstrate the pipeline shape.
+    """
+    return {"output": dataset_row.get("expected_output", "")}
+
+
+def _accuracy_evaluator(dataset_row: dict, output: Any):
+    """Simple accuracy evaluator: 1.0 if output matches expected, 0.0 otherwise."""
+    from arize.experiments import EvaluationResult
+
+    if output is None:
+        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
+    actual = output.get("output", "") if isinstance(output, dict) else str(output)
+    expected = dataset_row.get("expected_output", "")
+    match = str(actual).strip().lower() == str(expected).strip().lower()
+    return EvaluationResult(
+        score=1.0 if match else 0.0,
+        label="correct" if match else "incorrect",
+        explanation=f"expected={expected!r}, got={actual!r}",
+    )
+
+
+def _promote_notification(**ctx) -> dict[str, Any]:
+    """Placeholder for a real deployment hook.
+
+    In production, replace this with a call to your deployment API,
+    a Slack notification, or a webhook to trigger your release pipeline.
+    """
+    candidate_id = ctx["ti"].xcom_pull(task_ids="run_candidate_experiment")
+    scores = ctx["ti"].xcom_pull(task_ids="score_candidate") or {}
+    print("=" * 60)
+    print("CANDIDATE PROMOTED")
+    print(f"  Experiment ID : {candidate_id}")
+    print(f"  Scores        : {scores}")
+    print("  Next step     : trigger deployment pipeline (not implemented in this stub).")
+    print("=" * 60)
+    return {"promoted": True, "experiment_id": candidate_id, "scores": scores}
+
+
+with DAG(
+    dag_id="arize_ax_llm_cicd_gate",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "cicd", "llm", "experiments"],
+    catchup=False,
+    doc_md=__doc__,
+) as dag:
+
+    # Stage 0 — Guard: skip DAG if baseline experiment ID is not configured
+    check_baseline_configured = ShortCircuitOperator(
+        task_id="check_baseline_configured",
+        python_callable=_check_baseline_configured,
+    )
+
+    # Stage 1 — Dataset setup
+    create_candidate_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_candidate_dataset",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        name=CICD_DATASET_NAME,
+        # SDK 8.25+ rejects empty examples list at create time. Seed with a
+        # single placeholder; real examples are loaded by the subsequent
+        # append step.
+        examples=[{"input": "_seed_", "expected": "_seed_"}],
+        if_exists="skip",
+    )
+
+    append_candidate_examples = ArizeAxAppendDatasetExamplesOperator(
+        task_id="append_candidate_examples",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_candidate_dataset') }}",
+        examples=CICD_EVAL_EXAMPLES,
+    )
+
+    # Stage 2 — Run candidate experiment
+    run_candidate_experiment = ArizeAxRunExperimentOperator(
+        task_id="run_candidate_experiment",
+        name="cicd-candidate-{{ ts_nodash }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_candidate_dataset') }}",
+        task=_candidate_task,
+        evaluators=[_accuracy_evaluator],
+        concurrency=4,
+    )
+
+    # Stage 3 — Wait for runs to complete
+    wait_for_candidate = ArizeAxExperimentRunCountSensor(
+        task_id="wait_for_candidate",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_candidate_experiment') }}",
+        min_runs=CICD_MIN_RUNS,
+        poke_interval=15,
+        timeout=600,
+        mode="poke",
+        soft_fail=True,
+    )
+
+    # Stage 4 — Score candidate and baseline
+    score_candidate = ArizeAxGetExperimentScoreOperator(
+        task_id="score_candidate",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_candidate_experiment') }}",
+        aggregation="mean",
+    )
+
+    score_baseline = ArizeAxGetExperimentScoreOperator(
+        task_id="score_baseline",
+        experiment_id="{{ var.value.get('arize_ax_baseline_experiment_id', '') }}",
+        aggregation="mean",
+    )
+
+    # Stage 5 — Compare and gate (raises AirflowException on regression)
+    compare_experiments = ArizeAxCompareExperimentsOperator(
+        task_id="compare_experiments",
+        candidate_experiment_id="{{ ti.xcom_pull(task_ids='run_candidate_experiment') }}",
+        baseline_experiment_id="{{ var.value.get('arize_ax_baseline_experiment_id', '') }}",
+        pass_threshold=CICD_PASS_THRESHOLD,
+        aggregation="mean",
+        fail_on_regression=True,
+    )
+
+    # Stage 6 — Promotion (only reached if compare_experiments passes)
+    promote_notification = PythonOperator(
+        task_id="promote_notification",
+        python_callable=_promote_notification,
+    )
+
+    # Wiring
+    check_baseline_configured >> create_candidate_dataset >> append_candidate_examples >> run_candidate_experiment
+    run_candidate_experiment >> wait_for_candidate
+    wait_for_candidate >> [score_candidate, score_baseline]
+    [score_candidate, score_baseline] >> compare_experiments >> promote_notification

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_llm_experiments_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_llm_experiments_dag.py
@@ -1,0 +1,541 @@
+"""
+LLM Experiment Comparison DAG: runs 5 real experiments with different model and
+prompt combinations against the same dataset, so you can compare scores
+side-by-side on the Arize dashboard.
+
+Experiment matrix
+-----------------
++---+--------------------+-----------+--------------------------------------+
+| # | Model              | Prompt    | Purpose                              |
++---+--------------------+-----------+--------------------------------------+
+| 1 | gpt-4o-mini        | concise   | Baseline: cheap model, simple prompt |
+| 2 | gpt-4o             | concise   | Better model, same prompt            |
+| 3 | claude-3-haiku     | concise   | Different provider, same prompt      |
+| 4 | gpt-4o-mini        | detailed  | Same cheap model, better prompt      |
+| 5 | claude-3-haiku     | detailed  | Cross-provider prompt impact         |
++---+--------------------+-----------+--------------------------------------+
+
+Comparing (1 vs 2): model quality impact (holding prompt constant)
+Comparing (1 vs 3): provider comparison (same tier, different vendor)
+Comparing (1 vs 4): prompt engineering impact (holding model constant)
+Comparing (3 vs 5): prompt impact on same model, different provider
+
+Three LLM-as-Judge evaluators run on every experiment (using GPT-4o-mini
+as the judge via ``arize-phoenix-evals >= 3.0.0``):
+  - **qa_correctness**: is the answer factually correct? (correct / incorrect)
+  - **hallucination**: does the output contain fabricated information?
+    (factual / hallucinated)
+  - **relevance**: does the output address the question? (relevant / irrelevant)
+
+These evaluators produce score + label + explanation columns on the Arize
+dashboard, giving rich per-row insights into each model's behavior.
+
+Prompts are created in the Arize Prompt Hub using the
+``ArizeAxCreatePromptOperator`` and cleaned up at the end with
+``ArizeAxDeletePromptOperator``. Note: the Arize SDK ``experiments.run()`` API
+does not currently accept a prompt_id or prompt_version_id parameter, so
+experiments run via this DAG are not automatically linked to those Prompt Hub
+prompts in the Arize UI (you may see "No prompt template available" on the
+experiment row). Linking prompts to experiments is supported when running from
+the Arize Prompt Playground or when the API adds support. See
+``docs/arize-experiments-and-prompts-analysis.md`` for a full analysis of the
+API/SDK and options.
+
+Requires:
+  - Airflow connection ``arize_ax_default`` with valid API key + space_id.
+  - Environment variables ``OPENAI_API_KEY`` and ``ANTHROPIC_API_KEY`` set in
+    the Airflow worker (e.g. via docker-compose environment section).
+  - Python packages: ``openai``, ``anthropic``, ``arize-phoenix-evals``.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from typing import Any
+
+from airflow import DAG
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator
+
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxCreateDatasetOperator,
+    ArizeAxDeleteDatasetOperator,
+    ArizeAxGetDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.experiments import (
+    ArizeAxListExperimentsOperator,
+    ArizeAxRunExperimentOperator,
+)
+from airflow.providers.arize_ax.operators.projects import (
+    ArizeAxCreateProjectOperator,
+    ArizeAxDeleteProjectOperator,
+)
+from airflow.providers.arize_ax.operators.prompts import (
+    ArizeAxCreatePromptOperator,
+    ArizeAxDeletePromptOperator,
+)
+from airflow.providers.arize_ax.operators.spaces import (
+    ArizeAxListSpacesOperator,
+)
+from airflow.providers.arize_ax.sensors.arize_ax import (
+    ArizeAxDatasetReadySensor,
+)
+
+try:
+    from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
+except ImportError:
+    from airflow.sensors.time_delta import TimeDeltaSensor
+
+INSPECTION_WINDOW_MINUTES = 15
+
+PROMPT_CONCISE = (
+    "You are a helpful assistant. Answer the question in as few words as "
+    "possible. Give only the direct answer with no explanation."
+)
+
+PROMPT_DETAILED = (
+    "You are an expert knowledge assistant. Think step by step before "
+    "answering. After your reasoning, provide the final answer on its own "
+    "line prefixed with 'Answer: '. Be precise and accurate."
+)
+
+EXPERIMENT_CONFIGS: list[dict[str, str]] = [
+    {"name": "gpt4omini-concise", "provider": "openai", "model": "gpt-4o-mini", "prompt": PROMPT_CONCISE},
+    {"name": "gpt4o-concise", "provider": "openai", "model": "gpt-4o", "prompt": PROMPT_CONCISE},
+    {"name": "haiku-concise", "provider": "anthropic", "model": "claude-3-haiku-20240307", "prompt": PROMPT_CONCISE},
+    {"name": "gpt4omini-detailed", "provider": "openai", "model": "gpt-4o-mini", "prompt": PROMPT_DETAILED},
+    {"name": "haiku-detailed", "provider": "anthropic", "model": "claude-3-haiku-20240307", "prompt": PROMPT_DETAILED},
+]
+
+DATASET_EXAMPLES = [
+    {"query": "What is the capital of France?", "expected_output": "Paris"},
+    {"query": "What is 15 multiplied by 37?", "expected_output": "555"},
+    {"query": "Who wrote Romeo and Juliet?", "expected_output": "William Shakespeare"},
+    {"query": "What is the chemical formula for water?", "expected_output": "H2O"},
+    {"query": "In what year did World War II end?", "expected_output": "1945"},
+    {"query": "What is the largest planet in our solar system?", "expected_output": "Jupiter"},
+    {"query": "What programming language was created by Guido van Rossum?", "expected_output": "Python"},
+    {"query": "How many sides does a hexagon have?", "expected_output": "6"},
+]
+
+
+def _make_llm_task(provider: str, model: str, system_prompt: str):
+    """Return a task callable that calls the specified LLM."""
+
+    def _task(dataset_row: dict) -> str:
+        query = dataset_row.get("query", "")
+        if provider == "openai":
+            import openai
+
+            client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+            response = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": query},
+                ],
+                max_tokens=200,
+                temperature=0.0,
+            )
+            return response.choices[0].message.content.strip()
+
+        elif provider == "anthropic":
+            import anthropic
+
+            client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+            response = client.messages.create(
+                model=model,
+                max_tokens=200,
+                temperature=0.0,
+                system=system_prompt,
+                messages=[{"role": "user", "content": query}],
+            )
+            return response.content[0].text.strip()
+
+        raise ValueError(f"Unknown provider: {provider}")
+
+    _task.__name__ = f"task_{provider}_{model.replace('-', '_').replace('.', '_')}"
+    return _task
+
+
+QA_CORRECTNESS_TEMPLATE = (
+    "You are evaluating a question-answering system.\n\n"
+    "[BEGIN DATA]\n"
+    "[Question]: {query}\n"
+    "[Expected Answer]: {expected_output}\n"
+    "[System Output]: {output}\n"
+    "[END DATA]\n\n"
+    "The system output is correct if it conveys the same factual answer as the "
+    "expected answer, even if the phrasing differs. Minor wording differences "
+    "are acceptable.\n\n"
+    "Explain your reasoning in 1-2 sentences, then provide a single-word "
+    "LABEL on its own line: either 'correct' or 'incorrect'."
+)
+
+HALLUCINATION_TEMPLATE = (
+    "You are evaluating whether an AI response contains hallucinated "
+    "(fabricated or factually wrong) information.\n\n"
+    "[BEGIN DATA]\n"
+    "[Question]: {query}\n"
+    "[Expected Answer]: {expected_output}\n"
+    "[System Output]: {output}\n"
+    "[END DATA]\n\n"
+    "The output is 'factual' if all claims are accurate or consistent with "
+    "the expected answer. The output is 'hallucinated' if it contains any "
+    "made-up facts, wrong numbers, or fabricated details.\n\n"
+    "Explain your reasoning in 1-2 sentences, then provide a single-word "
+    "LABEL on its own line: either 'factual' or 'hallucinated'."
+)
+
+RELEVANCE_TEMPLATE = (
+    "You are evaluating whether an AI response is relevant to the question.\n\n"
+    "[BEGIN DATA]\n"
+    "[Question]: {query}\n"
+    "[System Output]: {output}\n"
+    "[END DATA]\n\n"
+    "The output is 'relevant' if it directly addresses the question, even if "
+    "it includes extra detail. The output is 'irrelevant' if it does not "
+    "attempt to answer the question or goes completely off-topic.\n\n"
+    "Explain your reasoning in 1-2 sentences, then provide a single-word "
+    "LABEL on its own line: either 'relevant' or 'irrelevant'."
+)
+
+
+# ---------------------------------------------------------------------------
+# LLM-as-Judge evaluator functions (arize-phoenix-evals >= 3.0.0)
+# Requires OPENAI_API_KEY env var. Falls back to keyword-heuristic scoring
+# when arize-phoenix-evals is unavailable or OPENAI_API_KEY is not set.
+# ---------------------------------------------------------------------------
+def _make_llm():
+    """Construct a phoenix.evals 3.x LLM instance (OpenAI gpt-4o-mini)."""
+    from phoenix.evals import LLM
+    return LLM(provider="openai", model="gpt-4o-mini", api_key=os.environ["OPENAI_API_KEY"])
+
+
+def _qa_correctness(output: str, dataset_row: dict):
+    """LLM-as-Judge correctness using arize-phoenix-evals 3.x create_classifier."""
+    from arize.experiments import EvaluationResult
+
+    if output is None:
+        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
+
+    try:
+        from phoenix.evals import create_classifier
+        evaluator = create_classifier(
+            name="qa_correctness",
+            prompt_template=QA_CORRECTNESS_TEMPLATE,
+            llm=_make_llm(),
+            choices={"correct": 1.0, "incorrect": 0.0},
+        )
+        scores = evaluator.evaluate({
+            "query": dataset_row.get("query", ""),
+            "expected_output": dataset_row.get("expected_output", ""),
+            "output": output,
+        })
+        s = scores[0]
+        return EvaluationResult(
+            score=float(s.score) if s.score is not None else 0.0,
+            label=s.label or "incorrect",
+            explanation=s.explanation or "LLM-as-judge (qa_correctness)",
+        )
+    except Exception as exc:
+        expected = str(dataset_row.get("expected_output", "")).strip().lower()
+        actual = str(output).strip().lower()
+        match = bool(expected and expected in actual)
+        return EvaluationResult(
+            score=1.0 if match else 0.0,
+            label="correct" if match else "incorrect",
+            explanation=f"Heuristic fallback ({exc.__class__.__name__}): expected in output={match}",
+        )
+
+
+def _hallucination_check(output: str, dataset_row: dict):
+    """LLM-as-Judge hallucination using arize-phoenix-evals 3.x create_classifier."""
+    from arize.experiments import EvaluationResult
+
+    if output is None:
+        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
+
+    try:
+        from phoenix.evals import create_classifier
+        evaluator = create_classifier(
+            name="hallucination",
+            prompt_template=HALLUCINATION_TEMPLATE,
+            llm=_make_llm(),
+            choices={"factual": 1.0, "hallucinated": 0.0},
+        )
+        scores = evaluator.evaluate({
+            "query": dataset_row.get("query", ""),
+            "expected_output": dataset_row.get("expected_output", ""),
+            "output": output,
+        })
+        s = scores[0]
+        return EvaluationResult(
+            score=float(s.score) if s.score is not None else 0.0,
+            label=s.label or "hallucinated",
+            explanation=s.explanation or "LLM-as-judge (hallucination)",
+        )
+    except Exception as exc:
+        expected_words = {w.lower() for w in str(dataset_row.get("expected_output", "")).split() if len(w) > 4}
+        output_words = {w.lower() for w in str(output).split() if len(w) > 4}
+        overlap = expected_words & output_words
+        factual = bool(overlap) or not expected_words
+        return EvaluationResult(
+            score=1.0 if factual else 0.0,
+            label="factual" if factual else "hallucinated",
+            explanation=f"Heuristic fallback ({exc.__class__.__name__}): keyword overlap={overlap or 'none'}",
+        )
+
+
+def _relevance_check(output: str, dataset_row: dict):
+    """LLM-as-Judge relevance using arize-phoenix-evals 3.x create_classifier."""
+    from arize.experiments import EvaluationResult
+
+    if output is None:
+        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
+
+    try:
+        from phoenix.evals import create_classifier
+        evaluator = create_classifier(
+            name="relevance",
+            prompt_template=RELEVANCE_TEMPLATE,
+            llm=_make_llm(),
+            choices={"relevant": 1.0, "irrelevant": 0.0},
+        )
+        scores = evaluator.evaluate({
+            "query": dataset_row.get("query", ""),
+            "output": output,
+        })
+        s = scores[0]
+        return EvaluationResult(
+            score=float(s.score) if s.score is not None else 0.0,
+            label=s.label or "irrelevant",
+            explanation=s.explanation or "LLM-as-judge (relevance)",
+        )
+    except Exception as exc:
+        query_words = {w.lower() for w in str(dataset_row.get("query", "")).split() if len(w) > 3}
+        output_words = {w.lower() for w in str(output).split() if len(w) > 3}
+        overlap = query_words & output_words
+        relevant = bool(overlap)
+        return EvaluationResult(
+            score=1.0 if relevant else 0.0,
+            label="relevant" if relevant else "irrelevant",
+            explanation=f"Heuristic fallback ({exc.__class__.__name__}): query–output overlap={overlap or 'none'}",
+        )
+
+
+def _verify_experiment_results(**ctx) -> dict[str, Any]:
+    """Summarise which experiment tasks produced non-None XCom values."""
+    ti = ctx["ti"]
+    task_ids = [f"exp_{cfg['name'].replace('-', '_')}" for cfg in EXPERIMENT_CONFIGS]
+    task_ids += [
+        "create_project", "create_dataset", "list_experiments",
+        "create_prompt_concise", "create_prompt_detailed",
+    ]
+    checks = {tid: ti.xcom_pull(task_ids=tid) is not None for tid in task_ids}
+    passed = sum(checks.values())
+    print(f"Verification: {passed}/{len(checks)} tasks produced output")
+    for tid, ok in checks.items():
+        print(f"  {'PASS' if ok else 'FAIL'}: {tid}")
+    return {"passed": passed, "total": len(checks), "checks": checks}
+
+
+def _cleanup_experiments(**ctx) -> None:
+    """Delete all experiments for the dataset, then the dataset and project."""
+    from airflow.providers.arize_ax.hooks.arize_ax import ArizeAxHook
+
+    hook = ArizeAxHook()
+    ds_id = ctx["ti"].xcom_pull(task_ids="create_dataset")
+    if not ds_id or str(ds_id) == "None":
+        print("No dataset ID -- skipping experiment cleanup.")
+        return
+
+    try:
+        result = hook.list_experiments(dataset_id=str(ds_id), limit=50)
+        items = result.get("items", []) if isinstance(result, dict) else []
+        for exp in items:
+            exp_id = exp.get("id") if isinstance(exp, dict) else None
+            if exp_id:
+                try:
+                    hook.delete_experiment(experiment_id=str(exp_id))
+                    print(f"Deleted experiment {exp_id}")
+                except Exception as exc:
+                    print(f"Failed to delete experiment {exp_id} (non-fatal): {exc}")
+    except Exception as exc:
+        print(f"Failed to list experiments for cleanup (non-fatal): {exc}")
+
+
+with DAG(
+    dag_id="arize_ax_e2e_llm_experiment_comparison",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "e2e", "llm", "experiments"],
+    catchup=False,
+    doc_md=__doc__,
+) as dag:
+
+    # Phase 1 -- Discovery
+    list_spaces = ArizeAxListSpacesOperator(task_id="list_spaces", limit=10)
+
+    # Phase 2 -- Resource setup
+    create_project = ArizeAxCreateProjectOperator(
+        task_id="create_project",
+        space_id="{{ ti.xcom_pull(task_ids='list_spaces', key='first_id') }}",
+        name="e2e-llm-{{ ts_nodash }}",
+        if_exists="skip",
+    )
+
+    create_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_dataset",
+        space_id="{{ ti.xcom_pull(task_ids='list_spaces', key='first_id') }}",
+        name="e2e-qa-{{ ts_nodash }}",
+        examples=DATASET_EXAMPLES,
+        if_exists="skip",
+    )
+
+    get_dataset = ArizeAxGetDatasetOperator(
+        task_id="get_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+    )
+
+    # Phase 3 -- Create prompts in Prompt Hub
+    create_prompt_concise = ArizeAxCreatePromptOperator(
+        task_id="create_prompt_concise",
+        space_id="{{ ti.xcom_pull(task_ids='list_spaces', key='first_id') }}",
+        name="e2e-concise-{{ ts_nodash }}",
+        messages=[
+            {"role": "system", "content": PROMPT_CONCISE},
+            {"role": "user", "content": "{query}"},
+        ],
+        provider="open_ai",
+        input_variable_format="f_string",
+        model="gpt-4o-mini",
+        commit_message="Concise prompt from e2e run {{ ts_nodash }}",
+        description="Auto-generated concise prompt",
+        if_exists="skip",
+    )
+
+    create_prompt_detailed = ArizeAxCreatePromptOperator(
+        task_id="create_prompt_detailed",
+        space_id="{{ ti.xcom_pull(task_ids='list_spaces', key='first_id') }}",
+        name="e2e-detailed-{{ ts_nodash }}",
+        messages=[
+            {"role": "system", "content": PROMPT_DETAILED},
+            {"role": "user", "content": "{query}"},
+        ],
+        provider="open_ai",
+        input_variable_format="f_string",
+        model="gpt-4o-mini",
+        commit_message="Detailed prompt from e2e run {{ ts_nodash }}",
+        description="Auto-generated detailed prompt",
+        if_exists="skip",
+    )
+
+    # Phase 4 -- Sensor gate
+    dataset_ready = ArizeAxDatasetReadySensor(
+        task_id="dataset_ready_sensor",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        min_examples=len(DATASET_EXAMPLES),
+        poke_interval=5,
+        timeout=120,
+        mode="poke",
+    )
+
+    # Phase 5 -- Run 5 experiments (parallel after dataset is ready)
+    experiment_tasks = []
+    for cfg in EXPERIMENT_CONFIGS:
+        task_id = f"exp_{cfg['name'].replace('-', '_')}"
+        exp_task = ArizeAxRunExperimentOperator(
+            task_id=task_id,
+            name=f"{cfg['name']}-{{{{ ts_nodash }}}}",
+            dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+            task=_make_llm_task(cfg["provider"], cfg["model"], cfg["prompt"]),
+            evaluators=[_qa_correctness, _hallucination_check, _relevance_check],
+            concurrency=4,
+        )
+        experiment_tasks.append(exp_task)
+
+    # Phase 5b -- List all experiments for the dataset
+    list_experiments = ArizeAxListExperimentsOperator(
+        task_id="list_experiments",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        limit=20,
+        trigger_rule="all_done",
+    )
+
+    # Phase 6 -- Verification + Inspection
+    verify = PythonOperator(
+        task_id="verify_results",
+        python_callable=_verify_experiment_results,
+        trigger_rule="all_done",
+    )
+
+    inspection_window = TimeDeltaSensor(
+        task_id="inspection_window",
+        delta=timedelta(minutes=INSPECTION_WINDOW_MINUTES),
+        mode="reschedule",
+        trigger_rule="all_done",
+    )
+
+    # Phase 7 -- Cleanup (always runs)
+    cleanup_exps = PythonOperator(
+        task_id="cleanup_experiments",
+        python_callable=_cleanup_experiments,
+        trigger_rule="all_done",
+    )
+
+    delete_prompt_concise = ArizeAxDeletePromptOperator(
+        task_id="cleanup_prompt_concise",
+        prompt_id="{{ ti.xcom_pull(task_ids='create_prompt_concise') }}",
+        trigger_rule="all_done",
+    )
+
+    delete_prompt_detailed = ArizeAxDeletePromptOperator(
+        task_id="cleanup_prompt_detailed",
+        prompt_id="{{ ti.xcom_pull(task_ids='create_prompt_detailed') }}",
+        trigger_rule="all_done",
+    )
+
+    cleanup_ds = ArizeAxDeleteDatasetOperator(
+        task_id="cleanup_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+
+    cleanup_proj = ArizeAxDeleteProjectOperator(
+        task_id="cleanup_project",
+        project_id="{{ ti.xcom_pull(task_ids='create_project') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+
+    # Wiring
+
+    # Phase 1 → 2
+    list_spaces >> [create_project, create_dataset]
+    create_dataset >> get_dataset
+
+    # Phase 2 → 3 (create prompts after space_id is known)
+    list_spaces >> [create_prompt_concise, create_prompt_detailed]
+
+    # Phase 2 → 4 (sensor gate after dataset exists)
+    get_dataset >> dataset_ready
+
+    # Phase 4 → 5 (all experiments run in parallel after dataset is ready)
+    for exp_task in experiment_tasks:
+        dataset_ready >> exp_task
+
+    # Phase 5 → 5b (list all experiments after they complete)
+    experiment_tasks >> list_experiments
+
+    # Phase 5 + extras → 6 (verify after everything)
+    [list_experiments, create_prompt_concise, create_prompt_detailed, create_project] >> verify
+
+    # Phase 6 → 6b → 7
+    verify >> inspection_window
+    inspection_window >> cleanup_exps >> [delete_prompt_concise, delete_prompt_detailed] >> cleanup_ds >> cleanup_proj

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_ml_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_ml_dag.py
@@ -1,0 +1,108 @@
+"""
+Example DAG: Arize AX ML batch logging and export workflow.
+
+Logs a small batch of synthetic ML predictions with ArizeAxMLLogBatchOperator,
+then exports the data for analysis with targeted ``where`` and ``columns``
+filters.
+
+The synthetic batch (4 rows) is built inline so the DAG runs end-to-end
+without user-supplied data. In production, replace ``_SAMPLE_DATAFRAME`` and
+``_SAMPLE_SCHEMA`` with your real predictions + schema.
+
+Requires:
+- Airflow connection ``arize_ax_default`` with API key.
+- Airflow variable ``arize_ax_space_id``.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta
+
+import pandas as pd
+from airflow import DAG
+from airflow.providers.arize_ax.operators.ml import (
+    ArizeAxMLExportToDataframeOperator,
+    ArizeAxMLExportToParquetOperator,
+    ArizeAxMLLogBatchOperator,
+)
+from arize.ml.types import Environments, ModelTypes, Schema
+
+# Tiny synthetic predictions batch — replace with your real DataFrame for production use.
+_NOW_TS = int(time.time())
+_SAMPLE_DATAFRAME = pd.DataFrame(
+    [
+        {"prediction_id": "ex-1", "prediction_label": "positive",
+         "prediction_score": 0.92, "actual_label": "positive",
+         "ts": _NOW_TS, "feature_1": 0.5},
+        {"prediction_id": "ex-2", "prediction_label": "negative",
+         "prediction_score": 0.71, "actual_label": "negative",
+         "ts": _NOW_TS, "feature_1": 0.3},
+        {"prediction_id": "ex-3", "prediction_label": "positive",
+         "prediction_score": 0.88, "actual_label": "negative",
+         "ts": _NOW_TS, "feature_1": 0.6},
+        {"prediction_id": "ex-4", "prediction_label": "negative",
+         "prediction_score": 0.65, "actual_label": "negative",
+         "ts": _NOW_TS, "feature_1": 0.2},
+    ]
+)
+_SAMPLE_SCHEMA = Schema(
+    prediction_id_column_name="prediction_id",
+    prediction_label_column_name="prediction_label",
+    prediction_score_column_name="prediction_score",
+    actual_label_column_name="actual_label",
+    timestamp_column_name="ts",
+    feature_column_names=["feature_1"],
+)
+
+
+with DAG(
+    dag_id="example_arize_ax_ml",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "example", "ml"],
+    catchup=False,
+) as dag:
+    log_batch = ArizeAxMLLogBatchOperator(
+        task_id="log_predictions",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        model_name="my-classifier",
+        model_type=ModelTypes.SCORE_CATEGORICAL,
+        environment=Environments.PRODUCTION,
+        dataframe=_SAMPLE_DATAFRAME,
+        schema=_SAMPLE_SCHEMA,
+        # SDK 8.25+ rejects empty model_version with ValidationFailure; pass a
+        # stable label so successive runs append to the same model version.
+        extra_log_kwargs={"model_version": "v1"},
+    )
+
+    # Just-logged ML data takes a few minutes to become queryable via the
+    # Flight export endpoint (model indexing delay). Retry with backoff so a
+    # single-DAG-run demo can complete end-to-end once indexing catches up.
+    export_df = ArizeAxMLExportToDataframeOperator(
+        task_id="export_ml_data",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        model_name="my-classifier",
+        environment=Environments.PRODUCTION,
+        start_time="{{ (logical_date - macros.timedelta(days=1)).isoformat() }}",
+        end_time="{{ logical_date.isoformat() }}",
+        # Arize exports score_categorical labels as ``scorePredictionLabel``
+        # at query time (not ``prediction_label`` as used at log time).
+        where="scorePredictionLabel = 'positive'",
+        retries=5,
+        retry_delay=timedelta(minutes=2),
+    )
+
+    export_parquet = ArizeAxMLExportToParquetOperator(
+        task_id="export_ml_parquet",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        model_name="my-classifier",
+        environment=Environments.PRODUCTION,
+        start_time="{{ (logical_date - macros.timedelta(days=1)).isoformat() }}",
+        end_time="{{ logical_date.isoformat() }}",
+        path="/tmp/ml_export.parquet",
+        retries=5,
+        retry_delay=timedelta(minutes=2),
+    )
+
+    log_batch >> [export_df, export_parquet]

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_ab_test_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_ab_test_dag.py
@@ -1,0 +1,231 @@
+"""
+Prompt A/B Testing DAG: compare N prompts against an evaluation dataset and
+promote the winner to the "production" label in Arize Prompt Hub.
+
+Pipeline stages
+---------------
+1. **create_eval_dataset** — create (or skip if exists) the evaluation dataset.
+2. **append_eval_examples** — load evaluation examples into the dataset.
+3. **compare_prompts** — run one experiment per prompt and rank by mean eval
+   score (ArizeAxComparePromptsOperator).
+4. **extract_winner** — pull the winning prompt name from compare_prompts XCom.
+5. **gate_has_winner** — short-circuit if no winner was determined.
+6. **promote_winner** — tag the winning prompt version with label="production"
+   (ArizeAxPromotePromptOperator).
+7. **log_results** — log the full rankings summary.
+
+Variables
+---------
+- ``arize_ax_space_id`` — Arize space ID (required).
+- ``arize_ax_dataset_id`` — dataset ID; if absent a new dataset is created.
+- ``arize_ax_prompt_names`` — prompt names to compare. Accepts either a
+  comma-separated list (``"prompt-a,prompt-b"``) or a JSON array
+  (``'["prompt-a","prompt-b"]'``). Default:
+  ``["prompt-v1", "prompt-v2", "prompt-v3"]``.
+
+Requires:
+  - Airflow connection ``arize_ax_default`` with a valid API key.
+  - At least two prompts already created in Arize Prompt Hub with the names
+    listed in ``arize_ax_prompt_names``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+from airflow.models import Variable
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxAppendDatasetExamplesOperator,
+    ArizeAxCreateDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.prompts import (
+    ArizeAxComparePromptsOperator,
+    ArizeAxPromotePromptOperator,
+)
+
+AB_DATASET_NAME = "prompt-ab-eval-dataset"
+
+# Sample evaluation examples used to score each prompt.
+AB_EVAL_EXAMPLES = [
+    {"query": "What is the capital of France?", "expected_output": "Paris"},
+    {"query": "What is 7 multiplied by 8?", "expected_output": "56"},
+    {"query": "Who wrote Hamlet?", "expected_output": "William Shakespeare"},
+    {"query": "What element has atomic number 1?", "expected_output": "Hydrogen"},
+    {"query": "How many continents are there?", "expected_output": "7"},
+]
+
+# Default prompt names compared when Variable is not set.
+_DEFAULT_PROMPT_NAMES = ["prompt-v1", "prompt-v2", "prompt-v3"]
+
+
+def _resolve_prompt_names() -> list[str]:
+    """Read the ``arize_ax_prompt_names`` Variable, accepting JSON or CSV."""
+    raw = Variable.get("arize_ax_prompt_names", default_var=None)
+    if not raw or not str(raw).strip():
+        return _DEFAULT_PROMPT_NAMES
+    s = str(raw).strip()
+    if s.startswith("["):
+        try:
+            parsed = json.loads(s)
+            if isinstance(parsed, list):
+                names = [str(n).strip() for n in parsed if str(n).strip()]
+                if names:
+                    return names
+        except json.JSONDecodeError:
+            pass
+    names = [n.strip() for n in s.split(",") if n.strip()]
+    return names or _DEFAULT_PROMPT_NAMES
+
+
+def _ab_task(dataset_row: dict) -> dict:
+    """Minimal task that echoes expected output to demonstrate the pipeline.
+
+    Replace with a real LLM call in production, e.g.::
+
+        response = openai.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": dataset_row["query"]}],
+        )
+        return {"output": response.choices[0].message.content}
+    """
+    return {"output": dataset_row.get("expected_output", "")}
+
+
+def _ab_evaluator(dataset_row: dict, output: Any):
+    """Accuracy evaluator: 1.0 if output matches expected, else 0.0."""
+    from arize.experiments import EvaluationResult
+
+    if output is None:
+        return EvaluationResult(score=0.0, label="error", explanation="no output")
+    actual = output.get("output", "") if isinstance(output, dict) else str(output)
+    expected = dataset_row.get("expected_output", "")
+    match = str(actual).strip().lower() == str(expected).strip().lower()
+    return EvaluationResult(
+        score=1.0 if match else 0.0,
+        label="correct" if match else "incorrect",
+        explanation=f"expected={expected!r}, got={actual!r}",
+    )
+
+
+def _extract_winner(**ctx) -> str | None:
+    """Pull the winning prompt name from compare_prompts XCom."""
+    result = ctx["ti"].xcom_pull(task_ids="compare_prompts")
+    if not isinstance(result, dict):
+        print(f"[extract_winner] unexpected XCom type: {type(result).__name__!r}")
+        return None
+    winner = result.get("winner")
+    rankings = result.get("rankings", [])
+    print(f"[extract_winner] winner={winner!r}")
+    for entry in rankings:
+        print(
+            f"  rank={entry.get('rank')}  prompt={entry.get('prompt_name')!r}"
+            f"  mean_score={entry.get('mean_score')}"
+        )
+    return winner
+
+
+def _gate_has_winner(**ctx) -> bool:
+    """Return True iff a clear winner was produced."""
+    winner = ctx["ti"].xcom_pull(task_ids="extract_winner")
+    if winner:
+        print(f"[gate] winner={winner!r} -- proceeding to promotion.")
+        return True
+    print("[gate] no winner determined -- short-circuiting.")
+    return False
+
+
+def _log_results(**ctx) -> dict[str, Any]:
+    """Log the A/B test summary."""
+    result = ctx["ti"].xcom_pull(task_ids="compare_prompts") or {}
+    winner = result.get("winner")
+    rankings = result.get("rankings", [])
+    print("=" * 60)
+    print("PROMPT A/B TEST COMPLETE")
+    print(f"  Winner: {winner!r}")
+    for entry in rankings:
+        print(
+            f"  rank={entry.get('rank')}  {entry.get('prompt_name')!r}"
+            f"  mean_score={entry.get('mean_score'):.4f}"
+            f"  exp_id={entry.get('experiment_id')}"
+        )
+    print("=" * 60)
+    return {"winner": winner, "rankings": rankings}
+
+
+with DAG(
+    dag_id="arize_ax_prompt_ab_test",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "prompts", "ab_test", "experiments"],
+    catchup=False,
+    doc_md=__doc__,
+) as dag:
+
+    # Stage 1 — Dataset setup
+    create_eval_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_eval_dataset",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        name=AB_DATASET_NAME,
+        # SDK 8.25+ rejects examples=[] with a client-side ValueError before
+        # the API is called, so if_exists="skip" can't intercept it. Seed
+        # with a single placeholder example; real examples are added by the
+        # subsequent append step.
+        examples=[{"input": "_seed_", "expected": "_seed_"}],
+        if_exists="skip",
+    )
+
+    append_eval_examples = ArizeAxAppendDatasetExamplesOperator(
+        task_id="append_eval_examples",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        examples=AB_EVAL_EXAMPLES,
+    )
+
+    # Stage 2 — Compare prompts
+    compare_prompts = ArizeAxComparePromptsOperator(
+        task_id="compare_prompts",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        prompt_names=_resolve_prompt_names(),
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        task=_ab_task,
+        evaluators=[_ab_evaluator],
+        experiment_name_prefix="prompt-ab",
+        concurrency=2,
+    )
+
+    # Stage 3 — Extract winner and gate
+    extract_winner = PythonOperator(
+        task_id="extract_winner",
+        python_callable=_extract_winner,
+    )
+
+    gate_has_winner = ShortCircuitOperator(
+        task_id="gate_has_winner",
+        python_callable=_gate_has_winner,
+    )
+
+    # Stage 4 — Promote winning prompt
+    promote_winner = ArizeAxPromotePromptOperator(
+        task_id="promote_winner",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        prompt_name="{{ ti.xcom_pull(task_ids='extract_winner') }}",
+        label="production",
+    )
+
+    # Stage 5 — Log results
+    log_results = PythonOperator(
+        task_id="log_results",
+        python_callable=_log_results,
+    )
+
+    # Wiring
+    create_eval_dataset >> append_eval_examples >> compare_prompts
+    compare_prompts >> extract_winner >> gate_has_winner >> promote_winner >> log_results

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_lifecycle_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_lifecycle_dag.py
@@ -1,0 +1,363 @@
+"""
+Prompt Lifecycle Management DAG: version → evaluate → promote → monitor → rollback.
+
+This DAG implements a full prompt lifecycle, using only existing Arize AX
+operators.  It is designed to be triggered externally (e.g. on a new prompt
+commit or a CI event) and gates each promotion stage with evaluation scores.
+
+Lifecycle stages
+----------------
+**Stage 1 — Setup**
+  - Fetch the latest version of the target prompt from Prompt Hub.
+  - Create (or reuse) the evaluation dataset.
+  - Append evaluation examples.
+
+**Stage 2 — Staging evaluation**
+  - Run an experiment against the staging dataset.
+  - Wait for runs to complete.
+  - Score the experiment.
+  - Gate: skip if avg score < ``arize_ax_staging_threshold`` Variable.
+  - Promote the prompt to the ``"staging"`` label.
+
+**Stage 3 — Production evaluation**
+  - Run a more rigorous experiment.
+  - Wait for runs to complete.
+  - Score the experiment.
+  - Compare the staging experiment against the configured baseline.
+  - Gate: skip if the comparison does not pass ``overall_passed=True``.
+  - Promote the prompt to the ``"production"`` label.
+
+**Stage 4 — Archival placeholder**
+  - Log that the previous version should be archived (implement with a
+    custom hook call or ArizeAxDeletePromptOperator in production).
+
+Pipeline
+--------
+get_latest_prompt
+  → create_eval_dataset
+  → append_eval_examples
+  → run_staging_eval
+  → wait_for_staging_runs
+  → score_staging
+  → gate_passes_staging
+  → promote_to_staging
+  → run_production_eval
+  → wait_for_production_runs
+  → score_production
+  → compare_to_baseline
+  → gate_passes_production
+  → promote_to_production
+  → archive_old_version
+
+Schedule: ``None`` — triggered externally (e.g. on prompt commit).
+
+Variables
+---------
+- ``arize_ax_space_id`` — Arize space ID.
+- ``arize_ax_dataset_id`` — dataset ID used for evaluations.
+- ``arize_ax_prompt_name`` — name of the prompt to manage.
+- ``arize_ax_baseline_experiment_id`` — experiment ID of the known-good
+  production baseline.
+- ``arize_ax_staging_threshold`` — minimum avg score to pass staging gate
+  (default ``"0.7"``).
+- ``arize_ax_production_threshold`` — minimum avg score to pass production
+  gate (default ``"0.8"``).
+
+Requires:
+  - Airflow connection ``arize_ax_default`` with a valid API key.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+from airflow.models import Variable
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxAppendDatasetExamplesOperator,
+    ArizeAxCreateDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.experiments import (
+    ArizeAxCompareExperimentsOperator,
+    ArizeAxGetExperimentScoreOperator,
+    ArizeAxRunExperimentOperator,
+)
+from airflow.providers.arize_ax.operators.prompts import (
+    ArizeAxGetPromptOperator,
+    ArizeAxPromotePromptOperator,
+)
+from airflow.providers.arize_ax.sensors.arize_ax import (
+    ArizeAxExperimentRunCountSensor,
+)
+
+# ---------------------------------------------------------------------------
+# Constants — adjust to your environment
+# ---------------------------------------------------------------------------
+LIFECYCLE_MIN_RUNS = 5
+LIFECYCLE_EVAL_EXAMPLES = [
+    {"query": "What is the capital of France?", "expected_output": "Paris"},
+    {"query": "What is 7 multiplied by 8?", "expected_output": "56"},
+    {"query": "Who wrote Hamlet?", "expected_output": "William Shakespeare"},
+    {"query": "What element has atomic number 1?", "expected_output": "Hydrogen"},
+    {"query": "How many continents are there?", "expected_output": "7"},
+]
+
+
+
+def _check_pipeline_configured(**ctx) -> bool:
+    """Return True only when required Variables are set for prompt lifecycle."""
+    required = {
+        "arize_ax_space_id": "a valid space ID",
+        "arize_ax_prompt_name": "the prompt name to manage",
+        "arize_ax_baseline_experiment_id": "a baseline experiment ID",
+    }
+    missing = []
+    for key, description in required.items():
+        val = Variable.get(key, default_var=None)
+        if not val or val.strip() in ("", "your-space-id", "my-prompt", "your-baseline-id"):
+            missing.append(f"  - {key}: set to {description}")
+    if missing:
+        print(
+            "The following Variables must be set to run the prompt lifecycle pipeline:\n"
+            + "\n".join(missing)
+        )
+        return False
+    return True
+
+
+def _lifecycle_task(dataset_row: dict) -> dict:
+    """Lifecycle evaluation task — stub that echoes expected output.
+
+    Replace with your real LLM call in production::
+
+        prompt_version = dataset_row.get("_prompt_version")
+        response = openai.chat.completions.create(
+            model="gpt-4o",
+            messages=prompt_version["messages"] + [
+                {"role": "user", "content": dataset_row["query"]}
+            ],
+        )
+        return {"output": response.choices[0].message.content}
+    """
+    return {"output": dataset_row.get("expected_output", "")}
+
+
+def _accuracy_evaluator(dataset_row: dict, output: Any) -> Any:
+    """Simple exact-match accuracy evaluator."""
+    from arize.experiments import EvaluationResult
+
+    if output is None:
+        return EvaluationResult(score=0.0, label="error", explanation="no output")
+    actual = output.get("output", "") if isinstance(output, dict) else str(output)
+    expected = dataset_row.get("expected_output", "")
+    match = str(actual).strip().lower() == str(expected).strip().lower()
+    return EvaluationResult(
+        score=1.0 if match else 0.0,
+        label="correct" if match else "incorrect",
+        explanation=f"expected={expected!r}, got={actual!r}",
+    )
+
+
+def _gate_passes_staging(**ctx) -> bool:
+    """Return True iff staging avg score >= arize_ax_staging_threshold."""
+    scores = ctx["ti"].xcom_pull(task_ids="score_staging") or {}
+    if not isinstance(scores, dict) or not scores:
+        print("[gate_passes_staging] No scores returned — failing gate.")
+        return False
+    avg_score = sum(scores.values()) / len(scores)
+    threshold = float(Variable.get("arize_ax_staging_threshold", default_var="0.7"))
+    print(f"[gate_passes_staging] avg_score={avg_score:.4f}, threshold={threshold}")
+    return avg_score >= threshold
+
+
+def _gate_passes_production(**ctx) -> bool:
+    """Return True iff compare_to_baseline overall_passed=True."""
+    result = ctx["ti"].xcom_pull(task_ids="compare_to_baseline")
+    if not isinstance(result, dict):
+        print(f"[gate_passes_production] compare_to_baseline XCom not a dict: {result!r} — failing gate.")
+        return False
+    overall_passed = result.get("overall_passed", False)
+    results = result.get("results", {})
+    print(f"[gate_passes_production] overall_passed={overall_passed}")
+    for metric, data in results.items():
+        print(
+            f"  {metric}: staging={data.get('candidate'):.4f}  "
+            f"baseline={data.get('baseline'):.4f}  "
+            f"delta={data.get('delta'):.4f}  passed={data.get('passed')}"
+        )
+    return bool(overall_passed)
+
+
+def _archive_old_version(**ctx) -> dict[str, Any]:
+    """Placeholder: log that the previous production version should be archived.
+
+    In production, replace this stub with a call to tag or delete the old
+    version.  For example::
+
+        from airflow.providers.arize_ax.hooks.arize_ax import ArizeAxHook
+        hook = ArizeAxHook()
+        hook.promote_prompt(
+            space_id=space_id,
+            prompt_id=prompt_id,
+            label="archived",
+            version_id=old_version_id,
+        )
+    """
+    production_result = ctx["ti"].xcom_pull(task_ids="promote_to_production") or {}
+    prompt_id = production_result.get("prompt_id")
+
+    print("=" * 60)
+    print("PROMPT LIFECYCLE COMPLETE")
+    print(f"  Prompt ID : {prompt_id}")
+    print("  Label     : production")
+    print("  Archive   : previous production version should now be labelled 'archived'.")
+    print("              Implement via ArizeAxPromotePromptOperator with label='archived'.")
+    print("=" * 60)
+    return {"prompt_id": prompt_id, "archived": False}  # stub
+
+
+with DAG(
+    dag_id="arize_ax_prompt_lifecycle",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "prompts", "lifecycle", "experiments"],
+    catchup=False,
+    doc_md=__doc__,
+) as dag:
+
+    # Stage 0 — Guard: skip DAG if required Variables are not configured
+    check_pipeline_configured = ShortCircuitOperator(
+        task_id="check_pipeline_configured",
+        python_callable=_check_pipeline_configured,
+    )
+
+    # Stage 1 — Dataset setup
+    get_latest_prompt = ArizeAxGetPromptOperator(
+        task_id="get_latest_prompt",
+        prompt_name="{{ var.value.get('arize_ax_prompt_name', '') }}",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+    )
+
+    create_eval_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_eval_dataset",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        name="lifecycle-eval-{{ ts_nodash }}",
+        # SDK 8.25+ rejects empty examples list at create time. Seed with a
+        # single placeholder; real examples are added by the subsequent
+        # append step.
+        examples=[{"input": "_seed_", "expected": "_seed_"}],
+        if_exists="skip",
+    )
+
+    append_eval_examples = ArizeAxAppendDatasetExamplesOperator(
+        task_id="append_eval_examples",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        examples=LIFECYCLE_EVAL_EXAMPLES,
+    )
+
+    # Stage 2 — Staging evaluation
+    run_staging_eval = ArizeAxRunExperimentOperator(
+        task_id="run_staging_eval",
+        name="lifecycle-staging-{{ ts_nodash }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        task=_lifecycle_task,
+        evaluators=[_accuracy_evaluator],
+        concurrency=4,
+    )
+
+    wait_for_staging_runs = ArizeAxExperimentRunCountSensor(
+        task_id="wait_for_staging_runs",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_staging_eval') }}",
+        min_runs=LIFECYCLE_MIN_RUNS,
+        poke_interval=15,
+        timeout=600,
+        mode="poke",
+        soft_fail=True,
+    )
+
+    score_staging = ArizeAxGetExperimentScoreOperator(
+        task_id="score_staging",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_staging_eval') }}",
+        aggregation="mean",
+    )
+
+    gate_passes_staging = ShortCircuitOperator(
+        task_id="gate_passes_staging",
+        python_callable=_gate_passes_staging,
+    )
+
+    promote_to_staging = ArizeAxPromotePromptOperator(
+        task_id="promote_to_staging",
+        prompt_name="{{ var.value.get('arize_ax_prompt_name', '') }}",
+        label="staging",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+    )
+
+    # Stage 3 — Production evaluation
+    run_production_eval = ArizeAxRunExperimentOperator(
+        task_id="run_production_eval",
+        name="lifecycle-production-{{ ts_nodash }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        task=_lifecycle_task,
+        evaluators=[_accuracy_evaluator],
+        concurrency=4,
+    )
+
+    wait_for_production_runs = ArizeAxExperimentRunCountSensor(
+        task_id="wait_for_production_runs",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_production_eval') }}",
+        min_runs=LIFECYCLE_MIN_RUNS,
+        poke_interval=15,
+        timeout=600,
+        mode="poke",
+        soft_fail=True,
+    )
+
+    score_production = ArizeAxGetExperimentScoreOperator(
+        task_id="score_production",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_production_eval') }}",
+        aggregation="mean",
+    )
+
+    compare_to_baseline = ArizeAxCompareExperimentsOperator(
+        task_id="compare_to_baseline",
+        candidate_experiment_id="{{ ti.xcom_pull(task_ids='run_production_eval') }}",
+        baseline_experiment_id="{{ var.value.get('arize_ax_baseline_experiment_id', '') }}",
+        pass_threshold=0.0,
+        aggregation="mean",
+    )
+
+    gate_passes_production = ShortCircuitOperator(
+        task_id="gate_passes_production",
+        python_callable=_gate_passes_production,
+    )
+
+    promote_to_production = ArizeAxPromotePromptOperator(
+        task_id="promote_to_production",
+        prompt_name="{{ var.value.get('arize_ax_prompt_name', '') }}",
+        label="production",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+    )
+
+    # Stage 4 — Archival placeholder
+    archive_old_version = PythonOperator(
+        task_id="archive_old_version",
+        python_callable=_archive_old_version,
+    )
+
+    # Wiring
+    check_pipeline_configured >> get_latest_prompt >> create_eval_dataset >> append_eval_examples
+
+    append_eval_examples >> run_staging_eval >> wait_for_staging_runs >> score_staging
+    score_staging >> gate_passes_staging >> promote_to_staging
+
+    promote_to_staging >> run_production_eval >> wait_for_production_runs >> score_production
+    score_production >> compare_to_baseline >> gate_passes_production
+    gate_passes_production >> promote_to_production >> archive_old_version

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_optimization_with_feedback_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_optimization_with_feedback_dag.py
@@ -1,0 +1,123 @@
+"""Self-learning agent demo — closed-loop prompt optimization from production feedback.
+
+End-to-end story implemented with three native Arize provider operators and
+**Airflow dynamic task mapping** so every system prompt in your project is
+optimized in parallel — one task instance per agent.
+
+Pipeline::
+
+    curate_feedback_dataset  ──┬─►  optimize_prompt  (mapped: one per prompt group)
+    (one Arize op)             │           │
+                               │           ▼
+                               └───────►  create_optimized_prompt  (mapped)
+
+1. **curate_feedback_dataset** — ``ArizeAxCurateFeedbackDatasetOperator``
+   fetches LLM spans from your project, reads only OpenInference standard
+   fields (``llm.input_messages`` for system prompts, ``llm.output_messages``
+   for outputs, row-level ``evaluations`` + ``annotations`` for feedback),
+   groups them by system-prompt fingerprint (or by a user-supplied metadata
+   key like ``"agent"``), and emits one ``{prompt, dataset, group_key}`` per
+   group ready for downstream mapping. Framework-agnostic.
+2. **optimize_prompt** — ``ArizeAxOptimizePromptOperator`` expanded with
+   ``.partial(...).expand_kwargs(curate.output)``. One task instance per
+   prompt group. Each instance calls the Arize Prompt Learning SDK to
+   produce a revised system prompt informed by that group's own feedback.
+3. **create_optimized_prompt** — ``ArizeAxCreatePromptOperator`` expanded
+   over the optimize output so every improved prompt is pushed (or
+   version-bumped via ``if_exists="skip"``) to the Arize Prompt Hub. The
+   created prompt name includes the ``group_key`` so each agent gets its
+   own named prompt.
+
+User configuration:
+- Airflow connection ``arize_ax_default`` with API key.
+- Variable ``arize_ax_project_id`` — base64 project ID to optimize.
+- Variable ``arize_ax_space_id`` — space the new prompts get written to.
+- Variable ``arize_ax_lookback_days`` (optional, default 30) — how far back
+  to read production feedback.
+- Variable ``arize_ax_group_by_metadata_key`` (optional, default unset) —
+  set to e.g. ``"agent"`` or ``"langgraph_node"`` if your spans carry a
+  per-agent metadata tag (yields readable group keys); otherwise spans
+  group by system-prompt fingerprint.
+- ``OPENAI_API_KEY`` in the worker environment.
+- ``arize-ax-airflow-provider[prompt_learning]`` installed in the worker
+  (Python 3.12+ recommended).
+
+Point the DAG at a project and trigger it — every system prompt with
+production feedback in the lookback window gets optimized and a new
+version lands in Prompt Hub.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from airflow import DAG
+from airflow.providers.arize_ax.operators.prompts import (
+    ArizeAxCreatePromptOperator,
+    ArizeAxOptimizePromptOperator,
+)
+from airflow.providers.arize_ax.operators.spans import (
+    ArizeAxCurateFeedbackDatasetOperator,
+)
+
+OPTIMIZATION_MODEL = "gpt-4o"
+
+
+def _build_create_prompt_kwargs(result: dict[str, Any]) -> dict[str, Any]:
+    """Per-group kwargs for ArizeAxCreatePromptOperator.expand_kwargs(...).
+
+    Defined at module level (rather than inline as a lambda on the .map call)
+    so Airflow's mapped-task serialization works across all executors —
+    lambdas pickle inconsistently under stricter executors.
+    """
+    group_key = result.get("group_key") or "default"
+    return {
+        "name": f"optimized-{group_key}-{datetime.now(timezone.utc):%Y%m%d}",
+        "messages": result["messages"],
+    }
+
+
+with DAG(
+    dag_id="example_arize_ax_prompt_optimization_with_feedback",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "example", "prompt_optimization", "self_learning"],
+    catchup=False,
+    doc_md=__doc__,
+) as dag:
+    curate = ArizeAxCurateFeedbackDatasetOperator(
+        task_id="curate_feedback_dataset",
+        project_id="{{ var.value.get('arize_ax_project_id', '') }}",
+        start_time=(
+            "{{ (logical_date - macros.timedelta("
+            "days=(var.value.get('arize_ax_lookback_days', 30) | int)"
+            ")).isoformat() }}"
+        ),
+        end_time="{{ logical_date.isoformat() }}",
+        group_by_metadata_key="{{ var.value.get('arize_ax_group_by_metadata_key', '') or None }}",
+        min_records_per_group=3,
+    )
+
+    # ArizeAxOptimizePromptOperator reads OPENAI_API_KEY from the worker
+    # environment automatically when openai_api_key is omitted, so callers
+    # don't need to bake the scheduler env into the DAG.
+    optimize = ArizeAxOptimizePromptOperator.partial(
+        task_id="optimize_prompt",
+        model_choice=OPTIMIZATION_MODEL,
+        feedback_columns=["feedback"],
+        output_column="output",
+    ).expand_kwargs(curate.output)
+
+    create_optimized_prompt = ArizeAxCreatePromptOperator.partial(
+        task_id="create_optimized_prompt",
+        space_id="{{ var.value.get('arize_ax_space_id', '') or None }}",
+        provider="open_ai",
+        input_variable_format="mustache",
+        model=OPTIMIZATION_MODEL,
+        description=(
+            "Optimized via ArizeAxOptimizePromptOperator from production "
+            "eval + annotation feedback."
+        ),
+        if_exists="skip",
+    ).expand_kwargs(optimize.output.map(_build_create_prompt_kwargs))

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_optimization_with_feedback_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_optimization_with_feedback_dag.py
@@ -39,8 +39,12 @@ User configuration:
   per-agent metadata tag (yields readable group keys); otherwise spans
   group by system-prompt fingerprint.
 - ``OPENAI_API_KEY`` in the worker environment.
-- ``arize-ax-airflow-provider[prompt_learning]`` installed in the worker
-  (Python 3.12+ recommended).
+- ``prompt-learning-enhanced`` installed in the worker — installed
+  separately because PyPI rejects direct-URL deps so the provider can no
+  longer declare it as an extra (Python 3.12+ recommended)::
+
+      pip install 'arize-phoenix-evals>=2.0,<3.0' \\
+                  'prompt-learning-enhanced @ git+https://github.com/Arize-ai/prompt-learning.git'
 
 Point the DAG at a project and trigger it — every system prompt with
 production feedback in the lookback window gets optimized and a new

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_rag_evaluation_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_rag_evaluation_dag.py
@@ -68,7 +68,10 @@ from airflow.providers.arize_ax.operators.spans import (
 )
 
 _TMP_PARQUET = "/tmp/rag_spans_{{ ds }}.parquet"
-_RAG_SPAN_WHERE = "span_kind='RETRIEVER' OR span_kind='LLM'"
+_RAG_SPAN_WHERE = (
+    "attributes.openinference.span.kind='RETRIEVER' "
+    "OR attributes.openinference.span.kind='LLM'"
+)
 
 
 def _extract_project_name(**ctx) -> str:

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_rag_evaluation_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_rag_evaluation_dag.py
@@ -1,0 +1,399 @@
+"""
+RAG Quality Evaluation DAG: automated daily faithfulness and relevance scoring.
+
+This DAG implements an automated daily pipeline that:
+1. Exports production RAG spans (RETRIEVER + LLM) from the previous 24 hours.
+2. Packages them into an evaluation dataset.
+3. Runs two Python evaluator experiments:
+   - **faithfulness**: does the LLM output stay grounded in the retrieved
+     context?  Score 1.0 = fully grounded, 0.0 = hallucinated.
+   - **context_relevance**: is the retrieved context actually relevant to the
+     user query?  Score 1.0 = highly relevant, 0.0 = irrelevant.
+4. Scores both experiments and logs a quality summary.
+
+Metrics computed
+----------------
+- ``faithfulness``: mean faithfulness score across all evaluated spans.
+- ``context_relevance``: mean context relevance score across evaluated spans.
+
+The ``report_rag_quality`` task pushes a summary dict to XCom so downstream
+alerting DAGs (e.g. a Slack notifier) can read it with
+``xcom_pull(dag_id="arize_ax_rag_evaluation", task_ids="report_rag_quality")``.
+
+Variables
+---------
+- ``arize_ax_project_name`` — Arize project **name** containing production RAG spans.
+  If absent, the first project returned by list_projects is used.
+- ``arize_ax_space_id``     — Arize space ID used to export spans and create datasets.
+  Required: ArizeAxListProjectsOperator and ArizeAxCreateDatasetOperator will raise
+  AirflowException with a clear message if this Variable is absent.
+
+Schedule
+--------
+Daily at midnight UTC (``@daily``).  Each run evaluates the spans from the
+previous calendar day via the Jinja macros ``data_interval_start`` and
+``data_interval_end``.
+
+Requires:
+  - Airflow connection ``arize_ax_default`` with a valid API key.
+  - Variable ``arize_ax_space_id`` — required by list_projects and create_dataset operators.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+from airflow.models import Variable
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxAppendDatasetExamplesOperator,
+    ArizeAxCreateDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.experiments import (
+    ArizeAxGetExperimentScoreOperator,
+    ArizeAxRunExperimentOperator,
+)
+from airflow.providers.arize_ax.operators.projects import (
+    ArizeAxListProjectsOperator,
+)
+from airflow.providers.arize_ax.operators.spans import (
+    ArizeAxSpansExportToParquetOperator,
+)
+
+_TMP_PARQUET = "/tmp/rag_spans_{{ ds }}.parquet"
+_RAG_SPAN_WHERE = "span_kind='RETRIEVER' OR span_kind='LLM'"
+
+
+def _extract_project_name(**ctx) -> str:
+    """Return the project name from ``arize_ax_project_name`` Variable.
+
+    Falls back to the name of the first project returned by
+    ArizeAxListProjectsOperator if the Variable is not set.
+    """
+    project_name_var = Variable.get("arize_ax_project_name", default_var=None)
+    if project_name_var:
+        return project_name_var
+
+    result = ctx["ti"].xcom_pull(task_ids="check_project_exists")
+    items = result.get("items", []) if isinstance(result, dict) else []
+    if not items:
+        raise ValueError(
+            "No projects found. Set Variable 'arize_ax_project_name' to your project name."
+        )
+    first_item = items[0]
+    name = first_item.get("name") if isinstance(first_item, dict) else None
+    if not name:
+        raise ValueError(
+            "Project item has no 'name' field. "
+            "Set Variable 'arize_ax_project_name' explicitly."
+        )
+    return str(name)
+
+
+def _check_has_spans(**ctx) -> bool:
+    """Return True if the parquet export produced at least one span."""
+    parquet_path = ctx["ti"].xcom_pull(task_ids="export_rag_spans")
+    if not parquet_path:
+        print("[check_has_spans] export task returned no path -- short-circuiting.")
+        return False
+    try:
+        import pandas as pd
+
+        df = pd.read_parquet(parquet_path)
+        count = len(df)
+        print(f"[check_has_spans] parquet has {count} rows.")
+        return count > 0
+    except Exception as exc:
+        print(f"[check_has_spans] could not read parquet: {exc} -- short-circuiting.")
+        return False
+
+
+def _prepare_rag_examples(**ctx) -> list[dict[str, Any]]:
+    """Load the exported parquet and extract input / output / context fields.
+
+    Returns a list of dataset example dicts ready for
+    ArizeAxAppendDatasetExamplesOperator.
+
+    Expected span columns (best-effort -- missing columns yield empty strings):
+    - ``input.value``   — the user query sent to the LLM / retriever
+    - ``output.value``  — the LLM response
+    - ``attributes.retrieval.documents`` — JSON list of retrieved document texts
+    """
+    import json
+
+    import pandas as pd
+
+    parquet_path = ctx["ti"].xcom_pull(task_ids="export_rag_spans")
+    if not parquet_path:
+        raise ValueError("No parquet path in XCom from export_rag_spans.")
+
+    df = pd.read_parquet(parquet_path)
+    examples: list[dict[str, Any]] = []
+    for _, row in df.iterrows():
+        input_val = str(row.get("input.value", row.get("input", "")))
+        output_val = str(row.get("output.value", row.get("output", "")))
+        raw_docs = row.get("attributes.retrieval.documents", row.get("retrieval.documents", ""))
+        if isinstance(raw_docs, str):
+            try:
+                docs = json.loads(raw_docs)
+                context = " ".join(
+                    d.get("document.content", "") if isinstance(d, dict) else str(d)
+                    for d in (docs if isinstance(docs, list) else [])
+                )
+            except (json.JSONDecodeError, TypeError):
+                context = raw_docs
+        elif isinstance(raw_docs, list):
+            context = " ".join(
+                d.get("document.content", "") if isinstance(d, dict) else str(d)
+                for d in raw_docs
+            )
+        else:
+            context = ""
+
+        if not input_val and not output_val:
+            continue  # skip empty rows
+
+        examples.append({
+            "query": input_val,
+            "response": output_val,
+            "context": context,
+        })
+
+    print(f"[prepare_rag_examples] produced {len(examples)} dataset examples.")
+    return examples
+
+
+def _faithfulness_evaluator(dataset_row: dict, output: Any) -> Any:
+    """Score whether the LLM response stays grounded in the retrieved context.
+
+    Uses a simple heuristic: if any non-trivial word from the response also
+    appears in the context, score = 1.0 (grounded); otherwise 0.0 (potential
+    hallucination).  Replace this with a real LLM-as-judge in production.
+    """
+    from arize.experiments import EvaluationResult
+
+    if output is None:
+        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
+
+    response = dataset_row.get("response", "")
+    context = dataset_row.get("context", "")
+
+    if not response or not context:
+        return EvaluationResult(
+            score=0.5,
+            label="unknown",
+            explanation="insufficient data to evaluate faithfulness",
+        )
+
+    response_words = {
+        w.lower() for w in response.split() if len(w) > 4
+    }
+    context_words = {
+        w.lower() for w in context.split() if len(w) > 4
+    }
+    overlap = response_words & context_words
+    grounded = len(overlap) >= max(1, len(response_words) // 4)
+
+    return EvaluationResult(
+        score=1.0 if grounded else 0.0,
+        label="grounded" if grounded else "hallucinated",
+        explanation=(
+            f"Overlap {len(overlap)}/{len(response_words)} meaningful words; "
+            f"threshold={max(1, len(response_words) // 4)}."
+        ),
+    )
+
+
+def _context_relevance_evaluator(dataset_row: dict, output: Any) -> Any:
+    """Score whether the retrieved context is relevant to the user query.
+
+    Uses a simple heuristic: if any word from the query (>3 chars) appears in
+    the context, score = 1.0 (relevant); otherwise 0.0 (irrelevant).  Replace
+    this with a real LLM-as-judge in production.
+    """
+    from arize.experiments import EvaluationResult
+
+    query = dataset_row.get("query", "")
+    context = dataset_row.get("context", "")
+
+    if not query or not context:
+        return EvaluationResult(
+            score=0.5,
+            label="unknown",
+            explanation="insufficient data to evaluate context relevance",
+        )
+
+    query_words = {w.lower() for w in query.split() if len(w) > 3}
+    context_words = {w.lower() for w in context.split() if len(w) > 3}
+    overlap = query_words & context_words
+    relevant = bool(overlap)
+
+    return EvaluationResult(
+        score=1.0 if relevant else 0.0,
+        label="relevant" if relevant else "irrelevant",
+        explanation=f"Query–context word overlap: {overlap or 'none'}.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Identity task: passes span data through to the experiment
+# ---------------------------------------------------------------------------
+def _rag_task(dataset_row: dict) -> dict:
+    """Identity task: surface the span's response field as the experiment output."""
+    return {
+        "output": dataset_row.get("response", ""),
+        "query": dataset_row.get("query", ""),
+        "context": dataset_row.get("context", ""),
+    }
+
+
+def _report_rag_quality(**ctx) -> dict[str, Any]:
+    """Log a RAG quality summary and push scores to XCom for downstream alerting."""
+    ti = ctx["ti"]
+    ds = ctx.get("ds", "unknown")
+    faithfulness_scores = ti.xcom_pull(task_ids="score_faithfulness") or {}
+    relevance_scores = ti.xcom_pull(task_ids="score_relevance") or {}
+
+    faithfulness = faithfulness_scores.get("_faithfulness_evaluator")
+    relevance = relevance_scores.get("_context_relevance_evaluator")
+
+    summary = {
+        "date": ds,
+        "faithfulness_score": faithfulness,
+        "context_relevance_score": relevance,
+    }
+
+    print("=" * 60)
+    print(f"RAG QUALITY REPORT — {ds}")
+    print(f"  Faithfulness score   : {faithfulness}")
+    print(f"  Context relevance    : {relevance}")
+    if faithfulness is not None and faithfulness < 0.7:
+        print("  WARNING: faithfulness below 0.7 — possible hallucination increase.")
+    if relevance is not None and relevance < 0.7:
+        print("  WARNING: context relevance below 0.7 — retrieval quality degraded.")
+    print("=" * 60)
+    return summary
+
+
+with DAG(
+    dag_id="arize_ax_rag_evaluation",
+    start_date=datetime(2025, 1, 1),
+    schedule="@daily",
+    tags=["arize_ax", "rag", "evaluation", "daily"],
+    catchup=False,
+    doc_md=__doc__,
+    render_template_as_native_obj=True,
+) as dag:
+
+    # Stage 1 — Discover project
+    check_project_exists = ArizeAxListProjectsOperator(
+        task_id="check_project_exists",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        limit=50,
+    )
+
+    extract_project_name = PythonOperator(
+        task_id="extract_project_name",
+        python_callable=_extract_project_name,
+    )
+
+    # Stage 2 — Export RAG spans from the previous 24 hours
+    export_rag_spans = ArizeAxSpansExportToParquetOperator(
+        task_id="export_rag_spans",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        project_name="{{ ti.xcom_pull(task_ids='extract_project_name') }}",
+        path=_TMP_PARQUET,
+        where=_RAG_SPAN_WHERE,
+        # Manual triggers leave data_interval_start == data_interval_end (both
+        # equal logical_date), and the SDK's exporter validates start < end
+        # strictly. Compute a 24h window off logical_date so manual triggers
+        # work; scheduled runs still see (close to) one schedule interval.
+        start_time="{{ (logical_date - macros.timedelta(hours=24)).isoformat() }}",
+        end_time="{{ logical_date.isoformat() }}",
+    )
+
+    check_has_spans = ShortCircuitOperator(
+        task_id="check_has_spans",
+        python_callable=_check_has_spans,
+    )
+
+    # Stage 3 — Build evaluation dataset
+    create_rag_eval_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_rag_eval_dataset",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        name="rag-eval-{{ ds }}",
+        # SDK 8.25+ rejects empty examples list at create time. Seed with a
+        # single placeholder; real RAG examples are appended by
+        # prepare_rag_examples once spans are exported.
+        examples=[{"input": "_seed_", "expected": "_seed_"}],
+        if_exists="skip",
+    )
+
+    prepare_rag_examples = PythonOperator(
+        task_id="prepare_rag_examples",
+        python_callable=_prepare_rag_examples,
+    )
+
+    append_rag_examples = ArizeAxAppendDatasetExamplesOperator(
+        task_id="append_rag_examples",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_rag_eval_dataset') }}",
+        examples="{{ ti.xcom_pull(task_ids='prepare_rag_examples') }}",
+    )
+
+    # Stage 4 — Run evaluation experiments
+    run_faithfulness_eval = ArizeAxRunExperimentOperator(
+        task_id="run_faithfulness_eval",
+        name="rag-faithfulness-{{ ds }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_rag_eval_dataset') }}",
+        task=_rag_task,
+        evaluators=[_faithfulness_evaluator],
+        concurrency=4,
+    )
+
+    run_relevance_eval = ArizeAxRunExperimentOperator(
+        task_id="run_relevance_eval",
+        name="rag-relevance-{{ ds }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_rag_eval_dataset') }}",
+        task=_rag_task,
+        evaluators=[_context_relevance_evaluator],
+        concurrency=4,
+    )
+
+    # Stage 5 — Score experiments
+    score_faithfulness = ArizeAxGetExperimentScoreOperator(
+        task_id="score_faithfulness",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_faithfulness_eval') }}",
+        aggregation="mean",
+    )
+
+    score_relevance = ArizeAxGetExperimentScoreOperator(
+        task_id="score_relevance",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_relevance_eval') }}",
+        aggregation="mean",
+    )
+
+    # Stage 6 — Report
+    report_rag_quality = PythonOperator(
+        task_id="report_rag_quality",
+        python_callable=_report_rag_quality,
+        trigger_rule="all_done",
+    )
+
+    # Wiring
+    check_project_exists >> extract_project_name >> export_rag_spans >> check_has_spans
+
+    check_has_spans >> create_rag_eval_dataset >> prepare_rag_examples >> append_rag_examples
+
+    append_rag_examples >> [run_faithfulness_eval, run_relevance_eval]
+
+    run_faithfulness_eval >> score_faithfulness
+    run_relevance_eval >> score_relevance
+
+    [score_faithfulness, score_relevance] >> report_rag_quality

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_spans_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_spans_dag.py
@@ -1,0 +1,87 @@
+"""
+Example DAG: Arize AX spans workflow.
+
+Demonstrates listing spans with filters, exporting spans to Parquet with
+targeted ``where`` / ``columns``, and updating evaluations on exported spans.
+
+This DAG requires a real Arize project with existing spans.  Set the
+``arize_ax_project_id`` Airflow Variable before triggering.  If the Variable
+is absent or empty the downstream operators will raise AirflowException with
+a clear message — no ShortCircuit task is required.
+
+Requires:
+- Airflow connection ``arize_ax_default`` with API key.
+- Airflow variable ``arize_ax_project_id`` — set to a real project ID.
+- Optional variable ``arize_ax_space_id`` (falls back to connection default_space).
+- Optional variable ``arize_ax_project_name`` (defaults to resolved from project).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.models import Variable
+from airflow.providers.arize_ax.operators.spans import (
+    ArizeAxListSpansOperator,
+    ArizeAxSpansExportToDataframeOperator,
+    ArizeAxSpansExportToParquetOperator,
+)
+from airflow.providers.arize_ax.sensors.arize_ax import ArizeAxSpanCountSensor
+
+# Resolve the project name from an Airflow Variable so the DAG is not
+# tied to a hard-coded string.  Falls back to None so the hook uses its
+# default resolution when the variable is not defined.
+try:
+    _project_name: str | None = Variable.get(
+        "arize_ax_project_name", default_var=None
+    )
+except Exception:
+    _project_name = None
+
+
+with DAG(
+    dag_id="example_arize_ax_spans",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "example", "spans"],
+    catchup=False,
+    doc_md=__doc__,
+) as dag:
+    wait_for_spans = ArizeAxSpanCountSensor(
+        task_id="wait_for_spans",
+        project_id="{{ var.value.get('arize_ax_project_id', '') }}",
+        min_count=10,
+        poke_interval=60,
+        timeout=600,
+        mode="poke",
+    )
+
+    list_error_spans = ArizeAxListSpansOperator(
+        task_id="list_error_spans",
+        project_id="{{ var.value.get('arize_ax_project_id', '') }}",
+        filter="status_code = 'ERROR'",
+        limit=50,
+    )
+
+    export_spans_df = ArizeAxSpansExportToDataframeOperator(
+        task_id="export_spans_filtered",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        project_name=_project_name,
+        start_time="{{ (logical_date - macros.timedelta(days=7)).isoformat() }}",
+        end_time="{{ logical_date.isoformat() }}",
+        where="span.status_code = 'ERROR'",
+        columns=["context.span_id", "name", "status_code", "latency_ms"],
+    )
+
+    export_spans_parquet = ArizeAxSpansExportToParquetOperator(
+        task_id="export_spans_parquet",
+        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        project_name=_project_name,
+        start_time="{{ (logical_date - macros.timedelta(days=7)).isoformat() }}",
+        end_time="{{ logical_date.isoformat() }}",
+        path="/tmp/spans_export.parquet",
+        where="span.status_code = 'OK'",
+    )
+
+    wait_for_spans >> [list_error_spans, export_spans_df, export_spans_parquet]

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_tasks_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_tasks_dag.py
@@ -1,0 +1,433 @@
+"""
+Example DAG: Arize AX Tasks — full end-to-end eval-gate pipeline.
+
+Fully self-contained — no pre-existing task IDs, evaluator IDs, or dataset IDs
+required.  The DAG auto-discovers a project in the space, creates a demo
+LLM-as-judge evaluator, wires it to an evaluation task, triggers an on-demand
+run, waits for completion, then gates a deployment decision on the eval score.
+The evaluator is deleted on exit (whether the run passed or failed).
+
+**Evaluator naming:** the evaluator is created with a date-stamped name
+(``arize-ax-tasks-e2e-demo-<YYYYMMDD>``) so each daily run starts with a
+brand-new evaluator ID and zero evaluation history.  Arize tracks evaluation
+history at the evaluator level — reusing the same evaluator ID across runs
+causes the platform to report "already evaluated" for spans processed in
+prior runs, making the trigger return ``cancelled``.  The date-stamp
+guarantees a fresh evaluator each day.  ``if_exists="skip"`` still handles
+same-day retries correctly.
+
+Flow::
+
+    check_ai_integration          (ShortCircuitOperator — skip if no AI integration)
+            │
+            ▼
+    list_projects                 (ArizeAxListProjectsOperator — auto-discover)
+            │
+            ▼
+    pick_project                  (ShortCircuitOperator — pick first; skip if none)
+            │
+            ▼
+    build_template_config         (PythonOperator — build LLM-judge template)
+            │
+            ▼
+    create_evaluator              (ArizeAxCreateEvaluatorOperator, if_exists="skip")
+            │
+            ▼
+    create_task                   (PythonOperator — link evaluator + project)
+            │
+            ▼
+    trigger_run                   (ArizeAxTriggerTaskRunOperator — returns scalar run_id)
+            │
+            ▼
+    wait_for_run                  (ArizeAxTaskRunSensor, mode="reschedule")
+            │
+            ▼
+    get_run_result                (ArizeAxGetTaskRunOperator)
+            │
+            ▼
+    gate_on_score                 (PythonOperator — raise on score < threshold)
+            │
+            ▼
+    cleanup_evaluator             (ArizeAxDeleteEvaluatorOperator, trigger_rule="all_done")
+
+Requires:
+- Airflow connection ``arize_ax_default`` with a valid API key.
+- Either the Airflow Variable ``arize_ax_space_id`` **or** a ``default_space``
+  field on the ``arize_ax_default`` connection extras.
+- ``ARIZE_AI_INTEGRATION_ID`` in the **worker environment** (Docker/Kubernetes)
+  **or** as an Airflow **Variable** (Admin → Variables).  This is the Arize
+  AI Integration ID for the LLM used by the judge (e.g. OpenAI gpt-4o-mini).
+  If neither is set, ``check_ai_integration`` short-circuits cleanly and the
+  entire DAG is skipped.
+- At least one project must exist in the space.  If none exist,
+  ``pick_project`` short-circuits cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+from airflow.models import Variable
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+from airflow.providers.arize_ax.operators.evaluators import (
+    ArizeAxCreateEvaluatorOperator,
+    ArizeAxDeleteEvaluatorOperator,
+)
+from airflow.providers.arize_ax.operators.projects import ArizeAxListProjectsOperator
+from airflow.providers.arize_ax.operators.tasks import (
+    ArizeAxGetTaskRunOperator,
+    ArizeAxTriggerTaskRunOperator,
+)
+from airflow.providers.arize_ax.sensors.arize_ax import ArizeAxTaskRunSensor
+
+# Optional Airflow Variable ``arize_ax_project_name`` targets a specific
+# project by name (e.g. "langraph-financial-agent-trace"); falls back to the
+# first project returned by the API when unset. Read at task-execution time
+# inside callables to avoid parse-time Variable lookups.
+
+_SPACE_JINJA = "{{ var.value.get('arize_ax_space_id', '') or None }}"
+
+_EVALUATOR_NAME = "arize-ax-tasks-e2e-demo"
+_SCORE_THRESHOLD = 0.7
+
+# Evaluate only LLM spans (ChatOpenAI, etc.) — excludes CHAIN, TOOL, RETRIEVER.
+_QUERY_FILTER = "\"attributes.openinference.span.kind\" = 'LLM'"
+
+
+
+def _get_ai_integration_id() -> str:
+    """Worker env ``ARIZE_AI_INTEGRATION_ID`` wins; else Airflow Variable of same key."""
+    v = os.environ.get("ARIZE_AI_INTEGRATION_ID", "").strip()
+    if v:
+        return v
+    return Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
+
+
+def _check_ai_integration() -> bool:
+    """Short-circuit when ARIZE_AI_INTEGRATION_ID is not configured."""
+    configured = bool(_get_ai_integration_id())
+    if not configured:
+        print(
+            "ARIZE_AI_INTEGRATION_ID is not set in worker env or Airflow Variables — "
+            "skipping tasks e2e demo.  Set it to your Arize AI Integration ID to enable."
+        )
+    return configured
+
+
+def _pick_project(**ctx) -> str | None:
+    """Return the project ID to use for evaluation.
+
+    If ``arize_ax_project_name`` Variable is set, find the project with that
+    name.  Falls back to the first project returned by the API.
+    Short-circuits if no projects exist in the space.
+    """
+    items = ctx["ti"].xcom_pull(task_ids="list_projects") or {}
+    projects = items.get("items", []) if isinstance(items, dict) else []
+    if not projects:
+        print(
+            "No projects found in space — cannot create an evaluation task without a project. "
+            "Create at least one project in Arize AX and re-run."
+        )
+        return None
+
+    target_name = Variable.get("arize_ax_project_name", default_var=None)
+    if target_name:
+        for p in projects:
+            if isinstance(p, dict) and p.get("name") == target_name:
+                project_id = str(p["id"])
+                print(f"[pick_project] Matched target project name={target_name!r}, id={project_id!r}")
+                return project_id
+        print(
+            f"[pick_project] Project {target_name!r} not found in page of {len(projects)} results — "
+            "falling back to first available project."
+        )
+
+    project = projects[0]
+    project_id = project.get("id") if isinstance(project, dict) else str(project)
+    name = project.get("name", "?") if isinstance(project, dict) else "?"
+    print(f"[pick_project] Using project id={project_id!r}, name={name!r}")
+    return project_id
+
+
+def _build_template_config(**_ctx) -> dict[str, Any]:
+    """Build the LLM-judge template_config for ArizeAxCreateEvaluatorOperator."""
+    integration_id = _get_ai_integration_id()
+    return {
+        "template_config": {
+            "name": "relevance",
+            # The Arize Evaluator API uses short aliases {input} and {output}
+            # which it maps to the OpenInference attributes input.value /
+            # output.value internally.  Do NOT use {input.value} or {output.value}
+            # directly — the API rejects them with "Invalid column".
+            "template": (
+                "You are an LLM judge evaluating response relevance.\n\n"
+                "Query: {input}\n"
+                "Response: {output}\n\n"
+                "Is the response relevant to the query?\n"
+                "Respond with exactly one word: relevant or irrelevant"
+            ),
+            "include_explanations": True,
+            "use_function_calling_if_available": False,
+            "classification_choices": {"irrelevant": 0, "relevant": 1},
+            "llm_config": {
+                "ai_integration_id": integration_id,
+                "model_name": "gpt-4o-mini",
+                "invocation_parameters": {"temperature": 0},
+                "provider_parameters": {},
+            },
+        }
+    }
+
+
+def _create_task(**ctx) -> str:
+    """Create (or reuse) an evaluation task and return its ID.
+
+    Pulls the evaluator ID (from create_evaluator XCom) and the project ID
+    (from pick_project XCom).
+
+    Tasks cannot be deleted via the SDK, so orphaned tasks from previous runs
+    accumulate.  To avoid creating a new task on same-day retries, scan for an
+    existing task named _EVALUATOR_NAME that already has the current evaluator
+    linked → reuse it.  Because the evaluator name is date-stamped, the
+    evaluator_id is always fresh across daily runs, so a new task is created
+    each day while retries within the same day reuse the existing one.
+
+    ``column_mappings`` explicitly binds ``{input}`` / ``{output}`` in the
+    evaluator template to the OpenInference attribute paths so the API always
+    resolves the placeholders correctly regardless of span kind.
+    """
+    from airflow.providers.arize_ax.hooks.arize_ax import ArizeAxHook
+
+    ti = ctx["ti"]
+    evaluator_id = str(ti.xcom_pull(task_ids="create_evaluator") or "")
+    project_id = str(ti.xcom_pull(task_ids="pick_project") or "")
+
+    if not evaluator_id:
+        raise ValueError("[create_task] evaluator_id not found in create_evaluator XCom.")
+    if not project_id:
+        raise ValueError("[create_task] project_id not found in pick_project XCom.")
+
+    hook = ArizeAxHook()
+
+    # column_mappings: explicitly map template placeholders to OpenInference
+    # attribute column paths so {input}/{output} always resolve, even when the
+    # API cannot auto-resolve the short aliases.
+    evaluator_entry = {
+        "evaluator_id": evaluator_id,
+        "column_mappings": {
+            "input": "attributes.input.value",
+            "output": "attributes.output.value",
+        },
+    }
+
+    # Reuse an existing task that has this evaluator already linked
+    # (handles same-day retries without creating duplicate tasks).
+    existing = hook.list_tasks(
+        space_id=Variable.get("arize_ax_space_id", default_var=None),
+        limit=50,
+    )
+    for t in (existing.get("items", []) if isinstance(existing, dict) else []):
+        if not isinstance(t, dict) or t.get("name") != _EVALUATOR_NAME:
+            continue
+        linked = [
+            e.get("evaluator_id") or e.get("id")
+            for e in (t.get("evaluators") or [])
+            if isinstance(e, dict)
+        ]
+        if evaluator_id in linked:
+            task_id = str(t["id"])
+            print(f"[create_task] Reusing existing task id={task_id!r}")
+            return task_id
+
+    # No matching task found — create a fresh one scoped to LLM spans.
+    result = hook.create_task(
+        name=_EVALUATOR_NAME,
+        task_type="template_evaluation",
+        evaluators=[evaluator_entry],
+        project_id=project_id,
+        is_continuous=False,
+        query_filter=_QUERY_FILTER,
+    )
+    task_id = None
+    if isinstance(result, dict):
+        task_id = result.get("id") or result.get("task_id")
+    if not task_id:
+        raise ValueError(f"[create_task] Could not extract task ID from result: {result!r}")
+    print(f"[create_task] Created task id={task_id!r}")
+    return task_id
+
+
+def _gate_on_score(**ctx) -> None:
+    """Log eval scores and raise if the average falls below the threshold."""
+    from airflow.exceptions import AirflowException
+
+    run = ctx["ti"].xcom_pull(task_ids="get_run_result") or {}
+    if not isinstance(run, dict):
+        print(f"[gate_on_score] Unexpected run result type: {type(run).__name__!r} — passing gate.")
+        return
+
+    run_id = run.get("id", "unknown")
+    run_status = run.get("status", "unknown")
+
+    # Evaluation results may be nested differently across SDK versions
+    evals = run.get("evaluations") or run.get("evals") or run.get("evaluation_results") or {}
+    scores: list[float] = []
+
+    def _collect(obj: Any) -> None:
+        if isinstance(obj, dict):
+            score = obj.get("score")
+            if score is not None:
+                try:
+                    scores.append(float(score))
+                except (TypeError, ValueError):
+                    pass
+            for v in obj.values():
+                _collect(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                _collect(item)
+
+    _collect(evals)
+
+    if not scores:
+        print(
+            f"[gate_on_score] Run {run_id!r} (status={run_status!r}) — "
+            "no numeric scores found in eval results. Passing gate."
+        )
+        return
+
+    avg = sum(scores) / len(scores)
+    print(
+        f"[gate_on_score] Run {run_id!r} — avg score={avg:.4f} "
+        f"across {len(scores)} evaluator(s) (threshold={_SCORE_THRESHOLD})."
+    )
+
+    if avg < _SCORE_THRESHOLD:
+        raise AirflowException(
+            f"Eval gate FAILED: avg score {avg:.4f} < threshold {_SCORE_THRESHOLD}. "
+            "Block deployment until evaluators pass."
+        )
+    print("[gate_on_score] Eval gate PASSED — safe to deploy.")
+
+
+
+with DAG(
+    dag_id="example_arize_ax_tasks",
+    start_date=datetime(2025, 1, 1),
+    schedule="@daily",
+    tags=["arize_ax", "example", "tasks"],
+    catchup=False,
+    doc_md=__doc__,
+) as dag:
+
+    # 1. Gate: require ARIZE_AI_INTEGRATION_ID
+    check_ai_integration = ShortCircuitOperator(
+        task_id="check_ai_integration",
+        python_callable=_check_ai_integration,
+    )
+
+    # 2. Auto-discover projects in the space — fetch up to 50 so name-based
+    # lookup (arize_ax_project_name Variable) finds projects beyond position 5.
+    list_projects = ArizeAxListProjectsOperator(
+        task_id="list_projects",
+        space_id=_SPACE_JINJA,
+        limit=50,
+    )
+
+    # 3. Pick first project; skip rest if none found
+    pick_project = ShortCircuitOperator(
+        task_id="pick_project",
+        python_callable=_pick_project,
+    )
+
+    # 4. Build the LLM-judge template config at runtime
+    build_template_config = PythonOperator(
+        task_id="build_template_config",
+        python_callable=_build_template_config,
+    )
+
+    # 5. Create (or reuse) the demo evaluator in Eval Hub.
+    # Name is date-stamped so each daily run gets a fresh evaluator ID with no
+    # prior evaluation history.  Arize deduplicates at the evaluator level, so
+    # reusing the same ID would cause "already evaluated" cancellations on re-runs.
+    # if_exists="skip" handles same-day retries (same logical date → same name →
+    # resolves the existing evaluator instead of creating a duplicate).
+    create_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_evaluator",
+        space_id=_SPACE_JINJA,
+        name=_EVALUATOR_NAME + "-{{ ds_nodash }}",
+        commit_message="arize-ax-tasks-e2e-demo v1",
+        description="Auto-created by example_arize_ax_tasks DAG — safe to delete.",
+        template_config_task_id="build_template_config",
+        template_config_key="template_config",
+        if_exists="skip",
+    )
+
+    # 6. Create the evaluation task linking evaluator + auto-discovered project
+    create_task = PythonOperator(
+        task_id="create_task",
+        python_callable=_create_task,
+    )
+
+    # 7. Trigger an on-demand run.  override_evaluations=True forces re-evaluation
+    # of spans that already have labels from prior runs — without this, the platform
+    # cancels the run with "already evaluated" if any previous task/evaluator has
+    # scored the same spans.  The operator returns a scalar run_id string via XCom.
+    trigger_run = ArizeAxTriggerTaskRunOperator(
+        task_id="trigger_run",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_task') }}",
+        space_id=_SPACE_JINJA,
+        override_evaluations=True,
+    )
+
+    # 8. Wait for the run to reach a terminal state (reschedule to free the worker slot)
+    wait_for_run = ArizeAxTaskRunSensor(
+        task_id="wait_for_run",
+        run_id="{{ ti.xcom_pull(task_ids='trigger_run') }}",
+        poke_interval=30,
+        timeout=1800,
+        mode="reschedule",
+        fail_on_error=True,
+    )
+
+    # 9. Fetch the completed run result (scores, labels, metadata)
+    get_run_result = ArizeAxGetTaskRunOperator(
+        task_id="get_run_result",
+        run_id="{{ ti.xcom_pull(task_ids='trigger_run') }}",
+    )
+
+    # 10. Gate deployment decision on eval scores
+    gate_on_score = PythonOperator(
+        task_id="gate_on_score",
+        python_callable=_gate_on_score,
+    )
+
+    # 11. Clean up demo evaluator regardless of outcome
+    cleanup_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_evaluator') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+
+    (
+        check_ai_integration
+        >> list_projects
+        >> pick_project
+        >> build_template_config
+        >> create_evaluator
+        >> create_task
+        >> trigger_run
+        >> wait_for_run
+        >> get_run_result
+        >> gate_on_score
+        >> cleanup_evaluator
+    )


### PR DESCRIPTION
## Summary
- Add 19 example DAGs under `python/cookbooks/airflow_example_dags/` demonstrating the `airflow.providers.arize_ax` operators.
- Covers datasets, experiments, prompts (lifecycle / A-B / optimization), evaluators, annotation queues, drift detection, RAG evaluation, fine-tune data pipelines, behavioral regression, LLM CI/CD gates, and span ingestion.
- All DAGs share a consistent connection (`arize_ax_default`) and Airflow Variable scheme (`arize_ax_*`); cleanup tasks use `trigger_rule="all_done"` so demo resources are removed even when upstream tasks fail.

## Test plan
- [ ] `python -c "import ast; ast.parse(open(f).read())"` passes for all 19 files
- [ ] Install `airflow.providers.arize_ax` in a local Airflow environment and confirm each DAG appears in the UI without import errors
- [ ] Configure `arize_ax_default` connection + required Variables (`arize_ax_space_id`, `arize_annotator_email`, etc.) and trigger each DAG end-to-end
- [ ] Verify cleanup tasks run and remove demo resources (datasets, prompts, annotation queues) in the Arize AX UI