### PR TITLE
Add e2e + self-optimizing-loop DAGs, simplify Airflow 3 imports

### DIFF
--- a/python/cookbooks/airflow_example_dags/README.md
+++ b/python/cookbooks/airflow_example_dags/README.md
@@ -1,10 +1,10 @@
 # Arize AX Airflow Example DAGs
 
-A collection of 19 example DAGs demonstrating the [`arize-ax-airflow-provider`](https://github.com/Arize-ai/arize-ax-airflow) — the official Apache Airflow provider for [Arize AX](https://arize.com/docs/ax/).
+A collection of 21 example DAGs demonstrating the [`arize-ax-airflow-provider`](https://github.com/Arize-ai/arize-ax-airflow) — the official Apache Airflow provider for [Arize AX](https://arize.com/docs/ax/).
 
-Each DAG illustrates a real LLMOps workflow you can adapt for your own pipelines: CI/CD evaluation gates, prompt lifecycle management, drift detection with auto-rollback, RAG evaluation, dataset curation from production traces, fine-tuning data pipelines, behavioral regression checks, evaluator calibration, and more.
+Each DAG illustrates a real LLMOps workflow you can adapt for your own pipelines: CI/CD evaluation gates, prompt lifecycle management, drift detection with auto-rollback, RAG evaluation, dataset curation from production traces, fine-tuning data pipelines, behavioral regression checks, evaluator calibration, self-optimizing prompt loops, and more.
 
-> **Last Updated:** 2026-05-15
+> **Last Updated:** 2026-05-18
 
 ---
 
@@ -22,15 +22,19 @@ Each DAG illustrates a real LLMOps workflow you can adapt for your own pipelines
 pip install arize-ax-airflow-provider
 ```
 
-Some DAGs need optional extras:
+Some DAGs need extra packages on the worker:
 
-| DAG | Extra | Why |
-|-----|-------|-----|
-| `example_arize_ax_prompt_optimization_with_feedback_dag.py` | `prompt_learning` | Uses the Prompt Learning SDK for meta-prompt optimization |
-| `example_arize_ax_admin_dag.py` (prompt tasks) | `PromptHub` | Requires the Arize `[PromptHub]` extra |
+| DAG | What to install | Why |
+|-----|-----------------|-----|
+| `example_arize_ax_prompt_optimization_with_feedback_dag.py`, `example_arize_ax_self_optimizing_loop_dag.py` | `prompt-learning-enhanced` (from git) + `arize-phoenix-evals<3.0` | Prompt Learning SDK for meta-prompt optimization; installed directly from git because PyPI rejects direct-URL deps |
+| `example_arize_ax_admin_dag.py` (prompt tasks) | `arize[PromptHub]` | Requires the Arize `[PromptHub]` extra |
 
 ```bash
-pip install 'arize-ax-airflow-provider[prompt_learning]'
+# Prompt Learning SDK (used by prompt_optimization_with_feedback and self_optimizing_loop)
+pip install 'arize-phoenix-evals>=2.0,<3.0' \
+            'prompt-learning-enhanced @ git+https://github.com/Arize-ai/prompt-learning.git'
+
+# PromptHub extra (used by admin DAG prompt tasks)
 pip install 'arize[PromptHub]'
 ```
 
@@ -82,10 +86,16 @@ The DAGs read configuration from Airflow Variables so you can run them without e
 | `drift_detection_dag` | `arize_ax_baseline_experiment_id` | ✅ | Baseline experiment for drift comparison |
 | `drift_detection_dag` | `arize_ax_candidate_experiment_id` | ✅ | Candidate experiment for drift comparison |
 | `llm_cicd_gate_dag` | `arize_ax_baseline_experiment_id` | ✅ | Baseline to gate releases against |
+| `llm_cicd_gate_dag` | `arize_ax_prompt_name` | optional | Prompt to promote on gate-pass; unset = gate-only mode (no promotion) |
+| `llm_cicd_gate_dag` | `arize_ax_prompt_label` | optional | Label applied to the promoted prompt version (default: `production`) |
 | `prompt_lifecycle_dag` | `arize_ax_prompt_name` | ✅ | Prompt to promote staging → production |
 | `prompt_ab_test_dag` | `arize_ax_prompt_names` | optional | JSON list or CSV of prompt names to compare |
 | `prompt_optimization_with_feedback_dag` | `arize_ax_lookback_days` | optional | Days of production feedback to learn from |
 | `tasks_dag` / `evaluators_dag` | `ARIZE_AI_INTEGRATION_ID`, `ARIZE_EVALUATOR_MODEL` | ✅ | OpenAI/Anthropic integration UUID + model name for LLM-as-judge |
+| `e2e_dag` | `arize_ai_integration_id` | optional | Enables LLM evaluator + task lifecycle phases (skipped when unset) |
+| `e2e_dag` | `arize_annotator_email` | optional | Enables the annotation-queue lifecycle phase |
+| `self_optimizing_loop_dag` | `arize_ax_self_optimizing_model` | optional | OpenAI model used by experiment tasks (default `gpt-4o-mini`) |
+| `self_optimizing_loop_dag` | `arize_ax_self_optimizing_cleanup` | optional | Set to `"true"` to delete the demo dataset on DAG completion (default `"false"`) |
 
 The required values are documented in each DAG's module docstring — open the file and check the `**Required**` / `**Optional Airflow Variables**` sections.
 
@@ -105,7 +115,7 @@ Or symlink the directory so updates propagate:
 ln -s "$(pwd)/python/cookbooks/airflow_example_dags" $AIRFLOW_HOME/dags/arize_ax_examples
 ```
 
-Refresh the Airflow UI — all 19 DAGs should appear under the `arize_ax` tag.
+Refresh the Airflow UI — all 21 DAGs should appear under the `arize_ax` tag.
 
 ---
 
@@ -138,6 +148,8 @@ From there, work up to the workflow that matches your use case. The table below 
 | Human-in-the-loop annotation queues | `example_arize_ax_annotation_queues_dag.py` |
 | Multi-model experiment matrix | `example_arize_ax_llm_experiments_dag.py` |
 | Self-learning prompt optimization | `example_arize_ax_prompt_optimization_with_feedback_dag.py` |
+| Self-optimizing prompt loop (baseline → optimize → gate → promote) | `example_arize_ax_self_optimizing_loop_dag.py` |
+| End-to-end provider smoke test (~70 operators, 7 sensors) | `example_arize_ax_e2e_dag.py` |
 | Inventory / admin (list spaces, projects) | `example_arize_ax_admin_dag.py` |
 | Span export & metrics | `example_arize_ax_spans_dag.py` |
 | Custom evaluator creation | `example_arize_ax_evaluators_dag.py` |

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_annotation_queues_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_annotation_queues_dag.py
@@ -51,16 +51,8 @@ from airflow.providers.arize_ax.operators.annotations import (
     ArizeAxListAnnotationQueueRecordsOperator,
     ArizeAxListAnnotationQueuesOperator,
 )
-
-try:
-    from airflow.providers.standard.operators.python import PythonOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator
-
-try:
-    from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
-except ImportError:
-    from airflow.sensors.time_delta import TimeDeltaSensor
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
 
 log = logging.getLogger(__name__)
 

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_behavioral_regression_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_behavioral_regression_dag.py
@@ -33,22 +33,6 @@ from typing import Any
 
 from airflow import DAG
 from airflow.models import Variable
-
-try:
-    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator, ShortCircuitOperator
-
-try:
-    from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
-except ImportError:
-    from airflow.sensors.time_delta import TimeDeltaSensor
-
-try:
-    from airflow.task.trigger_rule import TriggerRule
-except ImportError:
-    from airflow.utils.trigger_rule import TriggerRule
-
 from airflow.providers.arize_ax.operators.datasets import (
     ArizeAxCreateDatasetOperator,
     ArizeAxDeleteDatasetOperator,
@@ -63,6 +47,9 @@ from airflow.providers.arize_ax.operators.tasks import (
     ArizeAxTriggerTaskRunOperator,
 )
 from airflow.providers.arize_ax.sensors.arize_ax import ArizeAxTaskRunSensor
+from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
+from airflow.task.trigger_rule import TriggerRule
 
 _SPACE_ID = "{{ var.value.get('arize_ax_space_id', '') or None }}"
 

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_dataset_curation_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_dataset_curation_dag.py
@@ -33,18 +33,13 @@ from datetime import datetime
 from typing import Any
 
 from airflow import DAG
-
-try:
-    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator, ShortCircuitOperator
-
 from airflow.providers.arize_ax.operators.datasets import (
     ArizeAxListDatasetExamplesOperator,
 )
 from airflow.providers.arize_ax.operators.spans import (
     ArizeAxCurateSpansToDatasetOperator,
 )
+from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 
 
 def _check_curated(**ctx) -> bool:

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_drift_detection_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_drift_detection_dag.py
@@ -56,17 +56,6 @@ from typing import Any
 
 from airflow import DAG
 from airflow.models import Variable
-
-try:
-    from airflow.task.trigger_rule import TriggerRule
-except ImportError:
-    from airflow.utils.trigger_rule import TriggerRule
-
-try:
-    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator, ShortCircuitOperator
-
 from airflow.providers.arize_ax.operators.experiments import (
     ArizeAxDetectEvalDriftOperator,
     ArizeAxRunExperimentOperator,
@@ -77,6 +66,8 @@ from airflow.providers.arize_ax.operators.prompts import (
 from airflow.providers.arize_ax.sensors.arize_ax import (
     ArizeAxExperimentRunCountSensor,
 )
+from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+from airflow.task.trigger_rule import TriggerRule
 
 # ---------------------------------------------------------------------------
 # Constants — adjust to your environment

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_e2e_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_e2e_dag.py
@@ -1,0 +1,1386 @@
+"""
+End-to-end test DAG: exercises every Arize AX operator and sensor that can be
+exercised in a single self-contained run.
+
+Each DAG run creates its own isolated resources using ``{{ ts_nodash }}`` as a
+unique suffix, so consecutive runs never collide. All create operators use
+``if_exists="skip"`` so retries within the same run are safe.
+
+After verification, a configurable inspection window (default 15 minutes)
+pauses the DAG so you can inspect resources on the Arize dashboard.
+Set ``INSPECTION_WINDOW_MINUTES = 0`` to skip the pause for CI runs.
+
+Cleanup tasks at the end remove every resource created during the run. They
+use ``trigger_rule="all_done"`` so cleanup always runs, even on partial failure.
+
+Optional Airflow Variables (phases that depend on them short-circuit cleanly):
+  - ``arize_ai_integration_id``: enables Phase 5 (LLM evaluator lifecycle),
+    Phase 6's comparison sub-phase, and Phase 7 (tasks lifecycle). These
+    phases need a real (working) AI integration since the evaluator/task
+    issues live LLM calls. The dummy integration created in Phase 2 is for
+    CRUD coverage only.
+  - ``arize_annotator_email``: enables Phase 8's annotation-queue sub-phase.
+    Without it the annotation-config CRUD still runs.
+
+Operators exercised (~70):
+  Discovery (9): ListSpaces, ListAIIntegrations, ListProjects, ListDatasets,
+    ListEvaluators, ListTasks, ListAnnotationConfigs, ListAnnotationQueues,
+    ListAPIKeys
+  AI Integration CRUD (4): CreateAIIntegration (dummy), GetAIIntegration,
+    UpdateAIIntegration, DeleteAIIntegration
+  API Key CRUD (3): CreateAPIKey, RefreshAPIKey, DeleteAPIKey
+  Datasets (10): CreateDataset, GetDataset, AppendDatasetExamples,
+    ListDatasetExamples, ExportDatasetExamplesToFile, EvalDatasetHealth,
+    SmartDatasetRefresh, AnnotateDatasetExamples, DeleteDataset, GetProject
+  Evaluators (LLM, gated, 7): CreateEvaluator, GetEvaluator, UpdateEvaluator,
+    AddEvaluatorVersion, ListEvaluatorVersions, GetEvaluatorVersion,
+    DeleteEvaluator
+  Experiments (12): RunExperiment, GetExperiment, ListExperiments,
+    ListExperimentRuns, GetExperimentScore, CompareExperiments,
+    DetectEvalDrift, EvaluatorCalibration (LLM-gated), BehavioralRegression,
+    EvalBudgetAllocator, ExportExperimentRunsToFile, AnnotateExperimentRuns,
+    DeleteExperiment
+  Tasks (LLM, gated, 9): CreateTask, GetTask, ListTaskRuns,
+    TriggerTaskRun, GetTaskRun, CancelTaskRun, UpdateTask, DeleteTask,
+    CreateRunExperimentTask
+  Annotations (11): CreateAnnotationConfig, DeleteAnnotationConfig,
+    CreateAnnotationQueue (gated), GetAnnotationQueue, UpdateAnnotationQueue,
+    AddAnnotationQueueRecords, ListAnnotationQueueRecords, AnnotateQueueRecord,
+    AssignQueueRecord, DeleteAnnotationQueueRecords, DeleteAnnotationQueue
+  Prompts (6): CreatePrompt, GetPrompt, ListPrompts, ComparePrompts (gated),
+    PromotePrompt, DeletePrompt
+  Spans (1, alpha): ListSpans
+
+Sensors exercised (7):
+  DatasetReadySensor, ExperimentCompleteSensor, ExperimentRunCountSensor,
+  EvaluationScoreSensor, SpanCountSensor, SpanIngestionSensor,
+  AnnotationQueueSensor, TaskRunSensor (gated)
+
+Not covered (need real production span/ML state or admin-level mutations):
+  Span log/update/export operators (need OpenInference DataFrames with platform
+    schema and real span IDs),
+  Span curation/export/metrics/adaptive sampling (need a project with real
+    production spans),
+  ML log/export operators (need ML DataFrames + schemas),
+  Spaces Create/Update/Delete (would mutate Arize tenancy — admin only;
+    ListSpaces/GetSpace are exercised),
+  CreateExperimentOperator (its experiment_runs param needs runtime
+    example IDs; RunExperiment covers the equivalent end-to-end path).
+
+Requires:
+  - Airflow connection ``arize_ax_default`` with a valid API key.
+  - Connection extra must include ``space_id``.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta
+from typing import Any
+
+from airflow import DAG
+from airflow.providers.arize_ax.operators.ai_integrations import (
+    ArizeAxCreateAIIntegrationOperator,
+    ArizeAxDeleteAIIntegrationOperator,
+    ArizeAxGetAIIntegrationOperator,
+    ArizeAxListAIIntegrationsOperator,
+    ArizeAxUpdateAIIntegrationOperator,
+)
+from airflow.providers.arize_ax.operators.annotations import (
+    ArizeAxAddAnnotationQueueRecordsOperator,
+    ArizeAxAnnotateQueueRecordOperator,
+    ArizeAxAssignQueueRecordOperator,
+    ArizeAxCreateAnnotationConfigOperator,
+    ArizeAxCreateAnnotationQueueOperator,
+    ArizeAxDeleteAnnotationConfigOperator,
+    ArizeAxDeleteAnnotationQueueOperator,
+    ArizeAxDeleteAnnotationQueueRecordsOperator,
+    ArizeAxGetAnnotationQueueOperator,
+    ArizeAxListAnnotationConfigsOperator,
+    ArizeAxListAnnotationQueueRecordsOperator,
+    ArizeAxListAnnotationQueuesOperator,
+    ArizeAxUpdateAnnotationQueueOperator,
+)
+from airflow.providers.arize_ax.operators.api_keys import (
+    ArizeAxCreateAPIKeyOperator,
+    ArizeAxDeleteAPIKeyOperator,
+    ArizeAxListAPIKeysOperator,
+    ArizeAxRefreshAPIKeyOperator,
+)
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxAnnotateDatasetExamplesOperator,
+    ArizeAxAppendDatasetExamplesOperator,
+    ArizeAxCreateDatasetOperator,
+    ArizeAxDeleteDatasetOperator,
+    ArizeAxEvalDatasetHealthOperator,
+    ArizeAxExportDatasetExamplesToFileOperator,
+    ArizeAxGetDatasetOperator,
+    ArizeAxListDatasetExamplesOperator,
+    ArizeAxListDatasetsOperator,
+    ArizeAxSmartDatasetRefreshOperator,
+)
+from airflow.providers.arize_ax.operators.evaluators import (
+    ArizeAxAddEvaluatorVersionOperator,
+    ArizeAxCreateEvaluatorOperator,
+    ArizeAxDeleteEvaluatorOperator,
+    ArizeAxGetEvaluatorOperator,
+    ArizeAxGetEvaluatorVersionOperator,
+    ArizeAxListEvaluatorsOperator,
+    ArizeAxListEvaluatorVersionsOperator,
+    ArizeAxUpdateEvaluatorOperator,
+)
+from airflow.providers.arize_ax.operators.experiments import (
+    ArizeAxAnnotateExperimentRunsOperator,
+    ArizeAxBehavioralRegressionOperator,
+    ArizeAxCompareExperimentsOperator,
+    ArizeAxDeleteExperimentOperator,
+    ArizeAxDetectEvalDriftOperator,
+    ArizeAxEvalBudgetAllocatorOperator,
+    ArizeAxEvaluatorCalibrationOperator,
+    ArizeAxExportExperimentRunsToFileOperator,
+    ArizeAxGetExperimentOperator,
+    ArizeAxGetExperimentScoreOperator,
+    ArizeAxListExperimentRunsOperator,
+    ArizeAxListExperimentsOperator,
+    ArizeAxRunExperimentOperator,
+)
+from airflow.providers.arize_ax.operators.projects import (
+    ArizeAxCreateProjectOperator,
+    ArizeAxDeleteProjectOperator,
+    ArizeAxGetProjectOperator,
+    ArizeAxListProjectsOperator,
+)
+from airflow.providers.arize_ax.operators.prompts import (
+    ArizeAxComparePromptsOperator,
+    ArizeAxCreatePromptOperator,
+    ArizeAxDeletePromptOperator,
+    ArizeAxGetPromptOperator,
+    ArizeAxListPromptsOperator,
+    ArizeAxPromotePromptOperator,
+)
+from airflow.providers.arize_ax.operators.spaces import (
+    ArizeAxListSpacesOperator,
+)
+from airflow.providers.arize_ax.operators.spans import (
+    ArizeAxListSpansOperator,
+)
+from airflow.providers.arize_ax.operators.tasks import (
+    ArizeAxCancelTaskRunOperator,
+    ArizeAxCreateRunExperimentTaskOperator,
+    ArizeAxCreateTaskOperator,
+    ArizeAxDeleteTaskOperator,
+    ArizeAxGetTaskOperator,
+    ArizeAxGetTaskRunOperator,
+    ArizeAxListTaskRunsOperator,
+    ArizeAxListTasksOperator,
+    ArizeAxTriggerTaskRunOperator,
+    ArizeAxUpdateTaskOperator,
+)
+from airflow.providers.arize_ax.sensors.arize_ax import (
+    ArizeAxAnnotationQueueSensor,
+    ArizeAxDatasetReadySensor,
+    ArizeAxEvaluationScoreSensor,
+    ArizeAxExperimentCompleteSensor,
+    ArizeAxExperimentRunCountSensor,
+    ArizeAxSpanCountSensor,
+    ArizeAxSpanIngestionSensor,
+    ArizeAxTaskRunSensor,
+)
+from airflow.providers.standard.operators.python import (
+    PythonOperator,
+    ShortCircuitOperator,
+)
+
+
+def _echo_task(dataset_row: dict) -> dict:
+    """Trivial task that echoes the expected output."""
+    return {"output": dataset_row.get("expected_output", "no-answer")}
+
+
+def _exact_match_evaluator(dataset_row: dict, output: dict):
+    """Evaluator: strict equality between output and expected answer."""
+    from arize.experiments import EvaluationResult
+
+    if output is None:
+        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
+    actual = output.get("output") if isinstance(output, dict) else str(output)
+    expected = dataset_row.get("expected_output", "")
+    match = actual == expected
+    return EvaluationResult(
+        score=1.0 if match else 0.0,
+        label="correct" if match else "incorrect",
+        explanation=f"expected={expected!r}, got={actual!r}",
+    )
+
+
+def _contains_answer_evaluator(dataset_row: dict, output: dict):
+    """Evaluator: lenient check -- expected answer appears within output."""
+    from arize.experiments import EvaluationResult
+
+    if output is None:
+        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
+    actual = output.get("output", "") if isinstance(output, dict) else str(output)
+    expected = dataset_row.get("expected_output", "")
+    found = expected.lower() in actual.lower()
+    return EvaluationResult(
+        score=1.0 if found else 0.0,
+        label="contains" if found else "missing",
+        explanation=f"looking for {expected!r} in {actual!r}",
+    )
+
+
+def _get_first_var(*names: str) -> str:
+    """Return the first non-empty Airflow Variable from *names* (case variants)."""
+    from airflow.models import Variable
+
+    for name in names:
+        try:
+            val = Variable.get(name, default_var="")
+        except Exception:
+            val = ""
+        if val and str(val).strip():
+            return str(val).strip()
+    return ""
+
+
+def _has_ai_integration_var(**_ctx) -> bool:
+    """Short-circuit predicate: True if the AI-integration Variable is set.
+
+    Accepts either ``arize_ai_integration_id`` (lowercase — preferred to match
+    the other ``arize_ax_*`` variables) or ``ARIZE_AI_INTEGRATION_ID``
+    (uppercase — matches the env-var name used by the system test suite).
+    """
+    val = _get_first_var("arize_ai_integration_id", "ARIZE_AI_INTEGRATION_ID")
+    if not val:
+        print(
+            "[gate] Neither 'arize_ai_integration_id' nor "
+            "'ARIZE_AI_INTEGRATION_ID' is set — downstream LLM phases "
+            "(evaluators, tasks, LLM-evaluator comparison) will be skipped."
+        )
+        return False
+    return True
+
+
+def _has_annotator_email_var(**_ctx) -> bool:
+    """Short-circuit predicate: True if the annotator-email Variable is set."""
+    val = _get_first_var("arize_annotator_email", "ARIZE_ANNOTATOR_EMAIL")
+    if not val:
+        print(
+            "[gate] Neither 'arize_annotator_email' nor "
+            "'ARIZE_ANNOTATOR_EMAIL' is set — annotation-queue sub-phase "
+            "will be skipped (config CRUD still runs)."
+        )
+        return False
+    return True
+
+
+def _make_xcom_present_gate(*, task_ids: str, key: str | None = None) -> Any:
+    """Return a callable that short-circuits when an upstream XCom is missing.
+
+    The Airflow caveat this guards against: when a task is skipped (e.g. by an
+    earlier ShortCircuit gate) its XCom is None. Downstream tasks with
+    ``trigger_rule="all_done"`` will still run, and Jinja renders None as the
+    literal string ``"None"``, which most Arize endpoints then reject with a
+    confusing 400 "Invalid ... ID format" or even 500. Use this guard between
+    upstream creates/lists and downstream consumers that must not run on
+    placeholder IDs.
+    """
+    def _gate(**ctx: Any) -> bool:
+        ti = ctx["ti"]
+        val = (
+            ti.xcom_pull(task_ids=task_ids, key=key)
+            if key is not None
+            else ti.xcom_pull(task_ids=task_ids)
+        )
+        if val is None:
+            print(
+                f"[gate] no XCom from task_ids={task_ids!r} key={key!r}; "
+                "skipping downstream consumers."
+            )
+            return False
+        if isinstance(val, str) and (not val or val.strip().lower() in {"none", ""}):
+            print(
+                f"[gate] XCom from {task_ids!r} resolved to placeholder "
+                f"{val!r}; skipping downstream consumers."
+            )
+            return False
+        return True
+    return _gate
+
+
+def _build_run_configuration(**ctx) -> Any:
+    """Build a ``RunConfiguration`` for CreateRunExperimentTask using the
+    configured AI-integration Airflow Variable. Pushed to XCom so the
+    downstream operator can pull it.
+    """
+    from arize.tasks.types import LlmGenerationRunConfig, RunConfiguration
+
+    integration_id = _get_first_var(
+        "arize_ai_integration_id", "ARIZE_AI_INTEGRATION_ID",
+    )
+    if not integration_id:
+        raise RuntimeError(
+            "AI-integration Variable required for this task "
+            "(set 'arize_ai_integration_id' or 'ARIZE_AI_INTEGRATION_ID')."
+        )
+    llm_cfg = LlmGenerationRunConfig(
+        experiment_type="llm_generation",
+        ai_integration_id=integration_id,
+        model_name="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Echo: {query}"}],
+        input_variable_format="f_string",
+        invocation_parameters={"temperature": 0},
+        provider_parameters={},
+    )
+    return RunConfiguration(llm_cfg).model_dump(mode="json")
+
+
+def _build_evaluator_template_config(**ctx) -> dict[str, Any]:
+    """Build a template-evaluator config using the configured AI integration."""
+    integration_id = _get_first_var(
+        "arize_ai_integration_id", "ARIZE_AI_INTEGRATION_ID",
+    )
+    if not integration_id:
+        raise RuntimeError(
+            "AI-integration Variable required for evaluator "
+            "(set 'arize_ai_integration_id' or 'ARIZE_AI_INTEGRATION_ID')."
+        )
+    suffix = (ctx.get("ts_nodash") or "x")[-8:]
+    return {
+        "name": f"e2e_eval_{suffix}",
+        "template": (
+            "Evaluate the response. Input: {input}\nOutput: {output}\n"
+            "Respond with JSON label correct or incorrect."
+        ),
+        "include_explanations": False,
+        "use_function_calling_if_available": False,
+        "classification_choices": {"incorrect": 0, "correct": 1},
+        "llm_config": {
+            "ai_integration_id": integration_id,
+            "model_name": "gpt-4o-mini",
+            "invocation_parameters": {"temperature": 0},
+            "provider_parameters": {},
+        },
+    }
+
+
+# Task IDs whose XCom values _verify_results checks. Exposed as a module-level
+# constant so unit tests can derive expected counts without hardcoding numbers.
+VERIFY_TASK_IDS: list[str] = [
+    # Phase 1 -- discovery
+    "list_spaces",
+    "list_ai_integrations",
+    "list_annotation_configs",
+    "list_annotation_queues",
+    "list_api_keys",
+    "list_evaluators",
+    "list_tasks",
+    # Phase 2-3 -- AI integration + API key CRUD
+    "create_ai_integration",
+    "get_ai_integration",
+    "create_api_key",
+    # Phase 4 -- project + dataset
+    "create_project",
+    "get_project",
+    "create_dataset",
+    "get_dataset",
+    "append_examples",
+    "list_dataset_examples",
+    "export_dataset_examples_to_file",
+    "eval_dataset_health",
+    # Phase 6 -- experiment + scoring
+    "run_experiment",
+    "get_experiment",
+    "list_experiment_runs",
+    "get_experiment_score",
+    "compare_experiments",
+    "detect_eval_drift",
+    "behavioral_regression",
+    "eval_budget_allocator",
+    "export_experiment_runs_to_file",
+    # Phase 8 -- annotations
+    "create_annotation_config",
+    # Phase 9 -- prompts
+    "create_prompt",
+    "get_prompt",
+    # Phase 10 -- spans
+    "list_spans",
+]
+
+
+def _verify_results(**ctx) -> dict[str, Any]:
+    """Summarise which tasks produced non-None XCom values."""
+    ti = ctx["ti"]
+    checks = {tid: ti.xcom_pull(task_ids=tid) is not None for tid in VERIFY_TASK_IDS}
+    passed = sum(checks.values())
+    return {"passed": passed, "total": len(checks), "checks": checks}
+
+
+def _inspection_pause(**ctx) -> None:
+    """Sleep for the configured number of minutes so the user can inspect
+    resources on the platform before cleanup deletes them."""
+    minutes = ctx["params"].get("inspection_minutes", INSPECTION_WINDOW_MINUTES)
+    minutes = max(int(minutes), 0)
+    if minutes == 0:
+        print("Inspection window is 0 minutes -- skipping pause.")
+        return
+    print(
+        f"Pausing {minutes} minutes for manual inspection. "
+        f"Resources will be cleaned up after this task completes."
+    )
+    time.sleep(minutes * 60)
+    print("Inspection window finished -- proceeding to cleanup.")
+
+
+INSPECTION_WINDOW_MINUTES = 15
+SPACE_ID = "{{ ti.xcom_pull(task_ids='list_spaces', key='first_id') }}"
+
+
+with DAG(
+    dag_id="arize_ax_e2e_full_provider_test",
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "e2e", "test"],
+    catchup=False,
+    doc_md=__doc__,
+    params={"inspection_minutes": INSPECTION_WINDOW_MINUTES},
+    # render_template_as_native_obj makes Jinja XCom pulls return native Python
+    # types (dict/list/etc.) instead of stringified versions. Required for
+    # operators that take dict params (e.g. CreateRunExperimentTask's
+    # run_configuration) where the dict is built by an upstream PythonOperator.
+    render_template_as_native_obj=True,
+    # Many tasks here hit alpha/beta Arize APIs that occasionally return
+    # transient backend errors (Flight internal errors on experiment init,
+    # 5xx blips, etc.). One retry with a short delay handles the bulk of those
+    # without burying real test signal under noise.
+    default_args={
+        "retries": 2,
+        "retry_delay": timedelta(seconds=15),
+    },
+) as dag:
+
+    # Phase 1 -- Discovery (read-only listings)
+    list_spaces = ArizeAxListSpacesOperator(task_id="list_spaces", limit=10)
+    list_ai_integrations = ArizeAxListAIIntegrationsOperator(
+        task_id="list_ai_integrations", space_id=SPACE_ID, limit=10,
+    )
+    list_annotation_configs = ArizeAxListAnnotationConfigsOperator(
+        task_id="list_annotation_configs", limit=10,
+    )
+    list_annotation_queues = ArizeAxListAnnotationQueuesOperator(
+        task_id="list_annotation_queues", space=SPACE_ID, limit=10,
+    )
+    list_api_keys = ArizeAxListAPIKeysOperator(
+        task_id="list_api_keys", limit=10,
+    )
+    list_evaluators = ArizeAxListEvaluatorsOperator(
+        task_id="list_evaluators", space_id=SPACE_ID, limit=10,
+    )
+    list_tasks = ArizeAxListTasksOperator(
+        task_id="list_tasks", space_id=SPACE_ID, limit=10,
+    )
+
+    # Phase 2 -- AI Integration CRUD (dummy key, fully self-contained)
+    create_ai_integration = ArizeAxCreateAIIntegrationOperator(
+        task_id="create_ai_integration",
+        space_id=SPACE_ID,
+        name="e2e-ai-integration-{{ ts_nodash }}",
+        # API expects exact SDK enum value casing: "openAI", not "openai".
+        provider="openAI",
+        api_key="sk-e2e-dummy-do-not-use",
+        # API rejects integrations with zero models; enable defaults so the
+        # integration is well-formed without hardcoding model names here.
+        enable_default_models=True,
+        if_exists="skip",
+    )
+    get_ai_integration = ArizeAxGetAIIntegrationOperator(
+        task_id="get_ai_integration",
+        integration_id="{{ ti.xcom_pull(task_ids='create_ai_integration') }}",
+    )
+    update_ai_integration = ArizeAxUpdateAIIntegrationOperator(
+        task_id="update_ai_integration",
+        integration_id="{{ ti.xcom_pull(task_ids='create_ai_integration') }}",
+        space_id=SPACE_ID,
+        api_key="sk-e2e-dummy-rotated",
+    )
+
+    # Phase 3 -- API Key CRUD
+    create_api_key = ArizeAxCreateAPIKeyOperator(
+        task_id="create_api_key",
+        name="e2e-api-key-{{ ts_nodash }}",
+        description="Created by arize_ax_e2e_full_provider_test DAG; safe to delete.",
+    )
+    refresh_api_key = ArizeAxRefreshAPIKeyOperator(
+        task_id="refresh_api_key",
+        api_key_id="{{ ti.xcom_pull(task_ids='create_api_key') }}",
+    )
+
+    # Phase 4 -- Project + dataset setup + enrichment
+    create_project = ArizeAxCreateProjectOperator(
+        task_id="create_project",
+        space_id=SPACE_ID,
+        name="e2e-proj-{{ ts_nodash }}",
+        if_exists="skip",
+    )
+    get_project = ArizeAxGetProjectOperator(
+        task_id="get_project",
+        project_id="{{ ti.xcom_pull(task_ids='create_project') }}",
+    )
+    list_projects = ArizeAxListProjectsOperator(
+        task_id="list_projects", space_id=SPACE_ID, limit=5,
+    )
+
+    create_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_dataset",
+        space_id=SPACE_ID,
+        name="e2e-ds-{{ ts_nodash }}",
+        examples=[
+            {"query": "What is 2+2?", "expected_output": "4"},
+            {"query": "Capital of France?", "expected_output": "Paris"},
+            {"query": "Largest planet?", "expected_output": "Jupiter"},
+        ],
+        if_exists="skip",
+    )
+    get_dataset = ArizeAxGetDatasetOperator(
+        task_id="get_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+    )
+    list_datasets = ArizeAxListDatasetsOperator(
+        task_id="list_datasets", space_id=SPACE_ID, limit=5,
+    )
+    append_examples = ArizeAxAppendDatasetExamplesOperator(
+        task_id="append_examples",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        examples=[
+            {"query": "Boiling point of water?", "expected_output": "100C"},
+            {"query": "Speed of light?", "expected_output": "299792458 m/s"},
+        ],
+    )
+    list_dataset_examples = ArizeAxListDatasetExamplesOperator(
+        task_id="list_dataset_examples",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        limit=50,
+    )
+    export_dataset_examples_to_file = ArizeAxExportDatasetExamplesToFileOperator(
+        task_id="export_dataset_examples_to_file",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        path="/tmp/arize_e2e_dataset_examples_{{ ts_nodash }}.json",
+    )
+    eval_dataset_health = ArizeAxEvalDatasetHealthOperator(
+        task_id="eval_dataset_health",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        project_id="{{ ti.xcom_pull(task_ids='create_project') }}",
+    )
+    smart_dataset_refresh = ArizeAxSmartDatasetRefreshOperator(
+        task_id="smart_dataset_refresh",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        project_id="{{ ti.xcom_pull(task_ids='create_project') }}",
+        max_new_examples=5,
+        # Project is fresh, no spans yet — the operator should no-op gracefully.
+    )
+
+    # Phase 4 sensors
+    dataset_ready = ArizeAxDatasetReadySensor(
+        task_id="dataset_ready_sensor",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        min_examples=1,
+        poke_interval=5,
+        timeout=60,
+        mode="poke",
+    )
+    span_count_sensor = ArizeAxSpanCountSensor(
+        task_id="span_count_sensor",
+        project_id="{{ ti.xcom_pull(task_ids='create_project') }}",
+        min_count=0,
+        poke_interval=5,
+        timeout=30,
+        mode="poke",
+        soft_fail=True,
+    )
+    span_ingestion_sensor = ArizeAxSpanIngestionSensor(
+        task_id="span_ingestion_sensor",
+        project_id="{{ ti.xcom_pull(task_ids='create_project') }}",
+        stable_for_pokes=1,
+        poke_interval=5,
+        timeout=30,
+        mode="poke",
+        soft_fail=True,
+    )
+
+    # Phase 5 -- Evaluator lifecycle (LLM, gated by arize_ai_integration_id)
+    gate_evaluator = ShortCircuitOperator(
+        task_id="gate_evaluator_phase",
+        python_callable=_has_ai_integration_var,
+        ignore_downstream_trigger_rules=False,
+    )
+    build_evaluator_config = PythonOperator(
+        task_id="build_evaluator_config",
+        python_callable=_build_evaluator_template_config,
+    )
+    create_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_evaluator",
+        space_id=SPACE_ID,
+        name="e2e-evaluator-{{ ts_nodash }}",
+        commit_message="e2e initial version",
+        template_config_task_id="build_evaluator_config",
+        description="Created by arize_ax_e2e_full_provider_test DAG; safe to delete.",
+        if_exists="skip",
+    )
+    get_evaluator = ArizeAxGetEvaluatorOperator(
+        task_id="get_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_evaluator') }}",
+    )
+    update_evaluator = ArizeAxUpdateEvaluatorOperator(
+        task_id="update_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_evaluator') }}",
+        description="patched by e2e DAG",
+    )
+    add_evaluator_version = ArizeAxAddEvaluatorVersionOperator(
+        task_id="add_evaluator_version",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_evaluator') }}",
+        commit_message="e2e second version",
+        template_config_task_id="build_evaluator_config",
+    )
+    list_evaluator_versions = ArizeAxListEvaluatorVersionsOperator(
+        task_id="list_evaluator_versions",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_evaluator') }}",
+        limit=10,
+    )
+    # Defensive: skip get_evaluator_version when the upstream list has no
+    # versions yet. Note: even with a valid first_id, the API has been observed
+    # to return 400 with an empty detail — that's an Arize bug to file
+    # separately; this gate just keeps the DAG green when the precondition
+    # genuinely isn't met.
+    gate_get_evaluator_version = ShortCircuitOperator(
+        task_id="gate_get_evaluator_version",
+        python_callable=_make_xcom_present_gate(
+            task_ids="list_evaluator_versions", key="first_id",
+        ),
+        ignore_downstream_trigger_rules=False,
+    )
+    get_evaluator_version = ArizeAxGetEvaluatorVersionOperator(
+        task_id="get_evaluator_version",
+        version_id="{{ ti.xcom_pull(task_ids='list_evaluator_versions', key='first_id') }}",
+    )
+
+    # Phase 6 -- Experiment lifecycle + scoring + comparison
+    run_experiment = ArizeAxRunExperimentOperator(
+        task_id="run_experiment",
+        name="e2e-run-{{ ts_nodash }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        task=_echo_task,
+        evaluators=[_exact_match_evaluator, _contains_answer_evaluator],
+        concurrency=2,
+    )
+    run_experiment_v2 = ArizeAxRunExperimentOperator(
+        task_id="run_experiment_v2",
+        name="e2e-run-v2-{{ ts_nodash }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        task=_echo_task,
+        evaluators=[_exact_match_evaluator, _contains_answer_evaluator],
+        concurrency=2,
+    )
+    experiment_complete = ArizeAxExperimentCompleteSensor(
+        task_id="experiment_complete_sensor",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+        poke_interval=5,
+        timeout=120,
+        mode="poke",
+    )
+    experiment_run_count_sensor = ArizeAxExperimentRunCountSensor(
+        task_id="experiment_run_count_sensor",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+        min_runs=1,
+        poke_interval=5,
+        timeout=60,
+        mode="poke",
+    )
+    evaluation_score_sensor = ArizeAxEvaluationScoreSensor(
+        task_id="evaluation_score_sensor",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+        # Arize records metric names from the evaluator function's __name__,
+        # so this must match `_exact_match_evaluator` exactly.
+        metric_name="_exact_match_evaluator",
+        min_score=0.0,
+        poke_interval=5,
+        timeout=60,
+        mode="poke",
+        soft_fail=True,
+    )
+    get_experiment = ArizeAxGetExperimentOperator(
+        task_id="get_experiment",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+    )
+    list_experiments = ArizeAxListExperimentsOperator(
+        task_id="list_experiments",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        limit=10,
+    )
+    list_experiment_runs = ArizeAxListExperimentRunsOperator(
+        task_id="list_experiment_runs",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+        limit=50,
+    )
+    get_experiment_score = ArizeAxGetExperimentScoreOperator(
+        task_id="get_experiment_score",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+    )
+    compare_experiments = ArizeAxCompareExperimentsOperator(
+        task_id="compare_experiments",
+        baseline_experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+        candidate_experiment_id="{{ ti.xcom_pull(task_ids='run_experiment_v2') }}",
+        pass_threshold=-1.0,  # tolerate any score; we just want to exercise the operator
+    )
+    detect_eval_drift = ArizeAxDetectEvalDriftOperator(
+        task_id="detect_eval_drift",
+        baseline_experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+        current_experiment_id="{{ ti.xcom_pull(task_ids='run_experiment_v2') }}",
+        drift_threshold=1.0,  # very lenient; we're not asserting drift behaviour here
+    )
+    behavioral_regression = ArizeAxBehavioralRegressionOperator(
+        task_id="behavioral_regression",
+        baseline_experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+        candidate_experiment_id="{{ ti.xcom_pull(task_ids='run_experiment_v2') }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        significance_threshold=1.0,  # lenient
+    )
+    eval_budget_allocator = ArizeAxEvalBudgetAllocatorOperator(
+        task_id="eval_budget_allocator",
+        space_id=SPACE_ID,
+        total_budget_spans=1000,
+        project_ids=["{{ ti.xcom_pull(task_ids='create_project') }}"],
+    )
+    export_experiment_runs_to_file = ArizeAxExportExperimentRunsToFileOperator(
+        task_id="export_experiment_runs_to_file",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+        path="/tmp/arize_e2e_experiment_runs_{{ ts_nodash }}.json",
+    )
+    annotate_experiment_runs = ArizeAxAnnotateExperimentRunsOperator(
+        task_id="annotate_experiment_runs",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+        annotations=[
+            # record_id will be patched at template time from list_experiment_runs.first_id.
+            # Use a categorical-style value: only label needed (score derived).
+            {
+                "record_id": (
+                    "{{ ti.xcom_pull(task_ids='list_experiment_runs', "
+                    "key='first_id') }}"
+                ),
+                "values": [
+                    {"name": "e2e-annot-cfg-{{ ts_nodash }}", "label": "correct"}
+                ],
+            },
+        ],
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        space_id=SPACE_ID,
+    )
+
+    # LLM-gated calibration uses the experiment we ran above as the candidate.
+    gate_calibration = ShortCircuitOperator(
+        task_id="gate_calibration",
+        python_callable=_has_ai_integration_var,
+        ignore_downstream_trigger_rules=False,
+    )
+    evaluator_calibration = ArizeAxEvaluatorCalibrationOperator(
+        task_id="evaluator_calibration",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+        annotation_name="e2e-annot-cfg-{{ ts_nodash }}",
+        # Arize records metric names from the evaluator function's __name__,
+        # so this must match `_exact_match_evaluator` exactly.
+        metric_name="_exact_match_evaluator",
+        min_samples=1,
+        # Don't fail the run if calibration is poor — annotations are sparse here.
+    )
+
+    # Annotate dataset examples (HITL) — categorical config with label only.
+    annotate_dataset_examples = ArizeAxAnnotateDatasetExamplesOperator(
+        task_id="annotate_dataset_examples",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        annotations=[
+            {
+                "record_id": (
+                    "{{ ti.xcom_pull(task_ids='list_dataset_examples', "
+                    "key='first_id') }}"
+                ),
+                "values": [
+                    {"name": "e2e-annot-cfg-{{ ts_nodash }}", "label": "correct"}
+                ],
+            },
+        ],
+        space_id=SPACE_ID,
+    )
+
+    # Phase 7 -- Tasks lifecycle (LLM, gated by arize_ai_integration_id)
+    gate_tasks = ShortCircuitOperator(
+        task_id="gate_tasks_phase",
+        python_callable=_has_ai_integration_var,
+        ignore_downstream_trigger_rules=False,
+    )
+    create_task = ArizeAxCreateTaskOperator(
+        task_id="create_task",
+        name="e2e-eval-task-{{ ts_nodash }}",
+        eval_task_type="template_evaluation",
+        evaluators=[
+            {"evaluator_id": "{{ ti.xcom_pull(task_ids='create_evaluator') }}"},
+        ],
+        project_id="{{ ti.xcom_pull(task_ids='create_project') }}",
+        is_continuous=False,
+        sampling_rate=1.0,
+    )
+    get_task = ArizeAxGetTaskOperator(
+        task_id="get_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_task') }}",
+    )
+    update_task = ArizeAxUpdateTaskOperator(
+        task_id="update_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_task') }}",
+        sampling_rate=0.5,
+        space_id=SPACE_ID,
+    )
+    trigger_task_run = ArizeAxTriggerTaskRunOperator(
+        task_id="trigger_task_run",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_task') }}",
+        space_id=SPACE_ID,
+        # Our DAG creates a fresh empty project — no spans yet means trigger
+        # has nothing to evaluate. Treat that as a skip instead of a failure
+        # so the rest of the lifecycle (list_runs, cancel, etc.) flows.
+        skip_on_no_data=True,
+    )
+    list_task_runs = ArizeAxListTaskRunsOperator(
+        task_id="list_task_runs",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_task') }}",
+        limit=10,
+    )
+    get_task_run = ArizeAxGetTaskRunOperator(
+        task_id="get_task_run",
+        run_id="{{ ti.xcom_pull(task_ids='trigger_task_run') }}",
+    )
+    task_run_sensor = ArizeAxTaskRunSensor(
+        task_id="task_run_sensor",
+        run_id="{{ ti.xcom_pull(task_ids='trigger_task_run') }}",
+        poke_interval=10,
+        timeout=180,
+        mode="poke",
+        fail_on_error=False,
+        soft_fail=True,
+    )
+    # Guard against cancel running with a placeholder ("None" string) run_id when
+    # trigger_task_run was skipped (e.g. AI-integration Variable not set yet).
+    gate_cancel_run = ShortCircuitOperator(
+        task_id="gate_cancel_run",
+        python_callable=_make_xcom_present_gate(task_ids="trigger_task_run"),
+        trigger_rule="all_done",  # evaluate even if sensor failed/skipped
+        ignore_downstream_trigger_rules=False,
+    )
+    cancel_task_run = ArizeAxCancelTaskRunOperator(
+        task_id="cancel_task_run",
+        run_id="{{ ti.xcom_pull(task_ids='trigger_task_run') }}",
+    )
+
+    # Run-experiment task variant.
+    build_run_config = PythonOperator(
+        task_id="build_run_config",
+        python_callable=_build_run_configuration,
+    )
+    create_run_experiment_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_run_experiment_task",
+        name="e2e-run-exp-task-{{ ts_nodash }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        run_configuration="{{ ti.xcom_pull(task_ids='build_run_config') }}",
+        space_id=SPACE_ID,
+        if_exists="skip",
+    )
+
+    # Phase 8 -- Annotations lifecycle
+    create_annotation_config = ArizeAxCreateAnnotationConfigOperator(
+        task_id="create_annotation_config",
+        space=SPACE_ID,
+        name="e2e-annot-cfg-{{ ts_nodash }}",
+        config_type="categorical",
+        values=[
+            {"label": "correct", "score": 1},
+            {"label": "wrong", "score": 0},
+        ],
+    )
+
+    # Annotation queue sub-phase (gated by arize_annotator_email)
+    gate_annotation_queue = ShortCircuitOperator(
+        task_id="gate_annotation_queue",
+        python_callable=_has_annotator_email_var,
+        ignore_downstream_trigger_rules=False,
+    )
+
+    def _build_annotator_emails(**_ctx) -> list[str]:
+        return [_get_first_var("arize_annotator_email", "ARIZE_ANNOTATOR_EMAIL")]
+
+    build_annotator_emails = PythonOperator(
+        task_id="build_annotator_emails",
+        python_callable=_build_annotator_emails,
+    )
+    create_annotation_queue = ArizeAxCreateAnnotationQueueOperator(
+        task_id="create_annotation_queue",
+        name="e2e-annot-q-{{ ts_nodash }}",
+        space=SPACE_ID,
+        annotation_config_ids=[
+            "{{ ti.xcom_pull(task_ids='create_annotation_config') }}",
+        ],
+        annotator_emails="{{ ti.xcom_pull(task_ids='build_annotator_emails') }}",
+        instructions="e2e annotation queue — safe to delete.",
+    )
+    get_annotation_queue = ArizeAxGetAnnotationQueueOperator(
+        task_id="get_annotation_queue",
+        annotation_queue="{{ ti.xcom_pull(task_ids='create_annotation_queue') }}",
+        space=SPACE_ID,
+    )
+    update_annotation_queue = ArizeAxUpdateAnnotationQueueOperator(
+        task_id="update_annotation_queue",
+        annotation_queue="{{ ti.xcom_pull(task_ids='create_annotation_queue') }}",
+        space=SPACE_ID,
+        instructions="updated by e2e DAG",
+    )
+    list_annotation_queue_records = ArizeAxListAnnotationQueueRecordsOperator(
+        task_id="list_annotation_queue_records",
+        annotation_queue="{{ ti.xcom_pull(task_ids='create_annotation_queue') }}",
+        space=SPACE_ID,
+        limit=5,
+    )
+
+    # Manually inject a record source so AddAnnotationQueueRecords has work to do.
+    add_annotation_queue_records = ArizeAxAddAnnotationQueueRecordsOperator(
+        task_id="add_annotation_queue_records",
+        annotation_queue="{{ ti.xcom_pull(task_ids='create_annotation_queue') }}",
+        space=SPACE_ID,
+        record_sources=[
+            # SDK shape: AnnotationQueueExampleRecordInput uses key "record_type"
+            # (discriminator) with value "example" — not "type"/"dataset".
+            {
+                "record_type": "example",
+                "dataset_id": "{{ ti.xcom_pull(task_ids='create_dataset') }}",
+            },
+        ],
+    )
+
+    annotation_queue_sensor = ArizeAxAnnotationQueueSensor(
+        task_id="annotation_queue_sensor",
+        space_id=SPACE_ID,
+        min_count=1,
+        poke_interval=5,
+        timeout=30,
+        mode="poke",
+        soft_fail=True,
+    )
+
+    def _annotate_first_record(**ctx) -> dict[str, Any]:
+        """Pick the first record from the queue (if any) and submit an
+        annotation + assignment via the hook directly so we can chain to the
+        AnnotateQueueRecord and AssignQueueRecord operators without forcing
+        Jinja into ambiguous list-of-dicts payloads.
+        """
+        ti = ctx["ti"]
+        recs = ti.xcom_pull(task_ids="list_annotation_queue_records")
+        items = (recs or {}).get("items") if isinstance(recs, dict) else None
+        if not items:
+            print("[annotate_first_record] queue has no records — nothing to push")
+            return {"record_id": None}
+        first_id = str(items[0].get("id") or "")
+        return {"record_id": first_id}
+
+    pick_first_queue_record = PythonOperator(
+        task_id="pick_first_queue_record",
+        python_callable=_annotate_first_record,
+    )
+
+    def _has_real_queue_record(**ctx) -> bool:
+        """Skip downstream queue-record ops if pick_first_queue_record didn't
+        find any real records (freshly created queue has none until the
+        backend processes its record_sources)."""
+        ti = ctx["ti"]
+        rec = ti.xcom_pull(task_ids="pick_first_queue_record")
+        rid = (rec or {}).get("record_id") if isinstance(rec, dict) else None
+        ok = bool(rid)
+        if not ok:
+            print("[gate] queue has no records yet — skipping annotate/assign/delete")
+        return ok
+
+    gate_queue_records = ShortCircuitOperator(
+        task_id="gate_queue_records",
+        python_callable=_has_real_queue_record,
+        ignore_downstream_trigger_rules=False,
+    )
+
+    annotate_queue_record = ArizeAxAnnotateQueueRecordOperator(
+        task_id="annotate_queue_record",
+        annotation_queue="{{ ti.xcom_pull(task_ids='create_annotation_queue') }}",
+        record_id=(
+            "{{ ti.xcom_pull(task_ids='pick_first_queue_record')['record_id'] }}"
+        ),
+        annotations=[
+            {"name": "e2e-annot-cfg-{{ ts_nodash }}", "label": "correct"},
+        ],
+        space=SPACE_ID,
+    )
+    assign_queue_record = ArizeAxAssignQueueRecordOperator(
+        task_id="assign_queue_record",
+        annotation_queue="{{ ti.xcom_pull(task_ids='create_annotation_queue') }}",
+        record_id=(
+            "{{ ti.xcom_pull(task_ids='pick_first_queue_record')['record_id'] }}"
+        ),
+        assigned_user_emails="{{ ti.xcom_pull(task_ids='build_annotator_emails') }}",
+        space=SPACE_ID,
+    )
+    delete_annotation_queue_records = ArizeAxDeleteAnnotationQueueRecordsOperator(
+        task_id="delete_annotation_queue_records",
+        annotation_queue="{{ ti.xcom_pull(task_ids='create_annotation_queue') }}",
+        record_ids=[
+            "{{ ti.xcom_pull(task_ids='pick_first_queue_record')['record_id'] }}",
+        ],
+        space_id=SPACE_ID,
+        ignore_if_missing=True,
+    )
+
+    # Phase 9 -- Prompts
+    create_prompt = ArizeAxCreatePromptOperator(
+        task_id="create_prompt",
+        space_id=SPACE_ID,
+        name="e2e-test-prompt-{{ ts_nodash }}",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant. Answer concisely."},
+            {"role": "user", "content": "{query}"},
+        ],
+        provider="open_ai",
+        input_variable_format="f_string",
+        model="gpt-4o-mini",
+        commit_message="Initial version from e2e run {{ ts_nodash }}",
+        if_exists="skip",
+    )
+    get_prompt = ArizeAxGetPromptOperator(
+        task_id="get_prompt",
+        prompt_id="{{ ti.xcom_pull(task_ids='create_prompt') }}",
+    )
+    list_prompts = ArizeAxListPromptsOperator(
+        task_id="list_prompts",
+        space_id=SPACE_ID,
+        limit=10,
+    )
+    promote_prompt = ArizeAxPromotePromptOperator(
+        task_id="promote_prompt",
+        prompt_name="e2e-test-prompt-{{ ts_nodash }}",
+        label="staging",
+        space_id=SPACE_ID,
+    )
+
+    # ComparePrompts only runs when AI integration is available
+    # (it actually invokes the LLM via the prompt).
+    gate_compare_prompts = ShortCircuitOperator(
+        task_id="gate_compare_prompts",
+        python_callable=_has_ai_integration_var,
+        ignore_downstream_trigger_rules=False,
+    )
+    compare_prompts = ArizeAxComparePromptsOperator(
+        task_id="compare_prompts",
+        prompt_names=["e2e-test-prompt-{{ ts_nodash }}"],
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        task=_echo_task,
+        evaluators=[_exact_match_evaluator],
+        experiment_name_prefix="e2e-prompt-ab-{{ ts_nodash }}",
+        space_id=SPACE_ID,
+        concurrency=1,
+    )
+
+    # Phase 10 -- Spans (alpha, non-critical)
+    list_spans = ArizeAxListSpansOperator(
+        task_id="list_spans",
+        project_id="{{ ti.xcom_pull(task_ids='create_project') }}",
+        limit=5,
+    )
+
+    # Phase 11 -- Verification + inspection window
+    verify = PythonOperator(
+        task_id="verify_results",
+        python_callable=_verify_results,
+        trigger_rule="all_done",
+    )
+    inspection_window = PythonOperator(
+        task_id="inspection_window",
+        python_callable=_inspection_pause,
+        trigger_rule="all_done",
+    )
+
+    # Phase 12 -- Cleanup (always runs, deletion ordered by dependency)
+    delete_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_delete_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_task') }}",
+        space_id=SPACE_ID,
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    delete_run_experiment_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_delete_run_experiment_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_run_experiment_task') }}",
+        space_id=SPACE_ID,
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    delete_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_delete_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_evaluator') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    delete_experiment = ArizeAxDeleteExperimentOperator(
+        task_id="cleanup_delete_experiment",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_experiment') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    delete_experiment_v2 = ArizeAxDeleteExperimentOperator(
+        task_id="cleanup_delete_experiment_v2",
+        experiment_id="{{ ti.xcom_pull(task_ids='run_experiment_v2') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    delete_annotation_queue = ArizeAxDeleteAnnotationQueueOperator(
+        task_id="cleanup_delete_annotation_queue",
+        annotation_queue="{{ ti.xcom_pull(task_ids='create_annotation_queue') }}",
+        space=SPACE_ID,
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    delete_annotation_config = ArizeAxDeleteAnnotationConfigOperator(
+        task_id="cleanup_delete_annotation_config",
+        annotation_config="{{ ti.xcom_pull(task_ids='create_annotation_config') }}",
+        space=SPACE_ID,
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    delete_prompt = ArizeAxDeletePromptOperator(
+        task_id="cleanup_delete_prompt",
+        prompt_id="{{ ti.xcom_pull(task_ids='create_prompt') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    delete_dataset = ArizeAxDeleteDatasetOperator(
+        task_id="cleanup_delete_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    delete_project = ArizeAxDeleteProjectOperator(
+        task_id="cleanup_delete_project",
+        project_id="{{ ti.xcom_pull(task_ids='create_project') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    delete_api_key = ArizeAxDeleteAPIKeyOperator(
+        task_id="cleanup_delete_api_key",
+        api_key_id="{{ ti.xcom_pull(task_ids='create_api_key') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    delete_ai_integration = ArizeAxDeleteAIIntegrationOperator(
+        task_id="cleanup_delete_ai_integration",
+        integration_id="{{ ti.xcom_pull(task_ids='create_ai_integration') }}",
+        space_id=SPACE_ID,
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+
+    # Wiring
+
+    # Phase 1: independent listings (only space_id-dependent ones chain off list_spaces).
+    list_spaces >> [
+        list_ai_integrations,
+        list_annotation_configs,
+        list_annotation_queues,
+        list_api_keys,
+        list_evaluators,
+        list_tasks,
+        list_projects,
+        list_datasets,
+    ]
+
+    # Phase 2: AI integration CRUD
+    list_spaces >> create_ai_integration >> get_ai_integration >> update_ai_integration
+
+    # Phase 3: API key CRUD
+    list_spaces >> create_api_key >> refresh_api_key
+
+    # Phase 4: project + dataset setup + enrichment
+    list_spaces >> create_project >> [get_project, span_count_sensor, span_ingestion_sensor]
+    list_spaces >> create_dataset >> [get_dataset, append_examples]
+    append_examples >> list_dataset_examples >> export_dataset_examples_to_file
+    list_dataset_examples >> dataset_ready
+    [create_project, create_dataset] >> eval_dataset_health
+    [create_project, create_dataset] >> smart_dataset_refresh
+
+    # Phase 5: evaluator lifecycle (gated)
+    list_spaces >> gate_evaluator >> build_evaluator_config >> create_evaluator
+    create_evaluator >> [get_evaluator, update_evaluator, add_evaluator_version]
+    # list_evaluator_versions must wait for add_evaluator_version so the list
+    # finds at least 2 versions (Arize's evaluators.list_versions does not appear
+    # to return the initial create_evaluator version synchronously when polled
+    # immediately after create — wait for v2 to guarantee non-empty results).
+    [create_evaluator, add_evaluator_version] >> list_evaluator_versions >> gate_get_evaluator_version >> get_evaluator_version
+
+    # Phase 6: experiment lifecycle
+    dataset_ready >> [run_experiment, run_experiment_v2]
+    run_experiment >> [
+        experiment_complete,
+        experiment_run_count_sensor,
+        evaluation_score_sensor,
+        get_experiment,
+        list_experiment_runs,
+        get_experiment_score,
+        export_experiment_runs_to_file,
+    ]
+    create_dataset >> list_experiments
+    [run_experiment, run_experiment_v2] >> compare_experiments
+    [run_experiment, run_experiment_v2] >> detect_eval_drift
+    [run_experiment, run_experiment_v2] >> behavioral_regression
+    create_project >> eval_budget_allocator
+
+    # Dataset-level HITL annotation (needs example IDs).
+    # Both annotate ops reference the annotation config by name, so the config
+    # must exist before they fire. They also depend on real first_id XComs from
+    # the upstream list operators — if those are empty/missing, the API
+    # returns 400 or even 500 instead of a clean validation error. Gate to skip.
+    gate_annotate_ds = ShortCircuitOperator(
+        task_id="gate_annotate_dataset_examples",
+        python_callable=_make_xcom_present_gate(
+            task_ids="list_dataset_examples", key="first_id",
+        ),
+        ignore_downstream_trigger_rules=False,
+    )
+    gate_annotate_exp = ShortCircuitOperator(
+        task_id="gate_annotate_experiment_runs",
+        python_callable=_make_xcom_present_gate(
+            task_ids="list_experiment_runs", key="first_id",
+        ),
+        ignore_downstream_trigger_rules=False,
+    )
+    [list_dataset_examples, create_annotation_config] >> gate_annotate_ds
+    gate_annotate_ds >> annotate_dataset_examples
+    [list_experiment_runs, create_annotation_config] >> gate_annotate_exp
+    gate_annotate_exp >> annotate_experiment_runs
+    # Evaluator calibration is LLM-gated and depends on annotations being present.
+    annotate_experiment_runs >> gate_calibration >> evaluator_calibration
+
+    # Phase 7: tasks (gated, depend on evaluator + project)
+    [create_evaluator, create_project] >> gate_tasks
+    gate_tasks >> create_task >> [get_task, list_task_runs, update_task]
+    create_task >> trigger_task_run >> [get_task_run, task_run_sensor]
+    [trigger_task_run, task_run_sensor] >> gate_cancel_run >> cancel_task_run
+    gate_tasks >> build_run_config >> create_run_experiment_task
+    create_dataset >> create_run_experiment_task
+
+    # Phase 8: annotations
+    list_spaces >> create_annotation_config
+    create_annotation_config >> gate_annotation_queue >> build_annotator_emails
+    build_annotator_emails >> create_annotation_queue
+    create_annotation_queue >> [
+        get_annotation_queue,
+        update_annotation_queue,
+        list_annotation_queue_records,
+        add_annotation_queue_records,
+        annotation_queue_sensor,
+    ]
+    list_annotation_queue_records >> pick_first_queue_record >> gate_queue_records
+    gate_queue_records >> [annotate_queue_record, assign_queue_record]
+    [annotate_queue_record, assign_queue_record] >> delete_annotation_queue_records
+
+    # Phase 9: prompts
+    list_spaces >> create_prompt >> [get_prompt, list_prompts, promote_prompt]
+    [create_prompt, create_dataset] >> gate_compare_prompts >> compare_prompts
+
+    # Phase 10: spans
+    create_project >> list_spans
+
+    # Phase 11: verification feeds off "most everything", then inspection window
+    [
+        # Phase 1
+        list_ai_integrations,
+        list_annotation_configs,
+        list_annotation_queues,
+        list_api_keys,
+        list_evaluators,
+        list_tasks,
+        list_projects,
+        list_datasets,
+        # Phase 2-3
+        get_ai_integration,
+        update_ai_integration,
+        refresh_api_key,
+        # Phase 4
+        get_project,
+        get_dataset,
+        list_dataset_examples,
+        export_dataset_examples_to_file,
+        eval_dataset_health,
+        smart_dataset_refresh,
+        dataset_ready,
+        span_count_sensor,
+        span_ingestion_sensor,
+        # Phase 5
+        get_evaluator,
+        update_evaluator,
+        add_evaluator_version,
+        list_evaluator_versions,
+        get_evaluator_version,
+        # Phase 6
+        experiment_complete,
+        experiment_run_count_sensor,
+        evaluation_score_sensor,
+        get_experiment,
+        list_experiments,
+        list_experiment_runs,
+        get_experiment_score,
+        compare_experiments,
+        detect_eval_drift,
+        behavioral_regression,
+        eval_budget_allocator,
+        export_experiment_runs_to_file,
+        annotate_dataset_examples,
+        annotate_experiment_runs,
+        evaluator_calibration,
+        # Phase 7
+        get_task,
+        list_task_runs,
+        update_task,
+        task_run_sensor,
+        cancel_task_run,
+        create_run_experiment_task,
+        # Phase 8
+        get_annotation_queue,
+        update_annotation_queue,
+        list_annotation_queue_records,
+        add_annotation_queue_records,
+        annotation_queue_sensor,
+        annotate_queue_record,
+        assign_queue_record,
+        delete_annotation_queue_records,
+        # Phase 9
+        get_prompt,
+        list_prompts,
+        promote_prompt,
+        compare_prompts,
+        # Phase 10
+        list_spans,
+    ] >> verify
+
+    verify >> inspection_window
+
+    # Phase 12: cleanup (correct deletion order — children before parents)
+    inspection_window >> [
+        delete_task,
+        delete_run_experiment_task,
+        delete_annotation_queue,
+    ] >> delete_evaluator
+    inspection_window >> [
+        delete_experiment,
+        delete_experiment_v2,
+        delete_prompt,
+    ]
+    [delete_evaluator, delete_experiment, delete_experiment_v2] >> delete_dataset
+    [delete_dataset, delete_prompt] >> delete_project
+    delete_annotation_queue >> delete_annotation_config
+    inspection_window >> [delete_api_key, delete_ai_integration]

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_evaluator_calibration_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_evaluator_calibration_dag.py
@@ -38,25 +38,16 @@ from typing import Any
 
 from airflow import DAG
 from airflow.models import Variable
-
-try:
-    from airflow.providers.standard.operators.python import (
-        PythonOperator,
-        ShortCircuitOperator,
-    )
-except ImportError:
-    from airflow.operators.python import PythonOperator, ShortCircuitOperator
-
-try:
-    from airflow.utils.trigger_rule import TriggerRule
-except ImportError:  # Airflow 3.x sdk path
-    from airflow.sdk.definitions._internal.trigger_rule import TriggerRule
-
 from airflow.providers.arize_ax.operators.experiments import (
     ArizeAxEvaluatorCalibrationOperator,
     ArizeAxRunExperimentOperator,
 )
 from airflow.providers.arize_ax.sensors.arize_ax import ArizeAxExperimentRunCountSensor
+from airflow.providers.standard.operators.python import (
+    PythonOperator,
+    ShortCircuitOperator,
+)
+from airflow.task.trigger_rule import TriggerRule
 
 
 def _check_dataset_configured(**ctx) -> bool:

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_evaluators_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_evaluators_dag.py
@@ -39,20 +39,15 @@ from typing import Any
 
 from airflow import DAG
 from airflow.models import Variable
-
-try:
-    from airflow.providers.standard.operators.python import (
-        PythonOperator,
-        ShortCircuitOperator,
-    )
-except ImportError:
-    from airflow.operators.python import PythonOperator, ShortCircuitOperator
-
 from airflow.providers.arize_ax.operators.evaluators import (
     ArizeAxAddEvaluatorVersionOperator,
     ArizeAxCreateEvaluatorOperator,
     ArizeAxListEvaluatorsOperator,
     ArizeAxUpdateEvaluatorOperator,
+)
+from airflow.providers.standard.operators.python import (
+    PythonOperator,
+    ShortCircuitOperator,
 )
 
 

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_finetune_data_pipeline_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_finetune_data_pipeline_dag.py
@@ -46,12 +46,6 @@ from datetime import datetime
 from typing import Any
 
 from airflow import DAG
-
-try:
-    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator, ShortCircuitOperator
-
 from airflow.providers.arize_ax.operators.datasets import (
     ArizeAxAppendDatasetExamplesOperator,
     ArizeAxCreateDatasetOperator,
@@ -59,6 +53,7 @@ from airflow.providers.arize_ax.operators.datasets import (
 from airflow.providers.arize_ax.operators.spans import (
     ArizeAxExportSpansToFineTuningOperator,
 )
+from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 
 SYSTEM_PROMPT = (
     "You are a helpful, accurate assistant. Answer concisely and factually."

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_llm_cicd_gate_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_llm_cicd_gate_dag.py
@@ -56,12 +56,6 @@ from typing import Any
 
 from airflow import DAG
 from airflow.models import Variable
-
-try:
-    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator, ShortCircuitOperator
-
 from airflow.providers.arize_ax.operators.datasets import (
     ArizeAxAppendDatasetExamplesOperator,
     ArizeAxCreateDatasetOperator,
@@ -77,6 +71,7 @@ from airflow.providers.arize_ax.operators.prompts import (
 from airflow.providers.arize_ax.sensors.arize_ax import (
     ArizeAxExperimentRunCountSensor,
 )
+from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 
 # ---------------------------------------------------------------------------
 # Constants — override via Airflow Variables in production

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_llm_experiments_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_llm_experiments_dag.py
@@ -55,12 +55,6 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from airflow import DAG
-
-try:
-    from airflow.providers.standard.operators.python import PythonOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator
-
 from airflow.providers.arize_ax.operators.datasets import (
     ArizeAxCreateDatasetOperator,
     ArizeAxDeleteDatasetOperator,
@@ -84,11 +78,8 @@ from airflow.providers.arize_ax.operators.spaces import (
 from airflow.providers.arize_ax.sensors.arize_ax import (
     ArizeAxDatasetReadySensor,
 )
-
-try:
-    from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
-except ImportError:
-    from airflow.sensors.time_delta import TimeDeltaSensor
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
 
 INSPECTION_WINDOW_MINUTES = 15
 

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_ab_test_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_ab_test_dag.py
@@ -37,12 +37,6 @@ from typing import Any
 
 from airflow import DAG
 from airflow.models import Variable
-
-try:
-    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator, ShortCircuitOperator
-
 from airflow.providers.arize_ax.operators.datasets import (
     ArizeAxAppendDatasetExamplesOperator,
     ArizeAxCreateDatasetOperator,
@@ -51,6 +45,7 @@ from airflow.providers.arize_ax.operators.prompts import (
     ArizeAxComparePromptsOperator,
     ArizeAxPromotePromptOperator,
 )
+from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 
 AB_DATASET_NAME = "prompt-ab-eval-dataset"
 

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_lifecycle_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_lifecycle_dag.py
@@ -74,12 +74,6 @@ from typing import Any
 
 from airflow import DAG
 from airflow.models import Variable
-
-try:
-    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator, ShortCircuitOperator
-
 from airflow.providers.arize_ax.operators.datasets import (
     ArizeAxAppendDatasetExamplesOperator,
     ArizeAxCreateDatasetOperator,
@@ -96,6 +90,7 @@ from airflow.providers.arize_ax.operators.prompts import (
 from airflow.providers.arize_ax.sensors.arize_ax import (
     ArizeAxExperimentRunCountSensor,
 )
+from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 
 # ---------------------------------------------------------------------------
 # Constants — adjust to your environment

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_optimization_with_feedback_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_optimization_with_feedback_dag.py
@@ -23,10 +23,13 @@ Pipeline::
    prompt group. Each instance calls the Arize Prompt Learning SDK to
    produce a revised system prompt informed by that group's own feedback.
 3. **create_optimized_prompt** — ``ArizeAxCreatePromptOperator`` expanded
-   over the optimize output so every improved prompt is pushed (or
-   version-bumped via ``if_exists="skip"``) to the Arize Prompt Hub. The
-   created prompt name includes the ``group_key`` so each agent gets its
-   own named prompt.
+   over the optimize output so every improved prompt lands in the Arize
+   Prompt Hub. The created prompt name includes the ``group_key`` and the
+   current date so each agent gets a uniquely-named prompt per run; on
+   same-day retries ``if_exists="skip"`` returns the existing prompt ID
+   without modifying anything. To version-bump under a single stable name
+   instead (one prompt that accumulates revisions over time), use
+   ``if_exists="add_version"``.
 
 User configuration:
 - Airflow connection ``arize_ax_default`` with API key.

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_rag_evaluation_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_rag_evaluation_dag.py
@@ -46,12 +46,6 @@ from typing import Any
 
 from airflow import DAG
 from airflow.models import Variable
-
-try:
-    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator, ShortCircuitOperator
-
 from airflow.providers.arize_ax.operators.datasets import (
     ArizeAxAppendDatasetExamplesOperator,
     ArizeAxCreateDatasetOperator,
@@ -66,6 +60,7 @@ from airflow.providers.arize_ax.operators.projects import (
 from airflow.providers.arize_ax.operators.spans import (
     ArizeAxSpansExportToParquetOperator,
 )
+from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 
 _TMP_PARQUET = "/tmp/rag_spans_{{ ds }}.parquet"
 _RAG_SPAN_WHERE = (

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_self_optimizing_loop_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_self_optimizing_loop_dag.py
@@ -1,0 +1,477 @@
+"""Self-Optimizing Loop demo — fully self-contained closed-loop prompt
+improvement: create a deliberately-broken starter prompt, run a baseline
+experiment, optimize the prompt from baseline feedback via the Arize
+Prompt Learning SDK, run a candidate experiment with the optimized
+prompt, gate promotion on an LLM-as-judge metric, and promote on win.
+
+The demo is designed to **reliably end green** when prerequisites are
+configured: the verbose starter prompt produces multi-paragraph answers
+that the terseness LLM judge rates low; the optimizer reliably reduces
+the prompt to a concise form; the candidate scores high. If you change
+the starter prompt or the dataset, the gate may fire and the DAG will
+end red — that is correct behavior, not a bug.
+
+Pipeline (12 stages)::
+
+    check_prereqs               (ShortCircuit — OPENAI_API_KEY + space + SDK import)
+        │
+        ▼
+    create_demo_dataset         (10 terse-answer trivia rows; if_exists="skip")
+        │
+        ▼
+    create_initial_prompt       (verbose-by-design starter; if_exists="skip")
+        │
+        ▼
+    run_baseline_experiment     (ArizeAxRunExperimentOperator, baseline_task + LLM judge)
+        │
+        ▼
+    optimize_and_store          (PythonOperator — Prompt Learning SDK + Variable.set)
+        │
+        ▼
+    push_optimized_prompt       (ArizeAxCreatePromptOperator if_exists="add_version" — pushes v2 under same name)
+        │
+        ▼
+    run_candidate_experiment    (ArizeAxRunExperimentOperator, candidate_task + LLM judge)
+        │
+        ▼
+    compare_experiments         (ArizeAxCompareExperimentsOperator, fail_on_regression=True)
+        │
+        ▼
+    promote_prompt              (ArizeAxPromotePromptOperator, label="production")
+        │
+        ▼
+    summarize_loop              (PythonOperator — print baseline/candidate/delta)
+        │
+        ▼
+    cleanup_dataset             (ArizeAxDeleteDatasetOperator, trigger_rule="all_done",
+                                 gated by arize_ax_self_optimizing_cleanup Variable)
+
+Prerequisites
+-------------
+1. Airflow connection ``arize_ax_default`` with a valid API key.
+2. Airflow Variable ``arize_ax_space_id`` (or ``default_space`` on the connection extras).
+3. ``OPENAI_API_KEY`` in the **worker environment** — used both by the
+   experiment tasks (worker-side LLM call) and by the Prompt Learning SDK
+   during optimization.
+4. ``prompt-learning-enhanced`` installed on the worker (separate install
+   because PyPI rejects direct-URL deps, so the provider can no longer
+   declare it as an extra)::
+
+       pip install 'arize-phoenix-evals>=2.0,<3.0' \\
+                   'prompt-learning-enhanced @ git+https://github.com/Arize-ai/prompt-learning.git'
+
+5. ``openai`` Python SDK installed on the worker (typically already present).
+
+Optional Variables
+------------------
+- ``arize_ax_self_optimizing_cleanup`` — set to ``"true"`` to delete the
+  demo dataset on DAG completion. Default ``"false"`` so you can inspect
+  the artifacts in the Arize UI between runs.
+- ``arize_ax_self_optimizing_model`` — the OpenAI model used by the
+  experiment tasks (default ``"gpt-4o-mini"``). The optimizer always
+  uses ``gpt-4o`` regardless.
+
+This demo runs **client-side experiments** via ``ArizeAxRunExperimentOperator``.
+Server-side (Eval Hub) execution would be cleaner but requires a separate
+``template_evaluation`` task chain per experiment because
+``LlmGenerationRunConfig`` does not accept ``evaluator_ids`` today (filed
+upstream as `Arize-ai/arize#72271 <https://github.com/Arize-ai/arize/issues/72271>`_).
+When that ships, this DAG can collapse the worker-side LLM calls in favor
+of the Eval Hub task chain.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+from airflow.models import Variable
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxCreateDatasetOperator,
+    ArizeAxDeleteDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.experiments import (
+    ArizeAxCompareExperimentsOperator,
+    ArizeAxRunExperimentOperator,
+)
+from airflow.providers.arize_ax.operators.prompts import (
+    ArizeAxCreatePromptOperator,
+    ArizeAxPromotePromptOperator,
+)
+from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+
+_SPACE_JINJA = "{{ var.value.get('arize_ax_space_id', '') or None }}"
+
+_PROMPT_NAME = "arize-ax-self-optimizing-loop-demo"
+_DATASET_NAME_TEMPLATE = "arize-ax-self-optimizing-loop-{{ ds_nodash }}"
+_OPTIMIZED_MESSAGES_VAR = "arize_ax_self_optimizing_optimized_messages"
+
+# Deliberately verbose starter — produces multi-paragraph answers that fail
+# an exact-match evaluator over terse expected answers. The optimizer
+# reliably reduces this to a concise form once it sees the failures.
+_INITIAL_SYSTEM_PROMPT = (
+    "You are a verbose, educational assistant. Always explain your "
+    "reasoning in multiple paragraphs before giving the final answer. "
+    "Include historical context and related facts. Your response should "
+    "feel like a textbook entry."
+)
+
+# 10 trivia rows with one-word expected answers. Each row uses ``input`` and
+# ``expected_output`` columns to match Arize experiment conventions.
+_DEMO_EXAMPLES = [
+    {"input": "What is the capital of France?", "expected_output": "Paris"},
+    {"input": "Chemical symbol for water?", "expected_output": "H2O"},
+    {"input": "Largest planet in the solar system?", "expected_output": "Jupiter"},
+    {"input": "Who wrote Hamlet?", "expected_output": "Shakespeare"},
+    {"input": "First president of the United States?", "expected_output": "Washington"},
+    {"input": "How many continents are there?", "expected_output": "7"},
+    {"input": "What is 7 multiplied by 8?", "expected_output": "56"},
+    {"input": "What element has atomic number 1?", "expected_output": "Hydrogen"},
+    {"input": "Speed of light in km/s (approx.)?", "expected_output": "300000"},
+    {"input": "Year humans first landed on the Moon?", "expected_output": "1969"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Prereq guard
+# ---------------------------------------------------------------------------
+def _check_prereqs(**_ctx) -> bool:
+    """Return True iff every prerequisite is satisfied; otherwise short-circuit."""
+    if not os.environ.get("OPENAI_API_KEY", "").strip():
+        print("OPENAI_API_KEY not set in worker environment — skipping demo.")
+        return False
+    if not Variable.get("arize_ax_space_id", default_var="").strip():
+        print("Airflow Variable arize_ax_space_id not set — skipping demo.")
+        return False
+    try:
+        import optimizer_sdk.prompt_learning_optimizer  # noqa: F401
+    except ImportError:
+        print(
+            "prompt-learning-enhanced SDK is not installed on the worker. "
+            "Install with: pip install 'arize-phoenix-evals>=2.0,<3.0' "
+            "'prompt-learning-enhanced @ git+https://github.com/Arize-ai/prompt-learning.git'"
+        )
+        return False
+    try:
+        import openai  # noqa: F401
+    except ImportError:
+        print("openai SDK is not installed on the worker — required for experiment tasks.")
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Task callables for the experiments
+# ---------------------------------------------------------------------------
+def _call_openai_with_messages(messages: list[dict[str, str]]) -> str:
+    """Single LLM call. Kept tiny so the demo is easy to read."""
+    import openai
+
+    model = Variable.get("arize_ax_self_optimizing_model", default_var="gpt-4o-mini")
+    response = openai.OpenAI().chat.completions.create(
+        model=model,
+        messages=messages,
+        temperature=0,
+    )
+    return (response.choices[0].message.content or "").strip()
+
+
+def baseline_task(dataset_row: dict) -> dict[str, Any]:
+    """Run the deliberately-verbose starter prompt against a dataset row."""
+    messages = [
+        {"role": "system", "content": _INITIAL_SYSTEM_PROMPT},
+        {"role": "user", "content": dataset_row.get("input", "")},
+    ]
+    return {"output": _call_openai_with_messages(messages)}
+
+
+def candidate_task(dataset_row: dict) -> dict[str, Any]:
+    """Run the optimized prompt (stored in Airflow Variable) against a dataset row."""
+    raw = Variable.get(_OPTIMIZED_MESSAGES_VAR, default_var=None)
+    if not raw:
+        raise RuntimeError(
+            f"Variable {_OPTIMIZED_MESSAGES_VAR!r} is not set — "
+            "the store_optimized_prompt stage must run before candidate_task."
+        )
+    optimized_messages = json.loads(raw)
+    user_msg = {"role": "user", "content": dataset_row.get("input", "")}
+    # Optimizer typically returns a single system message; append the user
+    # question so the call has both roles.
+    messages = list(optimized_messages) + [user_msg]
+    return {"output": _call_openai_with_messages(messages)}
+
+
+_JUDGE_SYSTEM_PROMPT = (
+    "You are a strict evaluator scoring an assistant's response to a "
+    "trivia question. Score the response on BOTH correctness AND "
+    "terseness. First count the words in the response, then score using "
+    "the rubric below. Reply with ONLY a single line in the exact form: "
+    "score=<float between 0.0 and 1.0>; label=<concise|brief|verbose|incorrect>; "
+    "reason=<word count + short explanation>.\n\n"
+    "Scoring rubric (response word count matters — count words carefully):\n"
+    "  - score=1.0, label=concise: response is 1-30 words AND contains the "
+    "expected answer. A short factual answer with at most one supporting "
+    "sentence fits here.\n"
+    "  - score=0.5, label=brief: response is 31-100 words AND contains the "
+    "expected answer. A short paragraph with limited context fits here.\n"
+    "  - score=0.0, label=verbose: response is MORE THAN 100 words "
+    "(regardless of correctness). Multi-paragraph explanations, historical "
+    "context tangents, or textbook-style answers fall here.\n"
+    "  - score=0.0, label=incorrect: response does not contain the "
+    "expected answer at all.\n\n"
+    "Be strict about word count: count every word, do not round generously. "
+    "The grade reflects format quality, not just factual accuracy."
+)
+
+
+def _parse_judge_response(text: str) -> tuple[float, str, str]:
+    """Parse 'score=...; label=...; reason=...' into (score, label, reason)."""
+    score = 0.0
+    label = "incorrect"
+    reason = text.strip()
+    for part in text.split(";"):
+        key, _, value = part.partition("=")
+        key = key.strip().lower()
+        value = value.strip()
+        if key == "score":
+            try:
+                score = float(value)
+            except (TypeError, ValueError):
+                score = 0.0
+        elif key == "label":
+            label = value or label
+        elif key == "reason":
+            reason = value or reason
+    score = max(0.0, min(1.0, score))
+    return score, label, reason
+
+
+def llm_judge_terseness(dataset_row: dict, output: Any) -> Any:
+    """LLM-as-judge: scores response on correctness AND terseness via gpt-4o-mini.
+
+    Cheap and fast (one extra LLM call per dataset row, gpt-4o-mini at
+    temperature=0). The rubric narrows variance enough that the demo
+    reliably ends green when the optimizer wins.
+    """
+    from arize.experiments import EvaluationResult
+
+    expected = str(dataset_row.get("expected_output", "")).strip()
+    question = str(dataset_row.get("input", "")).strip()
+    actual = str((output or {}).get("output", "") if isinstance(output, dict) else (output or "")).strip()
+
+    user_msg = (
+        f"Question: {question}\n"
+        f"Expected answer: {expected}\n"
+        f"Assistant response: {actual}"
+    )
+    raw = _call_openai_with_messages(
+        [
+            {"role": "system", "content": _JUDGE_SYSTEM_PROMPT},
+            {"role": "user", "content": user_msg},
+        ],
+    )
+    score, label, reason = _parse_judge_response(raw)
+    return EvaluationResult(score=score, label=label, explanation=reason)
+
+
+# ---------------------------------------------------------------------------
+# Optimization step — runs ArizeAxOptimizePromptOperator under the hood and
+# persists the result in an Airflow Variable so candidate_task can pick it up
+# without an Airflow context (Arize SDK task callables only receive the
+# dataset row).
+# ---------------------------------------------------------------------------
+def _optimize_and_store(**ctx) -> dict[str, Any]:
+    """Optimize the starter prompt against baseline feedback and store the result.
+
+    The Prompt Learning SDK's ``PromptLearningOptimizer.optimize`` requires a
+    pandas DataFrame (it calls ``dataset.columns`` during input validation),
+    so we materialize the baseline's row-dict records into one here.
+    """
+    import pandas as pd
+    from airflow.providers.arize_ax.hooks.arize_ax import ArizeAxHook
+
+    baseline_result = ctx["ti"].xcom_pull(task_ids="run_baseline_experiment", key="result") or {}
+    if not isinstance(baseline_result, dict):
+        raise RuntimeError(
+            f"Unexpected baseline result XCom shape: {type(baseline_result).__name__}."
+        )
+    records = baseline_result.get("dataframe_records") or []
+    if not records:
+        raise RuntimeError(
+            "Baseline experiment produced no dataframe_records — cannot optimize."
+        )
+
+    df = pd.DataFrame(records)
+    print(f"[optimize] Baseline DataFrame: {len(df)} rows, columns={list(df.columns)}")
+
+    hook = ArizeAxHook()
+    optimization = hook.optimize_prompt(
+        prompt=_INITIAL_SYSTEM_PROMPT,
+        dataset=df,
+        output_column="output",
+        feedback_columns=[
+            "eval.llm_judge_terseness.label",
+            "eval.llm_judge_terseness.explanation",
+        ],
+        model_choice="gpt-4o",
+    )
+
+    messages = optimization.get("messages") or []
+    if not messages:
+        raise RuntimeError(
+            "Prompt Learning SDK returned no optimized messages — "
+            f"raw output: {optimization!r}"
+        )
+
+    Variable.set(_OPTIMIZED_MESSAGES_VAR, json.dumps(messages))
+    print(f"[optimize] Optimized system prompt → {messages[0].get('content', '')[:200]!r}…")
+    return optimization
+
+
+# ---------------------------------------------------------------------------
+# Summary callable
+# ---------------------------------------------------------------------------
+def _summarize_loop(**ctx) -> dict[str, Any]:
+    """Log baseline / candidate / delta and a Prompt Hub pointer."""
+    baseline_id = ctx["ti"].xcom_pull(task_ids="run_baseline_experiment")
+    candidate_id = ctx["ti"].xcom_pull(task_ids="run_candidate_experiment")
+    compare = ctx["ti"].xcom_pull(task_ids="compare_experiments") or {}
+    promoted_version_id = ctx["ti"].xcom_pull(task_ids="promote_prompt")
+    print("=" * 60)
+    print("SELF-OPTIMIZING LOOP COMPLETE")
+    print(f"  Baseline experiment id : {baseline_id}")
+    print(f"  Candidate experiment id: {candidate_id}")
+    print(f"  Comparison verdict     : {compare}")
+    print(f"  Prompt name            : {_PROMPT_NAME}")
+    print(f"  Promoted version id    : {promoted_version_id}")
+    print("  Next step              : inspect the prompt in Arize Prompt Hub.")
+    print("=" * 60)
+    return {
+        "baseline_experiment_id": baseline_id,
+        "candidate_experiment_id": candidate_id,
+        "compare": compare,
+        "prompt_name": _PROMPT_NAME,
+        "prompt_version_id": promoted_version_id,
+    }
+
+
+def _should_cleanup(**_ctx) -> bool:
+    return Variable.get("arize_ax_self_optimizing_cleanup", default_var="false").strip().lower() == "true"
+
+
+# ---------------------------------------------------------------------------
+# DAG
+# ---------------------------------------------------------------------------
+with DAG(
+    dag_id="arize_ax_self_optimizing_loop",
+    start_date=datetime(2026, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "demo", "prompt", "optimization", "self-learning"],
+    catchup=False,
+    doc_md=__doc__,
+    render_template_as_native_obj=True,
+) as dag:
+
+    check_prereqs = ShortCircuitOperator(
+        task_id="check_prereqs",
+        python_callable=_check_prereqs,
+    )
+
+    create_demo_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_demo_dataset",
+        space_id=_SPACE_JINJA,
+        name=_DATASET_NAME_TEMPLATE,
+        examples=_DEMO_EXAMPLES,
+        if_exists="skip",
+    )
+
+    create_initial_prompt = ArizeAxCreatePromptOperator(
+        task_id="create_initial_prompt",
+        space_id=_SPACE_JINJA,
+        name=_PROMPT_NAME,
+        messages=[{"role": "system", "content": _INITIAL_SYSTEM_PROMPT}],
+        model="gpt-4o-mini",
+        commit_message="initial verbose starter prompt (deliberately broken for terse Q&A)",
+        if_exists="skip",
+    )
+
+    run_baseline_experiment = ArizeAxRunExperimentOperator(
+        task_id="run_baseline_experiment",
+        name="self-optimizing-baseline-{{ ts_nodash }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_demo_dataset') }}",
+        task=baseline_task,
+        evaluators=[llm_judge_terseness],
+        concurrency=4,
+    )
+
+    optimize_and_store = PythonOperator(
+        task_id="optimize_and_store",
+        python_callable=_optimize_and_store,
+    )
+
+    # Reuse ArizeAxCreatePromptOperator with ``if_exists="add_version"``:
+    # when the prompt name already exists, the operator catches the 409,
+    # resolves the existing prompt_id, and pushes the new messages as a
+    # fresh version (visible in Prompt Hub as v2 alongside the original).
+    push_optimized_prompt = ArizeAxCreatePromptOperator(
+        task_id="push_optimized_prompt",
+        space_id=_SPACE_JINJA,
+        name=_PROMPT_NAME,
+        messages_task_id="optimize_and_store",
+        messages_key="messages",
+        model="gpt-4o-mini",
+        commit_message="optimized via Prompt Learning SDK from baseline feedback ({{ ts_nodash }})",
+        if_exists="add_version",
+    )
+
+    run_candidate_experiment = ArizeAxRunExperimentOperator(
+        task_id="run_candidate_experiment",
+        name="self-optimizing-candidate-{{ ts_nodash }}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_demo_dataset') }}",
+        task=candidate_task,
+        evaluators=[llm_judge_terseness],
+        concurrency=4,
+    )
+
+    compare_experiments = ArizeAxCompareExperimentsOperator(
+        task_id="compare_experiments",
+        candidate_experiment_id="{{ ti.xcom_pull(task_ids='run_candidate_experiment') }}",
+        baseline_experiment_id="{{ ti.xcom_pull(task_ids='run_baseline_experiment') }}",
+        metric_names=["llm_judge_terseness"],
+        pass_threshold=0.0,
+        fail_on_regression=True,
+    )
+
+    promote_prompt = ArizeAxPromotePromptOperator(
+        task_id="promote_prompt",
+        prompt_name=_PROMPT_NAME,
+        label="production",
+        space_id=_SPACE_JINJA,
+    )
+
+    summarize_loop = PythonOperator(
+        task_id="summarize_loop",
+        python_callable=_summarize_loop,
+    )
+
+    should_cleanup = ShortCircuitOperator(
+        task_id="should_cleanup",
+        python_callable=_should_cleanup,
+        trigger_rule="all_done",
+    )
+
+    cleanup_dataset = ArizeAxDeleteDatasetOperator(
+        task_id="cleanup_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_demo_dataset') }}",
+        ignore_if_missing=True,
+    )
+
+    # Wiring
+    check_prereqs >> create_demo_dataset >> create_initial_prompt
+    create_initial_prompt >> run_baseline_experiment >> optimize_and_store
+    optimize_and_store >> push_optimized_prompt >> run_candidate_experiment
+    run_candidate_experiment >> compare_experiments >> promote_prompt
+    promote_prompt >> summarize_loop >> should_cleanup >> cleanup_dataset

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_tasks_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_tasks_dag.py
@@ -71,12 +71,6 @@ from typing import Any
 
 from airflow import DAG
 from airflow.models import Variable
-
-try:
-    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
-except ImportError:
-    from airflow.operators.python import PythonOperator, ShortCircuitOperator
-
 from airflow.providers.arize_ax.operators.evaluators import (
     ArizeAxCreateEvaluatorOperator,
     ArizeAxDeleteEvaluatorOperator,
@@ -87,6 +81,7 @@ from airflow.providers.arize_ax.operators.tasks import (
     ArizeAxTriggerTaskRunOperator,
 )
 from airflow.providers.arize_ax.sensors.arize_ax import ArizeAxTaskRunSensor
+from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 
 # Optional Airflow Variable ``arize_ax_project_name`` targets a specific
 # project by name (e.g. "langraph-financial-agent-trace"); falls back to the


### PR DESCRIPTION
Follow-up to #51.

## Summary
- Add `example_arize_ax_e2e_dag.py` — self-contained end-to-end smoke test exercising ~70 operators and 7 sensors against per-run isolated resources.
- Add `example_arize_ax_self_optimizing_loop_dag.py` — closed-loop prompt improvement demo: baseline experiment → optimize via Prompt Learning SDK → gate on LLM-as-judge → promote on win.
- Drop the legacy Airflow 2.x `ImportError` fallbacks across 14 DAGs (`standard.operators.python`, `standard.sensors.time_delta`, `task.trigger_rule`) — the provider now requires the modern import paths.
- `prompt_optimization_with_feedback`: clarify `create_optimized_prompt` uniqueness via `group_key` + date and document the `if_exists="skip"` vs `"add_version"` tradeoff.
- README: bump DAG count to 21, refresh install instructions for `prompt-learning-enhanced` (git install replacing the now-removed `[prompt_learning]` extra), add `e2e` + `self_optimizing_loop` entries to the per-DAG Variables and pattern → DAG tables.

## Test plan
- [ ] `python -c "import ast; ast.parse(open(f).read())"` passes for all 21 files
- [ ] Install `arize-ax-airflow-provider` in a local Airflow environment and confirm both new DAGs appear in the UI without import errors
- [ ] Trigger `arize_ax_e2e_full_provider_test` against a test space and verify all phases pass (with `arize_ai_integration_id` set for LLM-gated phases)
- [ ] Trigger `arize_ax_self_optimizing_loop` with `OPENAI_API_KEY` + `prompt-learning-enhanced` installed and verify the candidate scores higher than the baseline and gets promoted
- [ ] Confirm the 14 cleaned-up DAGs still load on Airflow 3.x (modern import paths only)