### PR TITLE
Add cloud-export DAG, harden e2e DAG, cross-link self-optimizing loop

### DIFF
--- a/python/cookbooks/airflow_example_dags/example_arize_ax_cloud_export_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_cloud_export_dag.py
@@ -1,0 +1,322 @@
+"""Cloud-Export + Round-Trip demo: spans → cloud → dataset, on S3 / GCS / ABFS.
+
+This DAG demonstrates both halves of the cloud-storage support:
+
+* **Write-side (Phase 1)** — write-side operators accept ``path`` /
+  ``output_path`` as either a local filesystem path or a remote URI
+  (``s3://``, ``gs://``, ``gcs://``, ``abfs://``, ``az://``, ``azure://``).
+  Remote URIs are streamed through ``fsspec`` after the SDK writes
+  locally — multipart upload + parallel transfers are handled transparently
+  by the protocol-specific backend (``s3fs``, ``gcsfs``, ``adlfs``).
+* **Read-side (Phase 2)** — read-side operators accept the same URI shapes
+  for ``examples_path`` / ``experiment_runs_path``. They download via
+  ``fsspec`` to a temp file (when the SDK cannot consume a URI directly)
+  or pass the URI through to pandas' native fsspec layer (for CSV /
+  parquet). Both halves accept ``storage_options`` (inline dict) or
+  ``cloud_conn_id`` (Airflow Connection) — the latter is idiomatic for
+  production where credentials live in Airflow's encrypted Connection
+  store.
+
+Pipeline (6 stages)::
+
+    check_prereqs           (ShortCircuit — Variables + project_id set)
+        │
+        ▼
+    resolve_storage_options (PythonOperator — Variable → dict)
+        │
+        ▼
+    export_spans_to_cloud   (ArizeAxSpansExportToParquetOperator, path="s3://...")
+        │
+        ▼
+    verify_object_landed    (PythonOperator — reads parquet back via fsspec)
+        │
+        ▼
+    stage_dataset_examples  (PythonOperator — converts spans parquet → examples JSON in cloud)
+        │
+        ▼
+    load_dataset_from_cloud (ArizeAxCreateDatasetOperator, examples_path="s3://...")
+        │
+        ▼
+    log_summary             (PythonOperator — prints row count + dataset ID)
+
+Required Airflow Variables
+--------------------------
+- ``arize_ax_project_name`` — name of the Arize project to export spans from
+  (e.g. ``"live-fin-langgraph"`` or ``"my-llm-app"``). Use a project NAME,
+  not the base64 project ID — ``ArizeAxSpansExportToParquetOperator`` looks
+  the export endpoint up by name.
+- ``arize_ax_cloud_target_prefix`` — scheme + bucket / container as a
+  plain string, no Jinja inside. Examples::
+
+      s3://demo-bucket
+      gs://demo-bucket
+      abfs://demo-container
+
+  The DAG composes the full URI inline as
+  ``{prefix}/spans-{{ ds_nodash }}.parquet`` so the date partition
+  actually renders. **Do not** include any Jinja syntax inside the
+  Variable value — Airflow does not recursively render templates that
+  live inside a Variable (it expands ``{{ var.value.* }}`` once and
+  stops). Fixed strings are fine; templates stored inside a Variable
+  land literally in the output. Keep configuration in the Variable;
+  keep templating in the DAG.
+- ``arize_ax_cloud_storage_options`` — JSON dict of credentials/endpoint
+  overrides for the target backend. Examples:
+
+  S3 (real AWS)::
+
+      {"key": "<AWS_ACCESS_KEY_ID>", "secret": "<AWS_SECRET_ACCESS_KEY>"}
+
+  MinIO (local, no cloud account)::
+
+      {"key": "minioadmin", "secret": "minioadmin",
+       "client_kwargs": {"endpoint_url": "http://minio:9000"}}
+
+  GCS (service account JSON loaded by gcsfs)::
+
+      {"token": "/path/to/service-account.json"}
+
+  Azure (account key)::
+
+      {"account_name": "myaccount", "account_key": "<KEY>"}
+
+Local testing without any cloud account
+---------------------------------------
+Spin up MinIO standalone (S3-API-compatible) and target it from the DAG:
+
+::
+
+    docker run -d --name minio -p 9000:9000 -p 9001:9001 \\
+      -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \\
+      minio/minio server /data --console-address ":9001"
+
+Then set Variables (full prefix with scheme, but no Jinja)::
+
+    arize_ax_cloud_target_prefix = s3://airflow-demo
+    arize_ax_cloud_storage_options = {
+      "key": "minioadmin",
+      "secret": "minioadmin",
+      "client_kwargs": {"endpoint_url": "http://host.docker.internal:9000"}
+    }
+
+Browse uploaded objects at http://localhost:9001 (minioadmin / minioadmin).
+
+The same DAG covers GCS (fake-gcs-server) and Azure (azurite) by swapping
+the prefix + storage_options::
+
+    # GCS via fake-gcs-server
+    arize_ax_cloud_target_prefix = gs://airflow-demo
+    arize_ax_cloud_storage_options = {
+      "token": "anon",
+      "endpoint_url": "http://host.docker.internal:4443"
+    }
+
+    # Azure via azurite (devstoreaccount1 is the default emulator account)
+    arize_ax_cloud_target_prefix = abfs://airflow-demo
+    arize_ax_cloud_storage_options = {
+      "account_name": "devstoreaccount1",
+      "account_key": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
+      "connection_string": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://host.docker.internal:10000/devstoreaccount1;"
+    }
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+from airflow import DAG
+from airflow.models import Variable
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
+except ImportError:
+    from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+from airflow.providers.arize_ax.operators.datasets import ArizeAxCreateDatasetOperator
+from airflow.providers.arize_ax.operators.spans import ArizeAxSpansExportToParquetOperator
+
+_SPACE_JINJA = "{{ var.value.get('arize_ax_space_id', '') or None }}"
+
+
+def _check_prereqs(**_ctx) -> bool:
+    project_name = Variable.get("arize_ax_project_name", default_var="").strip()
+    prefix = Variable.get("arize_ax_cloud_target_prefix", default_var="").strip()
+    if not project_name:
+        print("Variable arize_ax_project_name is not set — skipping demo.")
+        return False
+    if not prefix:
+        print("Variable arize_ax_cloud_target_prefix is not set — skipping demo.")
+        return False
+    if not prefix.startswith(("s3://", "gs://", "gcs://", "abfs://", "az://", "azure://")):
+        print(
+            f"Variable arize_ax_cloud_target_prefix must include a scheme "
+            f"(e.g. 's3://demo-bucket' or 'gs://demo-bucket'); got {prefix!r}."
+        )
+        return False
+    if "{{" in prefix or "}}" in prefix:
+        print(
+            f"Variable arize_ax_cloud_target_prefix contains Jinja syntax — "
+            f"Airflow does not recursively render templates inside Variable "
+            f"values. Store a plain prefix and let the DAG compose the key. "
+            f"Got {prefix!r}."
+        )
+        return False
+    return True
+
+
+def _resolve_storage_options(**_ctx) -> dict[str, Any] | None:
+    raw = Variable.get("arize_ax_cloud_storage_options", default_var=None)
+    if not raw:
+        return None
+    return json.loads(raw)
+
+
+def _verify_object_landed(**ctx) -> dict[str, Any]:
+    """Read the parquet back through fsspec to confirm the upload succeeded."""
+    target_uri = ctx["ti"].xcom_pull(task_ids="export_spans_to_cloud")
+    storage_options = json.loads(
+        Variable.get("arize_ax_cloud_storage_options", default_var="null")
+    )
+    import fsspec
+    import pandas as pd
+
+    with fsspec.open(target_uri, "rb", **(storage_options or {})) as fh:
+        df = pd.read_parquet(fh)
+    row_count = len(df)
+    columns = list(df.columns)
+    print(f"[verify] Read back {row_count} rows from {target_uri}")
+    print(f"[verify] Columns: {columns[:10]}{'…' if len(columns) > 10 else ''}")
+    return {"uri": target_uri, "row_count": row_count, "columns": columns}
+
+
+def _stage_dataset_examples(**ctx) -> str:
+    """Convert the spans parquet → a small examples JSON file, also in cloud storage.
+
+    This demonstrates the canonical "stage objects in cloud, then ingest"
+    pattern used by Snowflake / Databricks / BigQuery integrations: the
+    spans land in the bucket as parquet, then a follow-up task projects
+    the columns we want into a dataset-ready JSON object next to the
+    original — also in the bucket. The downstream
+    ``ArizeAxCreateDatasetOperator`` reads the object back via
+    ``examples_path="<uri>"`` + ``storage_options`` without any local
+    download in the DAG code.
+    """
+    spans_uri = ctx["ti"].xcom_pull(task_ids="export_spans_to_cloud")
+    storage_options = ctx["ti"].xcom_pull(task_ids="resolve_storage_options") or None
+    import fsspec
+    import pandas as pd
+
+    with fsspec.open(spans_uri, "rb", **(storage_options or {})) as fh:
+        df = pd.read_parquet(fh)
+    # Project a few common columns into dataset-example shape. Any columns
+    # missing on a given project are silently dropped — the demo only needs
+    # one or two rows to exercise the read-side cloud routing.
+    candidate_cols = [
+        "attributes.input.value", "input.value", "input",
+        "attributes.output.value", "output.value", "output",
+    ]
+    keep = [c for c in candidate_cols if c in df.columns]
+    sample = df[keep].head(5) if keep else df.head(5)
+    examples = [{"input": str(v) for k, v in row.items() if "input" in k.lower()} or {"input": ""}
+                for row in sample.to_dict(orient="records")]
+    if not examples:
+        # Fallback so the demo still produces a non-empty dataset payload.
+        examples = [{"input": "demo-only example (no input column found in spans)"}]
+
+    examples_uri = spans_uri.rsplit("/", 1)[0] + "/examples-" + ctx["ds_nodash"] + ".json"
+    with fsspec.open(examples_uri, "wb", **(storage_options or {})) as fh:
+        import json as _json
+        fh.write(_json.dumps(examples).encode("utf-8"))
+    print(f"[stage] Wrote {len(examples)} examples to {examples_uri}")
+    return examples_uri
+
+
+def _log_summary(**ctx) -> None:
+    export = ctx["ti"].xcom_pull(task_ids="export_spans_to_cloud", key="result") or {}
+    verify = ctx["ti"].xcom_pull(task_ids="verify_object_landed") or {}
+    examples_uri = ctx["ti"].xcom_pull(task_ids="stage_dataset_examples")
+    dataset_id = ctx["ti"].xcom_pull(task_ids="load_dataset_from_cloud")
+    print("=" * 60)
+    print("CLOUD ROUND-TRIP COMPLETE")
+    print(f"  Spans parquet : {export.get('path')}")
+    print(f"  Wrote         : {export.get('wrote')}")
+    print(f"  Rows read back: {verify.get('row_count')}")
+    print(f"  Examples URI  : {examples_uri}")
+    print(f"  Dataset ID    : {dataset_id}")
+    print("  Inspect the object in your cloud console (AWS, GCS, Azure, or MinIO).")
+    print("=" * 60)
+
+
+with DAG(
+    dag_id="arize_ax_cloud_export_demo",
+    start_date=datetime(2026, 1, 1),
+    schedule=None,
+    tags=["arize_ax", "demo", "spans", "cloud", "fsspec"],
+    catchup=False,
+    doc_md=__doc__,
+    render_template_as_native_obj=True,
+) as dag:
+
+    check_prereqs = ShortCircuitOperator(
+        task_id="check_prereqs",
+        python_callable=_check_prereqs,
+    )
+
+    resolve_storage_options = PythonOperator(
+        task_id="resolve_storage_options",
+        python_callable=_resolve_storage_options,
+    )
+
+    # The same operator handles local AND remote paths — only ``path`` and
+    # ``storage_options`` change between modes. ``storage_options`` is a real
+    # template_field so it can flow from upstream XCom like any other kwarg.
+    # The full URI is composed from the bucket Variable (just the bucket
+    # name) plus the date partition. Composing it here in the DAG (rather
+    # than storing it in the Variable) ensures Jinja actually renders the
+    # date — Airflow does not recursively expand templates that live
+    # inside a Variable's value.
+    export_spans_to_cloud = ArizeAxSpansExportToParquetOperator(
+        task_id="export_spans_to_cloud",
+        space_id=_SPACE_JINJA,
+        project_name="{{ var.value.arize_ax_project_name }}",
+        start_time="{{ (logical_date - macros.timedelta(days=1)).isoformat() }}",
+        end_time="{{ logical_date.isoformat() }}",
+        path="{{ var.value.arize_ax_cloud_target_prefix }}/spans-{{ ds_nodash }}.parquet",
+        storage_options="{{ ti.xcom_pull(task_ids='resolve_storage_options') }}",
+    )
+
+    verify_object_landed = PythonOperator(
+        task_id="verify_object_landed",
+        python_callable=_verify_object_landed,
+    )
+
+    stage_dataset_examples = PythonOperator(
+        task_id="stage_dataset_examples",
+        python_callable=_stage_dataset_examples,
+    )
+
+    # Read-side cloud routing: the operator downloads the staged JSON via
+    # fsspec (or, for CSV, passes the URI straight to pandas), parses it,
+    # and creates a dataset. ``cloud_conn_id`` would be the production
+    # equivalent of inline ``storage_options`` — point at any Airflow
+    # AWS / GCP / WASB Connection and the resolver maps it onto fsspec
+    # kwargs automatically.
+    load_dataset_from_cloud = ArizeAxCreateDatasetOperator(
+        task_id="load_dataset_from_cloud",
+        space_id=_SPACE_JINJA,
+        name="cloud-round-trip-{{ ds_nodash }}",
+        examples_path="{{ ti.xcom_pull(task_ids='stage_dataset_examples') }}",
+        storage_options="{{ ti.xcom_pull(task_ids='resolve_storage_options') }}",
+        if_exists="skip",
+    )
+
+    log_summary = PythonOperator(
+        task_id="log_summary",
+        python_callable=_log_summary,
+    )
+
+    check_prereqs >> resolve_storage_options >> export_spans_to_cloud
+    export_spans_to_cloud >> verify_object_landed >> stage_dataset_examples
+    stage_dataset_examples >> load_dataset_from_cloud >> log_summary

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_e2e_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_e2e_dag.py
@@ -79,6 +79,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from airflow import DAG
+from airflow.providers.arize_ax.hooks.arize_ax import ArizeAxHook
 from airflow.providers.arize_ax.operators.ai_integrations import (
     ArizeAxCreateAIIntegrationOperator,
     ArizeAxDeleteAIIntegrationOperator,
@@ -185,6 +186,9 @@ from airflow.providers.arize_ax.sensors.arize_ax import (
     ArizeAxSpanCountSensor,
     ArizeAxSpanIngestionSensor,
     ArizeAxTaskRunSensor,
+)
+from airflow.providers.arize_ax.utils.task_groups import (
+    arize_ax_chained_experiment_eval,
 )
 from airflow.providers.standard.operators.python import (
     PythonOperator,
@@ -308,31 +312,48 @@ def _make_xcom_present_gate(*, task_ids: str, key: str | None = None) -> Any:
     return _gate
 
 
-def _build_run_configuration(**ctx) -> Any:
-    """Build a ``RunConfiguration`` for CreateRunExperimentTask using the
-    configured AI-integration Airflow Variable. Pushed to XCom so the
-    downstream operator can pull it.
-    """
-    from arize.tasks.types import LlmGenerationRunConfig, RunConfiguration
+def _build_run_configuration(integration_id: str | None = None, **ctx) -> dict[str, Any]:
+    """Build a run configuration dict for CreateRunExperimentTask.
 
-    integration_id = _get_first_var(
+    Resolution order for the AI integration:
+      1. The ``arize_ai_integration_id`` Airflow Variable (preferred). This
+         is expected to point at an integration with a REAL API key so the
+         LLM-generation step can actually call the provider.
+      2. Fallback: the freshly-created ``create_ai_integration`` integration
+         passed via ``op_kwargs``. **Note**: the DAG creates that fresh
+         integration with a *dummy* API key (``sk-e2e-dummy-do-not-use``)
+         to exercise the create/get/delete lifecycle without leaking real
+         credentials, so a run_experiment using it will fail at the LLM
+         call. Only used here when the Variable isn't set.
+
+    Returns the LlmGenerationRunConfig-shaped dict directly. The hook layer
+    calls ``RunConfiguration.from_dict`` for the typed wrapping internally
+    (SDK 8.27+), so user code doesn't need to import the typed model.
+    """
+    var_integration_id = _get_first_var(
         "arize_ai_integration_id", "ARIZE_AI_INTEGRATION_ID",
     )
+    if var_integration_id:
+        integration_id = var_integration_id
     if not integration_id:
         raise RuntimeError(
-            "AI-integration Variable required for this task "
-            "(set 'arize_ai_integration_id' or 'ARIZE_AI_INTEGRATION_ID')."
+            "build_run_config: an AI-integration ID is required. Either let "
+            "the DAG create one via 'create_ai_integration' (it is wired up "
+            "automatically), or set the 'arize_ai_integration_id' Airflow "
+            "Variable."
         )
-    llm_cfg = LlmGenerationRunConfig(
-        experiment_type="llm_generation",
-        ai_integration_id=integration_id,
-        model_name="gpt-4o-mini",
-        messages=[{"role": "user", "content": "Echo: {query}"}],
-        input_variable_format="f_string",
-        invocation_parameters={"temperature": 0},
-        provider_parameters={},
-    )
-    return RunConfiguration(llm_cfg).model_dump(mode="json")
+    # Use mustache + double-brace substitution for the run_experiment
+    # template — produces real LLM output (single-brace / f_string can
+    # leave the placeholder unsubstituted depending on backend handling).
+    return {
+        "experiment_type": "llm_generation",
+        "ai_integration_id": integration_id,
+        "model_name": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "Echo: {{query}}"}],
+        "input_variable_format": "mustache",
+        "invocation_parameters": {"temperature": 0},
+        "provider_parameters": {},
+    }
 
 
 def _build_evaluator_template_config(**ctx) -> dict[str, Any]:
@@ -348,8 +369,13 @@ def _build_evaluator_template_config(**ctx) -> dict[str, Any]:
     suffix = (ctx.get("ts_nodash") or "x")[-8:]
     return {
         "name": f"e2e_eval_{suffix}",
+        # Template variables must match the experiment run's input column
+        # names. This DAG's dataset uses ``query`` (the dataset's input
+        # column) — referencing ``{input}`` here would fail substitution
+        # with "Task was unable to handle template variable: input".
+        # ``{output}`` is the LLM's output and is always available.
         "template": (
-            "Evaluate the response. Input: {input}\nOutput: {output}\n"
+            "Evaluate the response. Input: {query}\nOutput: {output}\n"
             "Respond with JSON label correct or incorrect."
         ),
         "include_explanations": False,
@@ -433,7 +459,18 @@ def _inspection_pause(**ctx) -> None:
 
 
 INSPECTION_WINDOW_MINUTES = 15
-SPACE_ID = "{{ ti.xcom_pull(task_ids='list_spaces', key='first_id') }}"
+# Prefer the user-configured ``arize_ax_space_id`` Airflow Variable so the
+# e2e DAG operates in the space the operator was wired against (where the
+# user's AI integration, datasets, projects, etc. live). Fall back to the
+# first space returned by ``list_spaces`` only if the Variable is unset —
+# convenient for first-time setup but historically a footgun, since
+# ``list_spaces.first_id`` can resolve to a different space than the one
+# the user has configured elsewhere, leading to cross-space "AI integration
+# not found" / "no spans" surprises.
+SPACE_ID = (
+    "{{ var.value.get('arize_ax_space_id', '') "
+    "or ti.xcom_pull(task_ids='list_spaces', key='first_id') }}"
+)
 
 
 with DAG(
@@ -877,10 +914,103 @@ with DAG(
         run_id="{{ ti.xcom_pull(task_ids='trigger_task_run') }}",
     )
 
+    def _log_synthetic_spans(**ctx) -> int:
+        """Push a tiny set of OpenInference-shaped spans into the fresh
+        project so that ``trigger_task_run`` (span-scoped template_evaluation)
+        has data to evaluate.
+
+        Without this, the freshly-created project has 0 spans and the eval
+        trigger fires ``skip_on_no_data=True`` → cascade-skip on
+        ``task_run_sensor`` / ``get_task_run`` / ``cancel_task_run``.
+
+        Uses ``hook.log_spans`` (which hits ``client.spans.log``) with a
+        minimal OpenInference parent-span shape.
+        """
+        import time
+        from datetime import datetime, timezone
+
+        import pandas as pd
+
+        ti = ctx["ti"]
+        project_name = "e2e-proj-" + ctx["ts_nodash"]
+        space_id = (
+            ti.xcom_pull(task_ids="list_spaces", key="first_id")
+            or ctx["dag_run"].conf.get("space_id")
+        )
+        # Try the Variable first (matches the DAG's SPACE_ID resolution).
+        try:
+            from airflow.models import Variable
+            space_var = Variable.get("arize_ax_space_id", default_var=None)
+            if space_var:
+                space_id = space_var
+        except Exception:
+            pass
+
+        # Build 3 spans with the minimum OpenInference column set.
+        now_ns = int(time.time() * 1e9)
+        rows = []
+        for i in range(3):
+            rows.append({
+                "context.span_id": f"e2e-span-{ctx['ts_nodash']}-{i:03d}",
+                "context.trace_id": f"e2e-trace-{ctx['ts_nodash']}-{i:03d}",
+                "name": "smoke-eval-target",
+                "span_kind": "LLM",
+                "attributes.input.value": f"echo: hello world {i}",
+                "attributes.output.value": f"hello world {i}",
+                "attributes.openinference.span.kind": "LLM",
+                "start_time": datetime.fromtimestamp(
+                    (now_ns - 60_000_000_000 + i * 1_000_000_000) / 1e9,
+                    tz=timezone.utc,
+                ),
+                "end_time": datetime.fromtimestamp(
+                    (now_ns - 59_000_000_000 + i * 1_000_000_000) / 1e9,
+                    tz=timezone.utc,
+                ),
+                "status_code": "OK",
+            })
+        df = pd.DataFrame(rows)
+
+        hook = ArizeAxHook()
+        resp = hook.log_spans(
+            space_id=space_id,
+            project_name=project_name,
+            dataframe=df,
+        )
+        print(f"[log_synthetic_spans] logged {len(rows)} spans to '{project_name}': {resp}")
+        return len(rows)
+
+    log_synthetic_spans = PythonOperator(
+        task_id="log_synthetic_spans",
+        python_callable=_log_synthetic_spans,
+    )
+
+    # log_synthetic_spans returns 200 OK immediately, but Arize's ingestion
+    # pipeline is async (Kafka → backend → queryable store) and takes
+    # tens of seconds to minutes to make the spans visible to ``spans.list``.
+    # Best-effort: if ingestion hasn't completed in 5 minutes, soft_fail so
+    # the downstream span-scoped eval trigger skips gracefully (its own
+    # ``skip_on_no_data=True`` handles the no-data path) rather than
+    # blocking the entire DAG run on observability latency.
+    wait_for_synthetic_spans = ArizeAxSpanCountSensor(
+        task_id="wait_for_synthetic_spans",
+        project_id="{{ ti.xcom_pull(task_ids='create_project') }}",
+        min_count=1,
+        poke_interval=10,
+        timeout=300,  # up to 5 minutes for ingestion
+        mode="poke",
+        soft_fail=True,
+    )
+
     # Run-experiment task variant.
+    # Wire in the freshly-created AI integration so the run_experiment task
+    # references one that exists in the DAG's own space — the legacy
+    # path-of-reading-a-Variable can leak a cross-space integration ID.
     build_run_config = PythonOperator(
         task_id="build_run_config",
         python_callable=_build_run_configuration,
+        op_kwargs={
+            "integration_id": "{{ ti.xcom_pull(task_ids='create_ai_integration') }}",
+        },
     )
     create_run_experiment_task = ArizeAxCreateRunExperimentTaskOperator(
         task_id="create_run_experiment_task",
@@ -889,6 +1019,29 @@ with DAG(
         run_configuration="{{ ti.xcom_pull(task_ids='build_run_config') }}",
         space_id=SPACE_ID,
         if_exists="skip",
+    )
+
+    # Demonstrate server-side experiment → evaluation chaining (SDK 8.27+).
+    # Arize triggers the run_experiment task, and once it completes the listed
+    # evaluation tasks run automatically against the new spans — no extra
+    # Airflow task needed to wait + fan out. Reuses ``create_task`` (a
+    # project-scoped template_evaluation task built earlier in this DAG) so
+    # the chain has a real evaluator on the other side.
+    #
+    # Uses the ``arize_ax_chained_experiment_eval`` TaskGroup helper so DAG
+    # authors get trigger + (optional) sensor + (optional) get_result wired
+    # up in one call, instead of hand-rolling three operators. Here we keep
+    # the default ``wait_for_completion=False`` — the rest of the e2e DAG
+    # is fire-and-forget at this step.
+    trigger_chained_experiment_run = arize_ax_chained_experiment_eval(
+        group_id="trigger_chained_experiment_run",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_run_experiment_task') }}",
+        space_id=SPACE_ID,
+        experiment_name="e2e-chained-{{ ts_nodash }}",
+        max_examples=2,
+        evaluation_task_ids=[
+            "{{ ti.xcom_pull(task_ids='create_task') }}",
+        ],
     )
 
     # Phase 8 -- Annotations lifecycle
@@ -938,13 +1091,6 @@ with DAG(
         space=SPACE_ID,
         instructions="updated by e2e DAG",
     )
-    list_annotation_queue_records = ArizeAxListAnnotationQueueRecordsOperator(
-        task_id="list_annotation_queue_records",
-        annotation_queue="{{ ti.xcom_pull(task_ids='create_annotation_queue') }}",
-        space=SPACE_ID,
-        limit=5,
-    )
-
     # Manually inject a record source so AddAnnotationQueueRecords has work to do.
     add_annotation_queue_records = ArizeAxAddAnnotationQueueRecordsOperator(
         task_id="add_annotation_queue_records",
@@ -958,6 +1104,47 @@ with DAG(
                 "dataset_id": "{{ ti.xcom_pull(task_ids='create_dataset') }}",
             },
         ],
+    )
+
+    def _wait_for_annotation_queue_records(**ctx) -> int:
+        """Poll the queue until at least one record materializes.
+
+        ``add_annotation_queue_records`` returns immediately, but the backend
+        scans the dataset and adds each example as a queue record
+        asynchronously. Without this wait, ``list_annotation_queue_records``
+        races and returns an empty list, causing the entire annotate /
+        assign / delete branch to skip.
+        """
+        import time
+        ti = ctx["ti"]
+        queue_id = ti.xcom_pull(task_ids="create_annotation_queue")
+        hook = ArizeAxHook()
+        for attempt in range(20):  # 20 × 3s = up to 60s
+            try:
+                result = hook.list_annotation_queue_records(
+                    annotation_queue=queue_id, limit=10,
+                )
+                items = (result or {}).get("items") if isinstance(result, dict) else None
+                count = len(items or [])
+                if count > 0:
+                    print(f"[wait] queue has {count} record(s) after {attempt * 3}s")
+                    return count
+            except Exception as exc:  # noqa: BLE001
+                print(f"[wait] attempt {attempt} probe error: {exc}")
+            time.sleep(3)
+        print("[wait] timed out after 60s — queue still empty, downstream will skip")
+        return 0
+
+    wait_for_annotation_queue_records = PythonOperator(
+        task_id="wait_for_annotation_queue_records",
+        python_callable=_wait_for_annotation_queue_records,
+    )
+
+    list_annotation_queue_records = ArizeAxListAnnotationQueueRecordsOperator(
+        task_id="list_annotation_queue_records",
+        annotation_queue="{{ ti.xcom_pull(task_ids='create_annotation_queue') }}",
+        space=SPACE_ID,
+        limit=5,
     )
 
     annotation_queue_sensor = ArizeAxAnnotationQueueSensor(
@@ -1268,10 +1455,17 @@ with DAG(
     # Phase 7: tasks (gated, depend on evaluator + project)
     [create_evaluator, create_project] >> gate_tasks
     gate_tasks >> create_task >> [get_task, list_task_runs, update_task]
-    create_task >> trigger_task_run >> [get_task_run, task_run_sensor]
+    # Span-scoped eval trigger needs spans in the project AND those spans
+    # need to be ingested into the queryable path before the trigger fires.
+    create_project >> log_synthetic_spans >> wait_for_synthetic_spans
+    [create_task, wait_for_synthetic_spans] >> trigger_task_run >> [get_task_run, task_run_sensor]
     [trigger_task_run, task_run_sensor] >> gate_cancel_run >> cancel_task_run
-    gate_tasks >> build_run_config >> create_run_experiment_task
+    # build_run_config now consumes create_ai_integration's XCom, so we need
+    # that upstream too (in addition to gate_tasks).
+    [gate_tasks, create_ai_integration] >> build_run_config >> create_run_experiment_task
     create_dataset >> create_run_experiment_task
+    # Chained trigger needs the eval task to be created first.
+    [create_task, create_run_experiment_task] >> trigger_chained_experiment_run
 
     # Phase 8: annotations
     list_spaces >> create_annotation_config
@@ -1280,10 +1474,13 @@ with DAG(
     create_annotation_queue >> [
         get_annotation_queue,
         update_annotation_queue,
-        list_annotation_queue_records,
         add_annotation_queue_records,
         annotation_queue_sensor,
     ]
+    # Wait for the queue records to actually materialize before listing.
+    # ``add_annotation_queue_records`` is fire-and-forget on the backend.
+    add_annotation_queue_records >> wait_for_annotation_queue_records
+    wait_for_annotation_queue_records >> list_annotation_queue_records
     list_annotation_queue_records >> pick_first_queue_record >> gate_queue_records
     gate_queue_records >> [annotate_queue_record, assign_queue_record]
     [annotate_queue_record, assign_queue_record] >> delete_annotation_queue_records

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_self_optimizing_loop_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_self_optimizing_loop_dag.py
@@ -72,12 +72,10 @@ Optional Variables
   uses ``gpt-4o`` regardless.
 
 This demo runs **client-side experiments** via ``ArizeAxRunExperimentOperator``.
-Server-side (Eval Hub) execution would be cleaner but requires a separate
-``template_evaluation`` task chain per experiment because
-``LlmGenerationRunConfig`` does not accept ``evaluator_ids`` today (filed
-upstream as `Arize-ai/arize#72271 <https://github.com/Arize-ai/arize/issues/72271>`_).
-When that ships, this DAG can collapse the worker-side LLM calls in favor
-of the Eval Hub task chain.
+For a server-side (Eval Hub) variant, see ``example_arize_ax_e2e_dag.py``,
+which uses the ``arize_ax_chained_experiment_eval`` TaskGroup helper to
+trigger a ``run_experiment`` task with chained evaluation tasks via
+``evaluation_task_ids``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Follow-up to #52.

## Summary
- **New DAG: `example_arize_ax_cloud_export_dag.py`** — round-trip demo that writes spans to a cloud URI (S3 / GCS / ABFS / Azure) via `fsspec`, verifies the object landed, and loads a dataset back from the same URI. Configurable via `arize_ax_project_name`, `arize_ax_cloud_target_prefix`, and `arize_ax_cloud_storage_options` Variables (the last two cover MinIO and real cloud accounts).
- **`example_arize_ax_e2e_dag.py` hardening**:
  - Prefer the `arize_ax_space_id` Variable over `list_spaces.first_id` for `SPACE_ID`, avoiding cross-space surprises when the user's AI integration / datasets live in a different space than the first one returned.
  - `_build_run_configuration` now returns a plain dict (hook layer wraps it via `RunConfiguration.from_dict` on SDK 8.27+) and falls back to the freshly-created AI integration when the `arize_ai_integration_id` Variable is unset.
  - Switch the LLM-generation template to mustache + double-brace substitution so `{{query}}` actually renders.
  - Fix the evaluator template variable from `{input}` to `{query}` to match the dataset's input column.
  - Add a `log_synthetic_spans` task that pushes three OpenInference-shaped spans into the fresh project so the span-scoped `trigger_task_run` has data to evaluate (without this the eval cascade-skipped).
- **`example_arize_ax_self_optimizing_loop_dag.py`**: drop the now-obsolete note about the upstream `evaluator_ids` issue and point readers at the e2e DAG for the server-side Eval Hub chained-eval pattern via `arize_ax_chained_experiment_eval`.

## Test plan
- [ ] `python -c "import ast; ast.parse(open(f).read())"` passes for all three changed files
- [ ] Trigger `arize_ax_e2e_full_provider_test` end-to-end against a test space with `arize_ax_space_id` + `arize_ai_integration_id` set; verify the LLM-evaluator + task lifecycle + span ingestion phases all succeed (no cascade-skips on `task_run_sensor`)
- [ ] Trigger `arize_ax_cloud_export_demo` against MinIO with `arize_ax_cloud_target_prefix=s3://<bucket>` and verify the parquet lands, is read back, and a dataset is created from the cloud URI
- [ ] Repeat against real S3 / GCS / Azure storage with credentialed `arize_ax_cloud_storage_options`