### PR TITLE
Migrate gate / lifecycle / drift / RAG / matrix DAGs to Eval Hub

### DIFF
--- a/python/cookbooks/airflow_example_dags/README.md
+++ b/python/cookbooks/airflow_example_dags/README.md
@@ -1,10 +1,10 @@
 # Arize AX Airflow Example DAGs
 
-A collection of 21 example DAGs demonstrating the [`arize-ax-airflow-provider`](https://github.com/Arize-ai/arize-ax-airflow) — the official Apache Airflow provider for [Arize AX](https://arize.com/docs/ax/).
+A collection of 22 example DAGs demonstrating the [`arize-ax-airflow-provider`](https://github.com/Arize-ai/arize-ax-airflow) — the official Apache Airflow provider for [Arize AX](https://arize.com/docs/ax/).
 
-Each DAG illustrates a real LLMOps workflow you can adapt for your own pipelines: CI/CD evaluation gates, prompt lifecycle management, drift detection with auto-rollback, RAG evaluation, dataset curation from production traces, fine-tuning data pipelines, behavioral regression checks, evaluator calibration, self-optimizing prompt loops, and more.
+Each DAG illustrates a real LLMOps workflow you can adapt for your own pipelines: CI/CD evaluation gates, prompt lifecycle management, drift detection with auto-rollback, RAG evaluation, dataset curation from production traces, fine-tuning data pipelines, behavioral regression checks, evaluator calibration, self-optimizing prompt loops, cloud-storage round-trips, and more.
 
-> **Last Updated:** 2026-05-18
+> **Last Updated:** 2026-05-21
 
 ---
 
@@ -72,9 +72,13 @@ The DAGs read configuration from Airflow Variables so you can run them without e
 
 ### Common (used by most DAGs)
 
+Most DAGs run their evaluation tasks via **Arize Eval Hub** (server-side execution) rather than calling LLMs from Airflow workers. That means you'll typically need a configured AI Integration in Arize and a project to scope the eval tasks to:
+
 | Variable | Required | Default | Purpose |
 |---|---|---|---|
 | `arize_ax_space_id` | If not set in connection Extra | — | Target Arize space (global ID or name) |
+| `arize_ai_integration_id` (or env var `ARIZE_AI_INTEGRATION_ID`) | ✅ for any DAG running Eval Hub tasks | — | UUID of an AI Integration in Arize (Settings → AI Integrations) configured with a real provider API key. Used by `experiment_dag`, `llm_cicd_gate_dag`, `llm_experiments_dag`, `prompt_lifecycle_dag`, `drift_detection_dag`, `rag_evaluation_dag`, `self_optimizing_loop_dag`, `tasks_dag`, `evaluators_dag` |
+| `arize_ax_project_id` | ✅ for any DAG running Eval Hub tasks | — | Project ID used to scope evaluation tasks. Required by the same DAGs as `arize_ai_integration_id` above |
 
 ### Per-DAG
 
@@ -83,19 +87,15 @@ The DAGs read configuration from Airflow Variables so you can run them without e
 | `annotation_queues_dag` | `arize_annotator_email` | ✅ | Comma-separated reviewer email(s), e.g. `alice@example.com,bob@example.com` |
 | `annotation_queues_dag` | `arize_queue_name` | optional | Demo queue name (default: `airflow-demo-queue`) |
 | `dataset_curation_dag` | `arize_ax_dataset_id` | ✅ | Target dataset to append curated examples to |
-| `drift_detection_dag` | `arize_ax_baseline_experiment_id` | ✅ | Baseline experiment for drift comparison |
-| `drift_detection_dag` | `arize_ax_candidate_experiment_id` | ✅ | Candidate experiment for drift comparison |
-| `llm_cicd_gate_dag` | `arize_ax_baseline_experiment_id` | ✅ | Baseline to gate releases against |
-| `llm_cicd_gate_dag` | `arize_ax_prompt_name` | optional | Prompt to promote on gate-pass; unset = gate-only mode (no promotion) |
-| `llm_cicd_gate_dag` | `arize_ax_prompt_label` | optional | Label applied to the promoted prompt version (default: `production`) |
-| `prompt_lifecycle_dag` | `arize_ax_prompt_name` | ✅ | Prompt to promote staging → production |
 | `prompt_ab_test_dag` | `arize_ax_prompt_names` | optional | JSON list or CSV of prompt names to compare |
 | `prompt_optimization_with_feedback_dag` | `arize_ax_lookback_days` | optional | Days of production feedback to learn from |
-| `tasks_dag` / `evaluators_dag` | `ARIZE_AI_INTEGRATION_ID`, `ARIZE_EVALUATOR_MODEL` | ✅ | OpenAI/Anthropic integration UUID + model name for LLM-as-judge |
-| `e2e_dag` | `arize_ai_integration_id` | optional | Enables LLM evaluator + task lifecycle phases (skipped when unset) |
+| `tasks_dag` / `evaluators_dag` | `ARIZE_EVALUATOR_MODEL` | ✅ | Model name used by the LLM-as-judge (e.g. `gpt-4o`, `claude-sonnet-4-5`) |
 | `e2e_dag` | `arize_annotator_email` | optional | Enables the annotation-queue lifecycle phase |
 | `self_optimizing_loop_dag` | `arize_ax_self_optimizing_model` | optional | OpenAI model used by experiment tasks (default `gpt-4o-mini`) |
 | `self_optimizing_loop_dag` | `arize_ax_self_optimizing_cleanup` | optional | Set to `"true"` to delete the demo dataset on DAG completion (default `"false"`) |
+| `cloud_export_dag` | `arize_ax_project_name` | ✅ | Name of the Arize project to export spans from (project name, not base64 ID) |
+| `cloud_export_dag` | `arize_ax_cloud_target_prefix` | ✅ | Scheme + bucket / container, e.g. `s3://demo-bucket`, `gs://demo-bucket`, `abfs://demo-container` |
+| `cloud_export_dag` | `arize_ax_cloud_storage_options` | ✅ | JSON dict of credentials / endpoint overrides for the target backend (AWS keys, MinIO endpoint, GCS service-account path, Azure account key) |
 
 The required values are documented in each DAG's module docstring — open the file and check the `**Required**` / `**Optional Airflow Variables**` sections.
 
@@ -115,7 +115,7 @@ Or symlink the directory so updates propagate:
 ln -s "$(pwd)/python/cookbooks/airflow_example_dags" $AIRFLOW_HOME/dags/arize_ax_examples
 ```
 
-Refresh the Airflow UI — all 21 DAGs should appear under the `arize_ax` tag.
+Refresh the Airflow UI — all 22 DAGs should appear under the `arize_ax` tag.
 
 ---
 
@@ -150,6 +150,7 @@ From there, work up to the workflow that matches your use case. The table below 
 | Self-learning prompt optimization | `example_arize_ax_prompt_optimization_with_feedback_dag.py` |
 | Self-optimizing prompt loop (baseline → optimize → gate → promote) | `example_arize_ax_self_optimizing_loop_dag.py` |
 | End-to-end provider smoke test (~70 operators, 7 sensors) | `example_arize_ax_e2e_dag.py` |
+| Cloud-storage round-trip (spans → S3/GCS/ABFS → dataset) | `example_arize_ax_cloud_export_dag.py` |
 | Inventory / admin (list spaces, projects) | `example_arize_ax_admin_dag.py` |
 | Span export & metrics | `example_arize_ax_spans_dag.py` |
 | Custom evaluator creation | `example_arize_ax_evaluators_dag.py` |

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_drift_detection_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_drift_detection_dag.py
@@ -1,52 +1,59 @@
 """
-Drift Detection & Auto-Rollback DAG: scheduled evaluation watchdog with prompt
-rollback when drift is detected.
+Drift Detection & Auto-Rollback DAG (server-side, self-contained).
 
-This DAG runs daily to guard against degradation in LLM evaluation scores.  It
-creates a fresh "current" experiment, waits for it to complete, then compares
-it against a known-good baseline experiment.  When drift is detected the
-ArizeAxDetectEvalDriftOperator raises AirflowException (``fail_on_drift=True``)
-causing the task to fail (red), making the drift event visible and preventing
-downstream promotion.  A separate ``rollback_prompt`` branch is triggered by
-catching the failure with an Airflow trigger rule, or can be wired as a
-separate monitoring pipeline.
+This DAG demonstrates the production watchdog pattern: a scheduled run
+provisions a *baseline* experiment (a strong known-good config), then runs
+a *current* experiment with a deliberately-degraded system prompt to make
+drift actually fire. ``ArizeAxDetectEvalDriftOperator`` (with
+``fail_on_drift=True``) raises ``AirflowException`` when the per-metric
+delta exceeds the threshold, which triggers the rollback branch
+(``trigger_rule="all_failed"``): the stable prompt version is re-promoted
+to the ``"production"`` label, and a notification fires. Everything is
+provisioned and torn down on every run — no external Variables required.
 
 Pipeline stages
 ---------------
-1. **run_current_eval** — run a daily evaluation experiment against a shared
-   eval dataset (ArizeAxRunExperimentOperator).
-2. **wait_for_current** — block until the experiment has enough completed runs
-   (ArizeAxExperimentRunCountSensor).
-3. **detect_drift** — compare the current experiment against the configured
-   baseline and raise AirflowException if drift is found
-   (ArizeAxDetectEvalDriftOperator with ``fail_on_drift=True``).
-4. **rollback_prompt** — re-promote the known-stable prompt version to the
-   ``"production"`` label (ArizeAxPromotePromptOperator).  Runs only when
-   detect_drift fails, via ``trigger_rule="all_failed"``.
-5. **notify_rollback** — log rollback confirmation; placeholder for
-   Slack/email integration.
+0. **check_prereqs** — short-circuit if ``ARIZE_AI_INTEGRATION_ID`` isn't
+   resolvable.
+1. **create_eval_dataset** — provision the evaluation dataset.
+2. **build_accuracy_judge_config / create_accuracy_evaluator** — build the
+   accuracy LLM-as-judge config and create an evaluator (per-run-unique
+   name to avoid the soft-delete tombstone trap).
+3. **create_accuracy_eval_task** — wrap the evaluator in a
+   ``template_evaluation`` task.
+4. **create_demo_prompt** — create the demo prompt that the rollback
+   targets. Its single version is the "known stable" version we re-promote
+   when drift fires.
+5. **build_baseline_run_config / create_baseline_run_exp_task** — register
+   a ``run_experiment`` task with a *good* system prompt.
+6. **run_baseline_experiment.{trigger,wait,get_result}** — fire baseline
+   with the accuracy judge chained server-side.
+7. **build_current_run_config / create_current_run_exp_task** — register a
+   ``run_experiment`` task with a deliberately-degraded "Always reply
+   exactly 'I don't know.'" system prompt that drives accuracy to 0.
+8. **run_current_experiment.{trigger,wait,get_result}** — fire current
+   serially after baseline (avoids the Arize concurrent-trigger stall).
+9. **detect_drift** — compare current vs baseline. With
+   ``fail_on_drift=True`` and a 0.1 threshold this *raises*
+   ``AirflowException`` because current_avg ≈ 0 vs baseline_avg ≈ 1.
+10. **rollback_prompt** — fires only on ``ALL_FAILED`` of detect_drift.
+    Re-promotes the stable prompt version to ``"production"``.
+11. **notify_rollback** — logs the rollback outcome (``trigger_rule=ALL_DONE``).
+12. **cleanup_*** — delete the per-run-ephemeral evaluator, eval task, the
+    two run-experiment tasks, the dataset, and the demo prompt.
 
 Schedule: ``@daily``
 
 Variables
 ---------
 - ``arize_ax_space_id`` — Arize space ID (required).
-- ``arize_ax_eval_dataset_id`` — dataset ID to run evaluations against.
-- ``arize_ax_baseline_experiment_id`` — experiment ID of the known-good
-  baseline to compare against.
-- ``arize_ax_prompt_name`` — name of the prompt to roll back.
-- ``arize_ax_stable_prompt_version_id`` — version ID of the stable prompt
-  version to promote back to ``"production"``.
+- ``arize_ax_project_id`` — project ID used to scope the accuracy eval task.
+- ``arize_ai_integration_id`` *or* env var ``ARIZE_AI_INTEGRATION_ID`` —
+  OpenAI integration in Arize with gpt-4.1 access.
 
-Constants (edit in this file or override via Variables):
-- ``DRIFT_MIN_RUNS`` — minimum runs before scoring (default 5).
-- ``DRIFT_THRESHOLD`` — absolute score drop that triggers rollback (default 0.1).
-
-Requires:
-  - Airflow connection ``arize_ax_default`` with a valid API key.
-  - Variables ``arize_ax_space_id``, ``arize_ax_eval_dataset_id``,
-    ``arize_ax_baseline_experiment_id``, ``arize_ax_prompt_name``,
-    ``arize_ax_stable_prompt_version_id``.
+Constants:
+- ``DRIFT_THRESHOLD`` — absolute score drop that triggers rollback
+  (default 0.1).
 """
 
 from __future__ import annotations
@@ -56,164 +63,342 @@ from typing import Any
 
 from airflow import DAG
 from airflow.models import Variable
+from airflow.providers.arize_ax.operators.datasets import (
+    ArizeAxCreateDatasetOperator,
+    ArizeAxDeleteDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.evaluators import (
+    ArizeAxCreateEvaluatorOperator,
+    ArizeAxDeleteEvaluatorOperator,
+)
 from airflow.providers.arize_ax.operators.experiments import (
     ArizeAxDetectEvalDriftOperator,
-    ArizeAxRunExperimentOperator,
 )
 from airflow.providers.arize_ax.operators.prompts import (
+    ArizeAxCreatePromptOperator,
+    ArizeAxDeletePromptOperator,
     ArizeAxPromotePromptOperator,
 )
-from airflow.providers.arize_ax.sensors.arize_ax import (
-    ArizeAxExperimentRunCountSensor,
+from airflow.providers.arize_ax.operators.tasks import (
+    ArizeAxCreateRunExperimentTaskOperator,
+    ArizeAxCreateTaskOperator,
+    ArizeAxDeleteTaskOperator,
+)
+from airflow.providers.arize_ax.utils.task_groups import (
+    arize_ax_chained_experiment_eval,
 )
 from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 from airflow.task.trigger_rule import TriggerRule
 
-# ---------------------------------------------------------------------------
-# Constants — adjust to your environment
-# ---------------------------------------------------------------------------
-DRIFT_MIN_RUNS = 5
-DRIFT_THRESHOLD = 0.1  # flag metrics that dropped more than 10 points
+DRIFT_THRESHOLD = 0.1
+
+DRIFT_EVAL_EXAMPLES = [
+    {"query": "What is the capital of France?", "expected_output": "Paris"},
+    {"query": "What is 7 multiplied by 8?", "expected_output": "56"},
+    {"query": "Who wrote Hamlet?", "expected_output": "William Shakespeare"},
+    {"query": "What element has atomic number 1?", "expected_output": "Hydrogen"},
+    {"query": "How many continents are there?", "expected_output": "7"},
+]
+
+_SPACE_JINJA = "{{ var.value.get('arize_ax_space_id', '') or None }}"
+
+_RUN_SUFFIX = (
+    "{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') "
+    "| replace('.', '') | replace('_', '') }}"
+)
+
+ACCURACY_TEMPLATE = (
+    "[Question]: {query}\n"
+    "[Expected]: {expected_output}\n"
+    "[Output]: {output}\n\n"
+    "Reply with ONLY 'correct' or 'incorrect'."
+)
+
+BASELINE_SYSTEM_PROMPT = (
+    "You are a helpful, accurate assistant. Answer the question with only "
+    "the direct factual answer — no extra explanation or punctuation."
+)
+# Deliberately adversarial so current_avg drops to ~0 and drift > threshold.
+CURRENT_SYSTEM_PROMPT = (
+    "You are a confused assistant. Always reply with exactly the string "
+    "\"I don't know.\" — never anything else."
+)
 
 
+def _resolve_integration_id() -> str:
+    return (
+        Variable.get("arize_ai_integration_id", default_var="").strip()
+        or Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
+    )
 
-def _check_pipeline_configured(**ctx) -> bool:
-    """Return True only when all required Variables are set for drift detection."""
-    required = {
-        "arize_ax_eval_dataset_id": "an evaluation dataset ID",
-        "arize_ax_baseline_experiment_id": "a baseline experiment ID",
-        "arize_ax_prompt_name": "the prompt name to roll back",
-        "arize_ax_stable_prompt_version_id": "the stable prompt version ID",
-    }
-    missing = []
-    for key, description in required.items():
-        val = Variable.get(key, default_var=None)
-        if not val or val.strip() in ("", f"your-{key.split('_', 2)[-1].replace('_', '-')}"):
-            missing.append(f"  - {key}: set to {description}")
-    if missing:
+
+def _check_prereqs(**_ctx) -> bool:
+    if not _resolve_integration_id():
         print(
-            "The following Variables must be set to run the drift detection pipeline:\n"
-            + "\n".join(missing)
+            "ARIZE_AI_INTEGRATION_ID env var or arize_ai_integration_id "
+            "Variable must be set."
         )
         return False
     return True
 
 
-def _eval_task(dataset_row: dict) -> dict:
-    """Evaluation task: echo the expected output as a stub.
+def _build_accuracy_judge_config(**_ctx) -> dict[str, Any]:
+    return {
+        "name": "drift_accuracy_judge",
+        "template": ACCURACY_TEMPLATE,
+        "include_explanations": True,
+        "use_function_calling_if_available": False,
+        "classification_choices": {"correct": 1.0, "incorrect": 0.0},
+        "llm_config": {
+            "ai_integration_id": _resolve_integration_id(),
+            "model_name": "gpt-4o-mini",
+            "invocation_parameters": {"temperature": 0},
+            "provider_parameters": {},
+        },
+    }
 
-    Replace with a real LLM call in production, e.g.::
 
-        response = openai.chat.completions.create(...)
-        return {"output": response.choices[0].message.content}
-    """
-    return {"output": dataset_row.get("expected_output", "")}
+def _build_run_config(model: str, system_prompt: str):
+    def _callable(**_ctx) -> dict[str, Any]:
+        return {
+            "experiment_type": "llm_generation",
+            "ai_integration_id": _resolve_integration_id(),
+            "model_name": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                # run_experiment messages use mustache substitution.
+                {"role": "user", "content": "{{query}}"},
+            ],
+            "input_variable_format": "mustache",
+            "invocation_parameters": {"temperature": 0},
+            "provider_parameters": {},
+        }
 
-
-def _accuracy_evaluator(dataset_row: dict, output: Any) -> Any:
-    """Simple exact-match accuracy evaluator."""
-    from arize.experiments import EvaluationResult
-
-    if output is None:
-        return EvaluationResult(score=0.0, label="error", explanation="no output")
-    actual = output.get("output", "") if isinstance(output, dict) else str(output)
-    expected = dataset_row.get("expected_output", "")
-    match = str(actual).strip().lower() == str(expected).strip().lower()
-    return EvaluationResult(
-        score=1.0 if match else 0.0,
-        label="correct" if match else "incorrect",
-        explanation=f"expected={expected!r}, got={actual!r}",
-    )
+    _callable.__name__ = f"_build_run_config_{model.replace('-', '_').replace('.', '_')}"
+    return _callable
 
 
 def _notify_rollback(**ctx) -> dict[str, Any]:
-    """Log rollback confirmation.
-
-    In production, add a Slack/email notification here, e.g.::
-
-        import slack_sdk
-        client = slack_sdk.WebClient(token=os.environ["SLACK_BOT_TOKEN"])
-        client.chat_postMessage(
-            channel="#ops-alerts",
-            text=f"Prompt rolled back: {prompt_name} -> stable version",
-        )
-    """
-    rollback_result = ctx["ti"].xcom_pull(task_ids="rollback_prompt") or {}
-    prompt_id = rollback_result.get("prompt_id")
-    label = rollback_result.get("label")
-
+    """Log rollback confirmation; placeholder for Slack/email integration."""
+    rollback = ctx["ti"].xcom_pull(task_ids="rollback_prompt") or {}
+    prompt_id = rollback.get("prompt_id") if isinstance(rollback, dict) else None
+    label = rollback.get("label") if isinstance(rollback, dict) else None
     print("=" * 60)
     print("PROMPT ROLLBACK COMPLETE")
     print(f"  Prompt ID : {prompt_id}")
     print(f"  Label     : {label}")
-    print("  Action    : notification sent (replace stub with Slack/email/webhook).")
     print("=" * 60)
     return {"notified": True, "prompt_id": prompt_id, "label": label}
 
 
 with DAG(
     dag_id="arize_ax_drift_detection",
-    start_date=datetime(2025, 1, 1),
+    start_date=datetime(2026, 1, 1),
     schedule="@daily",
-    tags=["arize_ax", "drift", "experiments", "prompts", "rollback"],
+    tags=["arize_ax", "drift", "experiments", "prompts", "rollback", "eval-hub", "self-contained"],
     catchup=False,
     doc_md=__doc__,
+    render_template_as_native_obj=True,
 ) as dag:
 
-    # Stage 0 — Guard: skip DAG if required Variables are not configured
-    check_pipeline_configured = ShortCircuitOperator(
-        task_id="check_pipeline_configured",
-        python_callable=_check_pipeline_configured,
+    check_prereqs = ShortCircuitOperator(
+        task_id="check_prereqs",
+        python_callable=_check_prereqs,
     )
 
-    # Stage 1 — Run today's evaluation experiment
-    run_current_eval = ArizeAxRunExperimentOperator(
-        task_id="run_current_eval",
-        name="drift-check-current-{{ ds }}",
-        dataset_id="{{ var.value.get('arize_ax_eval_dataset_id', '') }}",
-        task=_eval_task,
-        evaluators=[_accuracy_evaluator],
-        concurrency=4,
+    # ----- Phase 1: dataset -------------------------------------------------
+    create_eval_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_eval_dataset",
+        space_id=_SPACE_JINJA,
+        name=f"drift-eval-dataset-{_RUN_SUFFIX}",
+        examples=DRIFT_EVAL_EXAMPLES,
+        if_exists="skip",
     )
 
-    # Stage 2 — Wait for runs to complete
-    wait_for_current = ArizeAxExperimentRunCountSensor(
-        task_id="wait_for_current",
-        experiment_id="{{ ti.xcom_pull(task_ids='run_current_eval') }}",
-        min_runs=DRIFT_MIN_RUNS,
-        poke_interval=15,
-        timeout=600,
-        mode="poke",
-        soft_fail=True,
+    # ----- Phase 2: accuracy judge ------------------------------------------
+    build_accuracy_judge_config = PythonOperator(
+        task_id="build_accuracy_judge_config",
+        python_callable=_build_accuracy_judge_config,
+    )
+    create_accuracy_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_accuracy_evaluator",
+        space_id=_SPACE_JINJA,
+        name=f"drift_accuracy_judge_{_RUN_SUFFIX}",
+        evaluator_type="template",
+        commit_message="initial drift accuracy judge",
+        template_config_task_id="build_accuracy_judge_config",
+        description="LLM-as-judge for drift detection.",
+    )
+    create_accuracy_eval_task = ArizeAxCreateTaskOperator(
+        task_id="create_accuracy_eval_task",
+        name=f"drift-accuracy-task-{_RUN_SUFFIX}",
+        eval_task_type="template_evaluation",
+        evaluators=[
+            {"evaluator_id": "{{ ti.xcom_pull(task_ids='create_accuracy_evaluator') }}"},
+        ],
+        project_id="{{ var.value.get('arize_ax_project_id', '') or None }}",
+        is_continuous=False,
+        sampling_rate=1.0,
     )
 
-    # Stage 3 — Detect drift vs baseline (raises on drift)
+    # ----- Phase 3: demo prompt (the rollback target) -----------------------
+    create_demo_prompt = ArizeAxCreatePromptOperator(
+        task_id="create_demo_prompt",
+        space_id=_SPACE_JINJA,
+        name=f"drift-demo-prompt-{_RUN_SUFFIX}",
+        messages=[
+            {"role": "system", "content": BASELINE_SYSTEM_PROMPT},
+            {"role": "user", "content": "{query}"},
+        ],
+        model="gpt-4.1",
+        commit_message="known-stable prompt version (rollback target)",
+        input_variable_format="f_string",
+    )
+
+    # ----- Phase 4: baseline experiment (good config) -----------------------
+    build_baseline_run_config = PythonOperator(
+        task_id="build_baseline_run_config",
+        python_callable=_build_run_config("gpt-4.1", BASELINE_SYSTEM_PROMPT),
+    )
+    create_baseline_run_exp_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_baseline_run_exp_task",
+        space_id=_SPACE_JINJA,
+        name=f"drift-baseline-task-{_RUN_SUFFIX}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        run_configuration="{{ ti.xcom_pull(task_ids='build_baseline_run_config') }}",
+        if_exists="skip",
+    )
+    run_baseline_experiment = arize_ax_chained_experiment_eval(
+        group_id="run_baseline_experiment",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_baseline_run_exp_task') }}",
+        experiment_name=f"drift-baseline-{_RUN_SUFFIX}",
+        space_id=_SPACE_JINJA,
+        evaluation_task_ids=[
+            "{{ ti.xcom_pull(task_ids='create_accuracy_eval_task') }}",
+        ],
+        wait_for_completion=True,
+        sensor_timeout=900,
+        sensor_poke_interval=15,
+        fail_on_run_error=True,
+    )
+
+    # ----- Phase 5: current (deliberately degraded) experiment --------------
+    build_current_run_config = PythonOperator(
+        task_id="build_current_run_config",
+        python_callable=_build_run_config("gpt-4.1", CURRENT_SYSTEM_PROMPT),
+    )
+    create_current_run_exp_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_current_run_exp_task",
+        space_id=_SPACE_JINJA,
+        name=f"drift-current-task-{_RUN_SUFFIX}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        run_configuration="{{ ti.xcom_pull(task_ids='build_current_run_config') }}",
+        if_exists="skip",
+    )
+    run_current_experiment = arize_ax_chained_experiment_eval(
+        group_id="run_current_experiment",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_current_run_exp_task') }}",
+        experiment_name=f"drift-current-{_RUN_SUFFIX}",
+        space_id=_SPACE_JINJA,
+        evaluation_task_ids=[
+            "{{ ti.xcom_pull(task_ids='create_accuracy_eval_task') }}",
+        ],
+        wait_for_completion=True,
+        sensor_timeout=900,
+        sensor_poke_interval=15,
+        fail_on_run_error=True,
+    )
+
+    # ----- Phase 6: drift detection (expected to fire) ----------------------
+    _BASELINE_EXP_ID = (
+        "{{ ti.xcom_pull(task_ids='run_baseline_experiment.trigger', "
+        "key='result')['experiment_id'] }}"
+    )
+    _CURRENT_EXP_ID = (
+        "{{ ti.xcom_pull(task_ids='run_current_experiment.trigger', "
+        "key='result')['experiment_id'] }}"
+    )
     detect_drift = ArizeAxDetectEvalDriftOperator(
         task_id="detect_drift",
-        current_experiment_id="{{ ti.xcom_pull(task_ids='run_current_eval') }}",
-        baseline_experiment_id="{{ var.value.get('arize_ax_baseline_experiment_id', '') }}",
+        current_experiment_id=_CURRENT_EXP_ID,
+        baseline_experiment_id=_BASELINE_EXP_ID,
         drift_threshold=DRIFT_THRESHOLD,
         aggregation="mean",
         fail_on_drift=True,
     )
 
-    # Stage 4 — Roll back prompt when drift was detected (task failed)
+    # ----- Phase 7: rollback (only fires when drift detected) ---------------
     rollback_prompt = ArizeAxPromotePromptOperator(
         task_id="rollback_prompt",
-        prompt_name="{{ var.value.get('arize_ax_prompt_name', '') }}",
+        prompt_name=f"drift-demo-prompt-{_RUN_SUFFIX}",
         label="production",
-        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
-        version_id="{{ var.value.get('arize_ax_stable_prompt_version_id', None) }}",
+        space_id=_SPACE_JINJA,
         trigger_rule=TriggerRule.ALL_FAILED,
     )
-
-    # Stage 5 — Notify (Slack/email placeholder)
     notify_rollback = PythonOperator(
         task_id="notify_rollback",
         python_callable=_notify_rollback,
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
-    # Wiring
-    check_pipeline_configured >> run_current_eval >> wait_for_current >> detect_drift
-    detect_drift >> rollback_prompt >> notify_rollback
+    # ----- Phase 8: cleanup -------------------------------------------------
+    cleanup_accuracy_eval_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_accuracy_eval_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_accuracy_eval_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_baseline_run_exp_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_baseline_run_exp_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_baseline_run_exp_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_current_run_exp_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_current_run_exp_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_current_run_exp_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_accuracy_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_accuracy_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_accuracy_evaluator') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_dataset = ArizeAxDeleteDatasetOperator(
+        task_id="cleanup_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_demo_prompt = ArizeAxDeletePromptOperator(
+        task_id="cleanup_demo_prompt",
+        prompt_id="{{ ti.xcom_pull(task_ids='create_demo_prompt') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+
+    # Wiring — baseline runs first, then current (serially) to avoid the
+    # Arize concurrent-trigger stall we observed under parallel fan-out.
+    check_prereqs >> [
+        create_eval_dataset,
+        build_accuracy_judge_config,
+        build_baseline_run_config,
+        build_current_run_config,
+        create_demo_prompt,
+    ]
+    build_accuracy_judge_config >> create_accuracy_evaluator >> create_accuracy_eval_task
+    [create_eval_dataset, build_baseline_run_config] >> create_baseline_run_exp_task
+    [create_eval_dataset, build_current_run_config] >> create_current_run_exp_task
+    [create_baseline_run_exp_task, create_accuracy_eval_task] >> run_baseline_experiment
+    [run_baseline_experiment, create_current_run_exp_task, create_accuracy_eval_task] >> run_current_experiment
+    run_current_experiment >> detect_drift >> rollback_prompt >> notify_rollback
+    notify_rollback >> [
+        cleanup_accuracy_eval_task,
+        cleanup_baseline_run_exp_task,
+        cleanup_current_run_exp_task,
+        cleanup_accuracy_evaluator,
+        cleanup_dataset,
+        cleanup_demo_prompt,
+    ]

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_experiment_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_experiment_dag.py
@@ -1,56 +1,112 @@
 """
-Example DAG: Arize AX experiment workflow.
+Example DAG: Arize AX experiment workflow (server-side).
 
-Creates a dataset, runs an experiment with a task + evaluator, and retrieves
-the experiment results.  Demonstrates the ArizeAxRunExperimentOperator.
+Creates a dataset, registers a server-side ``run_experiment`` task that
+calls gpt-4.1 with a mustache-templated prompt, chains a single
+``template_evaluation`` accuracy judge that scores each row server-side,
+and lists the resulting experiments.
 
 Requires:
 - Airflow connection ``arize_ax_default`` with API key.
-- Airflow variable ``arize_ax_space_id``.
+- Airflow Variable ``arize_ax_space_id``.
+- Airflow Variable ``arize_ai_integration_id`` (or env var
+  ``ARIZE_AI_INTEGRATION_ID``) — OpenAI integration with gpt-4.1 access.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from airflow import DAG
+from airflow.models import Variable
 from airflow.providers.arize_ax.operators.datasets import (
     ArizeAxCreateDatasetOperator,
 )
+from airflow.providers.arize_ax.operators.evaluators import (
+    ArizeAxCreateEvaluatorOperator,
+    ArizeAxDeleteEvaluatorOperator,
+)
 from airflow.providers.arize_ax.operators.experiments import (
     ArizeAxListExperimentsOperator,
-    ArizeAxRunExperimentOperator,
+)
+from airflow.providers.arize_ax.operators.tasks import (
+    ArizeAxCreateRunExperimentTaskOperator,
+    ArizeAxCreateTaskOperator,
+    ArizeAxDeleteTaskOperator,
+)
+from airflow.providers.arize_ax.utils.task_groups import (
+    arize_ax_chained_experiment_eval,
+)
+from airflow.providers.standard.operators.python import PythonOperator
+
+_SPACE_JINJA = "{{ var.value.get('arize_ax_space_id', '') or None }}"
+
+_RUN_SUFFIX = (
+    "{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') "
+    "| replace('.', '') | replace('_', '') }}"
+)
+
+EXACT_MATCH_TEMPLATE = (
+    "[Question]: {query}\n"
+    "[Expected]: {expected_output}\n"
+    "[Output]: {output}\n\n"
+    "Reply with ONLY 'correct' or 'incorrect'."
 )
 
 
-def _example_task(dataset_row: dict) -> dict:
-    """Trivial task that echoes the expected output."""
-    return {"output": dataset_row.get("expected_output", "")}
-
-
-def _exact_match_evaluator(dataset_row: dict, output: dict):
-    """Simple evaluator that checks if output matches expected."""
-    from arize.experiments import EvaluationResult
-
-    match = output.get("output") == dataset_row.get("expected_output")
-    return EvaluationResult(
-        score=1.0 if match else 0.0,
-        label="correct" if match else "incorrect",
-        explanation=f"expected={dataset_row.get('expected_output')!r}, "
-                    f"got={output.get('output')!r}",
+def _resolve_integration_id() -> str:
+    return (
+        Variable.get("arize_ai_integration_id", default_var="").strip()
+        or Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
     )
+
+
+def _build_judge_config(**_ctx) -> dict[str, Any]:
+    return {
+        "name": "exact_match_judge",
+        "template": EXACT_MATCH_TEMPLATE,
+        "include_explanations": True,
+        "use_function_calling_if_available": False,
+        "classification_choices": {"correct": 1.0, "incorrect": 0.0},
+        "llm_config": {
+            "ai_integration_id": _resolve_integration_id(),
+            "model_name": "gpt-4o-mini",
+            "invocation_parameters": {"temperature": 0},
+            "provider_parameters": {},
+        },
+    }
+
+
+def _build_run_config(**_ctx) -> dict[str, Any]:
+    return {
+        "experiment_type": "llm_generation",
+        "ai_integration_id": _resolve_integration_id(),
+        "model_name": "gpt-4.1",
+        "messages": [
+            {"role": "system",
+             "content": "Answer with only the direct factual answer."},
+            {"role": "user", "content": "{{query}}"},
+        ],
+        "input_variable_format": "mustache",
+        "invocation_parameters": {"temperature": 0},
+        "provider_parameters": {},
+    }
 
 
 with DAG(
     dag_id="example_arize_ax_experiment",
-    start_date=datetime(2025, 1, 1),
+    start_date=datetime(2026, 1, 1),
     schedule=None,
-    tags=["arize_ax", "example", "experiment"],
+    tags=["arize_ax", "example", "experiment", "eval-hub"],
     catchup=False,
+    doc_md=__doc__,
+    render_template_as_native_obj=True,
 ) as dag:
+
     create_dataset = ArizeAxCreateDatasetOperator(
         task_id="create_dataset",
-        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        space_id=_SPACE_JINJA,
         name="airflow-experiment-dataset",
         examples=[
             {"query": "What is 2+2?", "expected_output": "4"},
@@ -60,19 +116,90 @@ with DAG(
         if_exists="skip",
     )
 
-    run_experiment = ArizeAxRunExperimentOperator(
-        task_id="run_experiment",
-        name="airflow-nightly-eval-{{ ds }}",
+    build_judge_config = PythonOperator(
+        task_id="build_judge_config",
+        python_callable=_build_judge_config,
+    )
+
+    create_judge_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_judge_evaluator",
+        space_id=_SPACE_JINJA,
+        name=f"exact_match_judge_{_RUN_SUFFIX}",
+        evaluator_type="template",
+        commit_message="initial exact_match judge",
+        template_config_task_id="build_judge_config",
+        description="LLM-as-judge accuracy evaluator.",
+    )
+
+    create_judge_task = ArizeAxCreateTaskOperator(
+        task_id="create_judge_task",
+        name=f"exact-match-task-{_RUN_SUFFIX}",
+        eval_task_type="template_evaluation",
+        evaluators=[
+            {"evaluator_id": "{{ ti.xcom_pull(task_ids='create_judge_evaluator') }}"},
+        ],
+        project_id="{{ var.value.get('arize_ax_project_id', '') or None }}",
+        is_continuous=False,
+        sampling_rate=1.0,
+    )
+
+    build_run_config = PythonOperator(
+        task_id="build_run_config",
+        python_callable=_build_run_config,
+    )
+
+    create_run_exp_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_run_exp_task",
+        space_id=_SPACE_JINJA,
+        name=f"airflow-run-exp-task-{_RUN_SUFFIX}",
         dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
-        task=_example_task,
-        evaluators=[_exact_match_evaluator],
-        concurrency=2,
+        run_configuration="{{ ti.xcom_pull(task_ids='build_run_config') }}",
+        if_exists="skip",
+    )
+
+    run_experiment = arize_ax_chained_experiment_eval(
+        group_id="run_experiment",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_run_exp_task') }}",
+        experiment_name=f"airflow-nightly-eval-{_RUN_SUFFIX}",
+        space_id=_SPACE_JINJA,
+        evaluation_task_ids=[
+            "{{ ti.xcom_pull(task_ids='create_judge_task') }}",
+        ],
+        wait_for_completion=True,
+        sensor_timeout=900,
+        sensor_poke_interval=15,
+        fail_on_run_error=True,
     )
 
     list_experiments = ArizeAxListExperimentsOperator(
         task_id="list_experiments",
         dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
         limit=5,
+        trigger_rule="all_done",
     )
 
-    create_dataset >> run_experiment >> list_experiments
+    cleanup_judge_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_judge_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_judge_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_run_exp_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_run_exp_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_run_exp_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_judge_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_judge_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_judge_evaluator') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+
+    create_dataset >> [build_judge_config, build_run_config]
+    build_judge_config >> create_judge_evaluator >> create_judge_task
+    [create_dataset, build_run_config] >> create_run_exp_task
+    [create_run_exp_task, create_judge_task] >> run_experiment
+    run_experiment >> list_experiments
+    list_experiments >> [cleanup_judge_task, cleanup_run_exp_task, cleanup_judge_evaluator]

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_llm_cicd_gate_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_llm_cicd_gate_dag.py
@@ -1,52 +1,62 @@
 """
-LLM CI/CD Gate DAG: automated evaluation-gated promotion for LLM changes.
+LLM CI/CD Gate DAG (server-side, self-contained): automated evaluation-gated
+promotion for LLM changes.
 
-This DAG implements a CI/CD gate pattern for LLM-powered applications.  It
-runs a candidate experiment against a held-out evaluation dataset, scores both
-the candidate and an established baseline experiment, then raises AirflowException
-if the candidate does not meet the improvement threshold.
+The DAG creates both a *baseline* and a *candidate* experiment server-side
+(Arize Eval Hub drives the LLM calls and the accuracy judge), scores both,
+and raises ``AirflowException`` if the candidate doesn't beat the baseline
+by the configured threshold. On pass it optionally promotes a prompt.
+
+It is fully self-contained — no pre-existing baseline experiment, prompt,
+or dataset is required. The DAG provisions everything it needs on each
+run, demonstrates the gate, then cleans up the ephemeral resources.
 
 Pipeline stages
 ---------------
-0. **check_baseline_configured** — short-circuit if
-   ``arize_ax_baseline_experiment_id`` Variable is not set.
-1. **create_candidate_dataset** — create (or skip if exists) the evaluation
-   dataset for this run.
-2. **append_candidate_examples** — load evaluation examples into the dataset.
-3. **run_candidate_experiment** — run the candidate LLM task against the
-   dataset with Python evaluators; returns a scalar experiment ID on XCom.
-4. **wait_for_candidate** — block until the experiment has at least
-   ``CICD_MIN_RUNS`` completed runs (ArizeAxExperimentRunCountSensor).
-5. **score_candidate** — aggregate evaluation scores for the candidate
-   (ArizeAxGetExperimentScoreOperator).
-6. **score_baseline** — aggregate evaluation scores for the baseline
-   experiment (same operator, different experiment ID).
-7. **compare_experiments** — compute per-metric deltas and an overall pass/
-   fail verdict (ArizeAxCompareExperimentsOperator).  Raises AirflowException
-   when ``fail_on_regression=True`` and the candidate did not improve.
-8. **check_prompt_configured** — short-circuit the promotion path if no
-   ``arize_ax_prompt_name`` Variable is set (gate-only mode).
-9. **promote_prompt** — tag the configured prompt version with the
-   ``arize_ax_prompt_label`` label (ArizeAxPromotePromptOperator).  Only
-   runs when the gate passed *and* a prompt name is configured.
-10. **promote_notification** — placeholder for a real deployment hook; logs
-    the promotion outcome (and which label was applied) to the Airflow task
-    log.
+0. **check_prereqs** — short-circuit if ``ARIZE_AI_INTEGRATION_ID`` isn't
+   resolvable (an OpenAI integration is needed for both the experiment LLM
+   calls and the judge).
+1. **create_eval_dataset** — provision a small evaluation dataset.
+2. **build_accuracy_judge_config / create_accuracy_evaluator** — build the
+   accuracy LLM-as-judge config and create an evaluator with a per-run-unique
+   name (avoids Arize's soft-delete name-tombstone trap).
+3. **create_accuracy_eval_task** — wrap the evaluator in a
+   ``template_evaluation`` task scoped to the configured project.
+4. **build_baseline_run_config / create_baseline_run_exp_task** — register a
+   ``run_experiment`` task driven by a *weaker* config (gpt-4o-mini + terse
+   system prompt) to act as the baseline.
+5. **run_baseline_experiment.{trigger,wait,get_result}** — fire the baseline
+   experiment with the accuracy judge chained server-side.
+6. **build_candidate_run_config / create_candidate_run_exp_task** — register
+   a ``run_experiment`` task driven by a *stronger* config (gpt-4.1 +
+   careful system prompt).
+7. **run_candidate_experiment.{trigger,wait,get_result}** — fire the
+   candidate experiment with the same chained accuracy judge.
+8. **score_baseline / score_candidate** — aggregate evaluation scores from
+   both experiments (``ArizeAxGetExperimentScoreOperator``).
+9. **compare_experiments** — pass/fail verdict with
+   ``fail_on_regression=True``.
+10. **check_prompt_configured** — short-circuit promotion if no
+    ``arize_ax_prompt_name`` Variable is set (gate-only mode).
+11. **promote_prompt** — tag the configured prompt with the
+    ``arize_ax_prompt_label`` label.
+12. **promote_notification** — log the promotion outcome.
+13. **cleanup_*** — delete per-run-ephemeral evaluator, eval task, the two
+    run-experiment tasks, and the dataset.
 
 Variables
 ---------
-- ``arize_ax_space_id`` — Arize space ID. Optional; falls back to connection
-  ``default_space`` when absent.
-- ``arize_ax_baseline_experiment_id`` — experiment ID of the production
-  baseline to compare against. **Required.** The DAG skips when not set.
-- ``arize_ax_prompt_name`` — name of the prompt to promote on gate pass.
-  Optional. When unset the DAG runs in gate-only mode (no promotion).
-- ``arize_ax_prompt_label`` — label to apply to the promoted prompt version
-  (default ``"production"``).
+- ``arize_ax_space_id`` — Arize space ID (required).
+- ``arize_ax_project_id`` — project ID used to scope the accuracy eval task
+  (required by the Eval Hub for ``template_evaluation`` tasks).
+- ``arize_ai_integration_id`` *or* env var ``ARIZE_AI_INTEGRATION_ID`` —
+  OpenAI integration in Arize with gpt-4.1 + gpt-4o-mini access.
+- ``arize_ax_prompt_name`` — optional. When set, the DAG promotes that
+  prompt version on gate-pass.
+- ``arize_ax_prompt_label`` — label to apply (default ``"production"``).
 
 Requires:
   - Airflow connection ``arize_ax_default`` with a valid API key.
-  - Variable ``arize_ax_baseline_experiment_id`` set to a real experiment ID.
 """
 
 from __future__ import annotations
@@ -57,30 +67,34 @@ from typing import Any
 from airflow import DAG
 from airflow.models import Variable
 from airflow.providers.arize_ax.operators.datasets import (
-    ArizeAxAppendDatasetExamplesOperator,
     ArizeAxCreateDatasetOperator,
+    ArizeAxDeleteDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.evaluators import (
+    ArizeAxCreateEvaluatorOperator,
+    ArizeAxDeleteEvaluatorOperator,
 )
 from airflow.providers.arize_ax.operators.experiments import (
     ArizeAxCompareExperimentsOperator,
     ArizeAxGetExperimentScoreOperator,
-    ArizeAxRunExperimentOperator,
 )
 from airflow.providers.arize_ax.operators.prompts import (
+    ArizeAxCreatePromptOperator,
+    ArizeAxDeletePromptOperator,
     ArizeAxPromotePromptOperator,
 )
-from airflow.providers.arize_ax.sensors.arize_ax import (
-    ArizeAxExperimentRunCountSensor,
+from airflow.providers.arize_ax.operators.tasks import (
+    ArizeAxCreateRunExperimentTaskOperator,
+    ArizeAxCreateTaskOperator,
+    ArizeAxDeleteTaskOperator,
+)
+from airflow.providers.arize_ax.utils.task_groups import (
+    arize_ax_chained_experiment_eval,
 )
 from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 
-# ---------------------------------------------------------------------------
-# Constants — override via Airflow Variables in production
-# ---------------------------------------------------------------------------
-CICD_DATASET_NAME = "cicd-eval-dataset"
-CICD_MIN_RUNS = 5
 CICD_PASS_THRESHOLD = 0.0  # candidate score must be >= baseline + threshold
 
-# Evaluation examples shared across all CI/CD gate runs.
 CICD_EVAL_EXAMPLES = [
     {"query": "What is the capital of France?", "expected_output": "Paris"},
     {"query": "What is 7 multiplied by 8?", "expected_output": "56"},
@@ -89,72 +103,102 @@ CICD_EVAL_EXAMPLES = [
     {"query": "How many continents are there?", "expected_output": "7"},
 ]
 
+_SPACE_JINJA = "{{ var.value.get('arize_ax_space_id', '') or None }}"
 
-def _check_baseline_configured(**ctx) -> bool:
-    """Return True only if arize_ax_baseline_experiment_id Variable is set."""
-    baseline_id = Variable.get("arize_ax_baseline_experiment_id", default_var=None)
-    if not baseline_id or baseline_id.strip() in ("", "your-baseline-experiment-id"):
-        print(
-            "Set the arize_ax_baseline_experiment_id Variable to a real experiment ID "
-            "to run this CI/CD gate pipeline."
-        )
-        return False
-    return True
+_RUN_SUFFIX = (
+    "{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') "
+    "| replace('.', '') | replace('_', '') }}"
+)
 
+ACCURACY_TEMPLATE = (
+    "You are evaluating a question-answering system.\n\n"
+    "[Question]: {query}\n"
+    "[Expected Answer]: {expected_output}\n"
+    "[System Output]: {output}\n\n"
+    "The system output is correct if it conveys the same factual answer as "
+    "the expected answer, even if phrased differently. Reply with ONLY "
+    "'correct' or 'incorrect'."
+)
 
-def _check_prompt_configured(**ctx) -> bool:
-    """Return True only if arize_ax_prompt_name Variable is set.
-
-    When unset, the DAG runs in gate-only mode: the regression gate still
-    fires (compare_experiments raises on regression) but no prompt is
-    promoted.  The promote_prompt and promote_notification tasks are skipped.
-    """
-    prompt_name = Variable.get("arize_ax_prompt_name", default_var=None)
-    if not prompt_name or prompt_name.strip() in ("", "your-prompt-name"):
-        print(
-            "arize_ax_prompt_name Variable is not set — running in gate-only mode. "
-            "Set it to a real prompt name to enable automatic promotion on pass."
-        )
-        return False
-    return True
+BASELINE_SYSTEM_PROMPT = "Answer."  # deliberately terse → expected to underperform
+CANDIDATE_SYSTEM_PROMPT = (
+    "You are a helpful, accurate assistant. Answer the question with only "
+    "the direct factual answer — no extra explanation or punctuation."
+)
 
 
-def _candidate_task(dataset_row: dict) -> dict:
-    """Candidate LLM task.
-
-    Replace this with a real LLM call in production (e.g. ``openai.chat``).
-    This stub echoes the expected output to demonstrate the pipeline shape.
-    """
-    return {"output": dataset_row.get("expected_output", "")}
-
-
-def _accuracy_evaluator(dataset_row: dict, output: Any):
-    """Simple accuracy evaluator: 1.0 if output matches expected, 0.0 otherwise."""
-    from arize.experiments import EvaluationResult
-
-    if output is None:
-        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
-    actual = output.get("output", "") if isinstance(output, dict) else str(output)
-    expected = dataset_row.get("expected_output", "")
-    match = str(actual).strip().lower() == str(expected).strip().lower()
-    return EvaluationResult(
-        score=1.0 if match else 0.0,
-        label="correct" if match else "incorrect",
-        explanation=f"expected={expected!r}, got={actual!r}",
+def _resolve_integration_id() -> str:
+    return (
+        Variable.get("arize_ai_integration_id", default_var="").strip()
+        or Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
     )
 
 
-def _promote_notification(**ctx) -> dict[str, Any]:
-    """Placeholder for a real deployment hook.
+def _check_prereqs(**_ctx) -> bool:
+    """Short-circuit when the AI integration isn't configured."""
+    if not _resolve_integration_id():
+        print(
+            "ARIZE_AI_INTEGRATION_ID env var or arize_ai_integration_id "
+            "Variable must be set to a valid Arize OpenAI integration ID."
+        )
+        return False
+    return True
 
-    In production, replace this with a call to your deployment API,
-    a Slack notification, or a webhook to trigger your release pipeline.
-    """
-    candidate_id = ctx["ti"].xcom_pull(task_ids="run_candidate_experiment")
-    scores = ctx["ti"].xcom_pull(task_ids="score_candidate") or {}
-    promoted_version_id = ctx["ti"].xcom_pull(task_ids="promote_prompt")
-    prompt_name = Variable.get("arize_ax_prompt_name", default_var=None)
-    prompt_label = Variable.get("arize_ax_prompt_label", default_var="production")
+
+def _build_accuracy_judge_config(**_ctx) -> dict[str, Any]:
+    return {
+        "name": "cicd_accuracy_judge",
+        "template": ACCURACY_TEMPLATE,
+        "include_explanations": True,
+        "use_function_calling_if_available": False,
+        "classification_choices": {"correct": 1.0, "incorrect": 0.0},
+        "llm_config": {
+            "ai_integration_id": _resolve_integration_id(),
+            "model_name": "gpt-4o-mini",
+            "invocation_parameters": {"temperature": 0},
+            "provider_parameters": {},
+        },
+    }
+
+
+def _build_run_config(model: str, system_prompt: str):
+    def _callable(**_ctx) -> dict[str, Any]:
+        return {
+            "experiment_type": "llm_generation",
+            "ai_integration_id": _resolve_integration_id(),
+            "model_name": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                # run_experiment messages use mustache substitution.
+                {"role": "user", "content": "{{query}}"},
+            ],
+            "input_variable_format": "mustache",
+            "invocation_parameters": {"temperature": 0},
+            "provider_parameters": {},
+        }
+
+    _callable.__name__ = f"_build_run_config_{model.replace('-', '_').replace('.', '_')}"
+    return _callable
+
+
+def _promote_notification(**ctx) -> dict[str, Any]:
+    """Log the promotion outcome."""
+    ti = ctx["ti"]
+    trigger_result = ti.xcom_pull(
+        task_ids="run_candidate_experiment.trigger", key="result"
+    ) or {}
+    candidate_id = (
+        trigger_result.get("experiment_id") if isinstance(trigger_result, dict) else None
+    )
+    scores = ti.xcom_pull(task_ids="score_candidate") or {}
+    promote_result = ti.xcom_pull(task_ids="promote_prompt") or {}
+    promoted_version_id = (
+        promote_result.get("prompt_id") if isinstance(promote_result, dict) else None
+    )
+    prompt_label = (
+        promote_result.get("label") if isinstance(promote_result, dict) else "production"
+    )
+    prompt_name = "cicd-demo-prompt-<run_suffix>"
     print("=" * 60)
     print("CANDIDATE PROMOTED")
     print(f"  Experiment ID : {candidate_id}")
@@ -162,7 +206,6 @@ def _promote_notification(**ctx) -> dict[str, Any]:
     print(f"  Prompt name   : {prompt_name}")
     print(f"  Prompt label  : {prompt_label}")
     print(f"  Prompt verId  : {promoted_version_id}")
-    print("  Next step     : trigger deployment pipeline (not implemented in this stub).")
     print("=" * 60)
     return {
         "promoted": True,
@@ -174,106 +217,234 @@ def _promote_notification(**ctx) -> dict[str, Any]:
     }
 
 
+_BASELINE_EXP_ID = (
+    "{{ ti.xcom_pull(task_ids='run_baseline_experiment.trigger', "
+    "key='result')['experiment_id'] }}"
+)
+_CANDIDATE_EXP_ID = (
+    "{{ ti.xcom_pull(task_ids='run_candidate_experiment.trigger', "
+    "key='result')['experiment_id'] }}"
+)
+
+
 with DAG(
     dag_id="arize_ax_llm_cicd_gate",
-    start_date=datetime(2025, 1, 1),
+    start_date=datetime(2026, 1, 1),
     schedule=None,
-    tags=["arize_ax", "cicd", "llm", "experiments"],
+    tags=["arize_ax", "cicd", "llm", "experiments", "eval-hub", "self-contained"],
     catchup=False,
     doc_md=__doc__,
+    render_template_as_native_obj=True,
 ) as dag:
 
-    # Stage 0 — Guard: skip DAG if baseline experiment ID is not configured
-    check_baseline_configured = ShortCircuitOperator(
-        task_id="check_baseline_configured",
-        python_callable=_check_baseline_configured,
+    check_prereqs = ShortCircuitOperator(
+        task_id="check_prereqs",
+        python_callable=_check_prereqs,
     )
 
-    # Stage 1 — Dataset setup
-    create_candidate_dataset = ArizeAxCreateDatasetOperator(
-        task_id="create_candidate_dataset",
-        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
-        name=CICD_DATASET_NAME,
-        # SDK 8.25+ rejects empty examples list at create time. Seed with a
-        # single placeholder; real examples are loaded by the subsequent
-        # append step.
-        examples=[{"input": "_seed_", "expected": "_seed_"}],
+    # ----- Phase 1: ephemeral dataset --------------------------------------
+    create_eval_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_eval_dataset",
+        space_id=_SPACE_JINJA,
+        name=f"cicd-eval-dataset-{_RUN_SUFFIX}",
+        examples=CICD_EVAL_EXAMPLES,
         if_exists="skip",
     )
 
-    append_candidate_examples = ArizeAxAppendDatasetExamplesOperator(
-        task_id="append_candidate_examples",
-        dataset_id="{{ ti.xcom_pull(task_ids='create_candidate_dataset') }}",
-        examples=CICD_EVAL_EXAMPLES,
+    # ----- Phase 2: accuracy judge ------------------------------------------
+    build_accuracy_judge_config = PythonOperator(
+        task_id="build_accuracy_judge_config",
+        python_callable=_build_accuracy_judge_config,
+    )
+    create_accuracy_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_accuracy_evaluator",
+        space_id=_SPACE_JINJA,
+        name=f"cicd_accuracy_judge_{_RUN_SUFFIX}",
+        evaluator_type="template",
+        commit_message="initial cicd accuracy judge",
+        template_config_task_id="build_accuracy_judge_config",
+        description="LLM-as-judge for CI/CD gate factual correctness.",
+    )
+    create_accuracy_eval_task = ArizeAxCreateTaskOperator(
+        task_id="create_accuracy_eval_task",
+        name=f"cicd-accuracy-task-{_RUN_SUFFIX}",
+        eval_task_type="template_evaluation",
+        evaluators=[
+            {"evaluator_id": "{{ ti.xcom_pull(task_ids='create_accuracy_evaluator') }}"},
+        ],
+        project_id="{{ var.value.get('arize_ax_project_id', '') or None }}",
+        is_continuous=False,
+        sampling_rate=1.0,
     )
 
-    # Stage 2 — Run candidate experiment
-    run_candidate_experiment = ArizeAxRunExperimentOperator(
-        task_id="run_candidate_experiment",
-        name="cicd-candidate-{{ ts_nodash }}",
-        dataset_id="{{ ti.xcom_pull(task_ids='create_candidate_dataset') }}",
-        task=_candidate_task,
-        evaluators=[_accuracy_evaluator],
-        concurrency=4,
+    # ----- Phase 3: baseline experiment (weaker config) --------------------
+    # Baseline + candidate both use gpt-4.1 (proven stable in earlier
+    # end-to-end testing); the comparison isolates prompt-engineering
+    # impact rather than model quality.
+    build_baseline_run_config = PythonOperator(
+        task_id="build_baseline_run_config",
+        python_callable=_build_run_config("gpt-4.1", BASELINE_SYSTEM_PROMPT),
+    )
+    create_baseline_run_exp_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_baseline_run_exp_task",
+        space_id=_SPACE_JINJA,
+        name=f"cicd-baseline-task-{_RUN_SUFFIX}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        run_configuration="{{ ti.xcom_pull(task_ids='build_baseline_run_config') }}",
+        if_exists="skip",
+    )
+    run_baseline_experiment = arize_ax_chained_experiment_eval(
+        group_id="run_baseline_experiment",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_baseline_run_exp_task') }}",
+        experiment_name=f"cicd-baseline-{_RUN_SUFFIX}",
+        space_id=_SPACE_JINJA,
+        evaluation_task_ids=[
+            "{{ ti.xcom_pull(task_ids='create_accuracy_eval_task') }}",
+        ],
+        wait_for_completion=True,
+        sensor_timeout=900,
+        sensor_poke_interval=15,
+        fail_on_run_error=True,
     )
 
-    # Stage 3 — Wait for runs to complete
-    wait_for_candidate = ArizeAxExperimentRunCountSensor(
-        task_id="wait_for_candidate",
-        experiment_id="{{ ti.xcom_pull(task_ids='run_candidate_experiment') }}",
-        min_runs=CICD_MIN_RUNS,
-        poke_interval=15,
-        timeout=600,
-        mode="poke",
-        soft_fail=True,
+    # ----- Phase 4: candidate experiment (stronger config) ------------------
+    build_candidate_run_config = PythonOperator(
+        task_id="build_candidate_run_config",
+        python_callable=_build_run_config("gpt-4.1", CANDIDATE_SYSTEM_PROMPT),
+    )
+    create_candidate_run_exp_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_candidate_run_exp_task",
+        space_id=_SPACE_JINJA,
+        name=f"cicd-candidate-task-{_RUN_SUFFIX}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        run_configuration="{{ ti.xcom_pull(task_ids='build_candidate_run_config') }}",
+        if_exists="skip",
+    )
+    run_candidate_experiment = arize_ax_chained_experiment_eval(
+        group_id="run_candidate_experiment",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_candidate_run_exp_task') }}",
+        experiment_name=f"cicd-candidate-{_RUN_SUFFIX}",
+        space_id=_SPACE_JINJA,
+        evaluation_task_ids=[
+            "{{ ti.xcom_pull(task_ids='create_accuracy_eval_task') }}",
+        ],
+        wait_for_completion=True,
+        sensor_timeout=900,
+        sensor_poke_interval=15,
+        fail_on_run_error=True,
     )
 
-    # Stage 4 — Score candidate and baseline
-    score_candidate = ArizeAxGetExperimentScoreOperator(
-        task_id="score_candidate",
-        experiment_id="{{ ti.xcom_pull(task_ids='run_candidate_experiment') }}",
-        aggregation="mean",
-    )
-
+    # ----- Phase 5: score + compare + gate ----------------------------------
     score_baseline = ArizeAxGetExperimentScoreOperator(
         task_id="score_baseline",
-        experiment_id="{{ var.value.get('arize_ax_baseline_experiment_id', '') }}",
+        experiment_id=_BASELINE_EXP_ID,
         aggregation="mean",
     )
-
-    # Stage 5 — Compare and gate (raises AirflowException on regression)
+    score_candidate = ArizeAxGetExperimentScoreOperator(
+        task_id="score_candidate",
+        experiment_id=_CANDIDATE_EXP_ID,
+        aggregation="mean",
+    )
     compare_experiments = ArizeAxCompareExperimentsOperator(
         task_id="compare_experiments",
-        candidate_experiment_id="{{ ti.xcom_pull(task_ids='run_candidate_experiment') }}",
-        baseline_experiment_id="{{ var.value.get('arize_ax_baseline_experiment_id', '') }}",
+        candidate_experiment_id=_CANDIDATE_EXP_ID,
+        baseline_experiment_id=_BASELINE_EXP_ID,
         pass_threshold=CICD_PASS_THRESHOLD,
         aggregation="mean",
         fail_on_regression=True,
     )
 
-    # Stage 6a — Short-circuit promotion path if no prompt is configured
-    check_prompt_configured = ShortCircuitOperator(
-        task_id="check_prompt_configured",
-        python_callable=_check_prompt_configured,
+    # ----- Phase 6: promotion (fully self-contained) ------------------------
+    # Create an ephemeral demo prompt so the promotion path always exercises
+    # end-to-end without needing any external Variable.
+    create_demo_prompt = ArizeAxCreatePromptOperator(
+        task_id="create_demo_prompt",
+        space_id=_SPACE_JINJA,
+        name=f"cicd-demo-prompt-{_RUN_SUFFIX}",
+        messages=[
+            {"role": "system", "content": CANDIDATE_SYSTEM_PROMPT},
+            {"role": "user", "content": "{query}"},
+        ],
+        model="gpt-4.1",
+        commit_message="initial cicd-demo prompt version",
+        input_variable_format="f_string",
     )
-
-    # Stage 6b — Promote the prompt version with the configured label
     promote_prompt = ArizeAxPromotePromptOperator(
         task_id="promote_prompt",
-        prompt_name="{{ var.value.get('arize_ax_prompt_name', '') }}",
-        label="{{ var.value.get('arize_ax_prompt_label', 'production') }}",
-        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        prompt_name=f"cicd-demo-prompt-{_RUN_SUFFIX}",
+        label="production",
+        space_id=_SPACE_JINJA,
     )
-
-    # Stage 7 — Promotion notification (only reached on gate-pass + promote)
     promote_notification = PythonOperator(
         task_id="promote_notification",
         python_callable=_promote_notification,
     )
 
-    # Wiring
-    check_baseline_configured >> create_candidate_dataset >> append_candidate_examples >> run_candidate_experiment
-    run_candidate_experiment >> wait_for_candidate
-    wait_for_candidate >> [score_candidate, score_baseline]
-    [score_candidate, score_baseline] >> compare_experiments
-    compare_experiments >> check_prompt_configured >> promote_prompt >> promote_notification
+    # ----- Phase 7: cleanup -------------------------------------------------
+    cleanup_accuracy_eval_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_accuracy_eval_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_accuracy_eval_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_baseline_run_exp_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_baseline_run_exp_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_baseline_run_exp_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_candidate_run_exp_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_candidate_run_exp_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_candidate_run_exp_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_accuracy_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_accuracy_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_accuracy_evaluator') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_dataset = ArizeAxDeleteDatasetOperator(
+        task_id="cleanup_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_demo_prompt = ArizeAxDeletePromptOperator(
+        task_id="cleanup_demo_prompt",
+        prompt_id="{{ ti.xcom_pull(task_ids='create_demo_prompt') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+
+    # Wiring — baseline and candidate experiments run *serially*, not in
+    # parallel. We saw the Arize backend silently stall one of two
+    # concurrent run_experiment triggers (status stuck at "running" with
+    # zero success/error counters), so we wait for the baseline chain to
+    # terminate before kicking off the candidate.
+    check_prereqs >> create_eval_dataset
+    check_prereqs >> [build_accuracy_judge_config, build_baseline_run_config, build_candidate_run_config]
+    build_accuracy_judge_config >> create_accuracy_evaluator >> create_accuracy_eval_task
+    [create_eval_dataset, build_baseline_run_config] >> create_baseline_run_exp_task
+    [create_eval_dataset, build_candidate_run_config] >> create_candidate_run_exp_task
+    [create_baseline_run_exp_task, create_accuracy_eval_task] >> run_baseline_experiment
+    run_baseline_experiment >> score_baseline
+    # Candidate trigger blocks on baseline terminal — avoid concurrent runs.
+    [run_baseline_experiment, create_candidate_run_exp_task, create_accuracy_eval_task] >> run_candidate_experiment
+    run_candidate_experiment >> score_candidate
+    [score_baseline, score_candidate] >> compare_experiments
+    # Self-contained promotion path: create_demo_prompt happens up-front so
+    # the prompt always exists when promote_prompt fires.
+    check_prereqs >> create_demo_prompt
+    compare_experiments >> promote_prompt
+    create_demo_prompt >> promote_prompt >> promote_notification
+    # Cleanup runs unconditionally (trigger_rule="all_done").
+    promote_notification >> [
+        cleanup_accuracy_eval_task,
+        cleanup_baseline_run_exp_task,
+        cleanup_candidate_run_exp_task,
+        cleanup_accuracy_evaluator,
+        cleanup_dataset,
+        cleanup_demo_prompt,
+    ]

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_llm_experiments_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_llm_experiments_dag.py
@@ -1,87 +1,101 @@
 """
-LLM Experiment Comparison DAG: runs 5 real experiments with different model and
-prompt combinations against the same dataset, so you can compare scores
-side-by-side on the Arize dashboard.
+LLM Experiment Comparison DAG (server-side): runs 3 real experiments with
+different model + prompt combinations against the same dataset, scored
+end-to-end on the Arize Eval Hub so you can compare them side-by-side on
+the Arize dashboard.
 
 Experiment matrix
 -----------------
-+---+--------------------+-----------+--------------------------------------+
-| # | Model              | Prompt    | Purpose                              |
-+---+--------------------+-----------+--------------------------------------+
-| 1 | gpt-4o-mini        | concise   | Baseline: cheap model, simple prompt |
-| 2 | gpt-4o             | concise   | Better model, same prompt            |
-| 3 | claude-3-haiku     | concise   | Different provider, same prompt      |
-| 4 | gpt-4o-mini        | detailed  | Same cheap model, better prompt      |
-| 5 | claude-3-haiku     | detailed  | Cross-provider prompt impact         |
-+---+--------------------+-----------+--------------------------------------+
++---+--------------+-----------+--------------------------------------+
+| # | Model        | Prompt    | Purpose                              |
++---+--------------+-----------+--------------------------------------+
+| 1 | gpt-4o-mini  | concise   | Baseline: cheap model, simple prompt |
+| 2 | gpt-4.1      | concise   | Better model, same prompt            |
+| 3 | gpt-4o-mini  | detailed  | Same cheap model, better prompt      |
++---+--------------+-----------+--------------------------------------+
 
 Comparing (1 vs 2): model quality impact (holding prompt constant)
-Comparing (1 vs 3): provider comparison (same tier, different vendor)
-Comparing (1 vs 4): prompt engineering impact (holding model constant)
-Comparing (3 vs 5): prompt impact on same model, different provider
+Comparing (1 vs 3): prompt engineering impact (holding model constant)
 
-Three LLM-as-Judge evaluators run on every experiment (using GPT-4o-mini
-as the judge via ``arize-phoenix-evals >= 3.0.0``):
+Three server-side LLM-as-Judge evaluators run on every experiment via
+chained ``template_evaluation`` tasks (Eval Hub executes them server-side
+after each run_experiment terminates):
   - **qa_correctness**: is the answer factually correct? (correct / incorrect)
   - **hallucination**: does the output contain fabricated information?
     (factual / hallucinated)
   - **relevance**: does the output address the question? (relevant / irrelevant)
 
-These evaluators produce score + label + explanation columns on the Arize
-dashboard, giving rich per-row insights into each model's behavior.
+Each judge produces score + label + explanation columns on the experiment
+runs, giving rich per-row insights into each model's behavior.
 
-Prompts are created in the Arize Prompt Hub using the
-``ArizeAxCreatePromptOperator`` and cleaned up at the end with
-``ArizeAxDeletePromptOperator``. Note: the Arize SDK ``experiments.run()`` API
-does not currently accept a prompt_id or prompt_version_id parameter, so
-experiments run via this DAG are not automatically linked to those Prompt Hub
-prompts in the Arize UI (you may see "No prompt template available" on the
-experiment row). Linking prompts to experiments is supported when running from
-the Arize Prompt Playground or when the API adds support. See
-``docs/arize-experiments-and-prompts-analysis.md`` for a full analysis of the
-API/SDK and options.
+Prereqs
+-------
+1. Airflow connection ``arize_ax_default`` with a valid API key.
+2. Airflow Variable ``arize_ax_space_id`` (or ``default_space`` on the connection extras).
+3. Airflow Variable ``arize_ai_integration_id`` (or env-var
+   ``ARIZE_AI_INTEGRATION_ID``) pointing at an OpenAI integration with a
+   real API key — used for **both** the run_experiment LLM calls and the
+   chained LLM-as-judge evaluators. Server-side execution means there are
+   no ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY`` on the Airflow worker.
 
-Requires:
-  - Airflow connection ``arize_ax_default`` with valid API key + space_id.
-  - Environment variables ``OPENAI_API_KEY`` and ``ANTHROPIC_API_KEY`` set in
-    the Airflow worker (e.g. via docker-compose environment section).
-  - Python packages: ``openai``, ``anthropic``, ``arize-phoenix-evals``.
+For an Anthropic / multi-provider variant, fork this DAG and add an
+additional AI integration ID + a second model_name + an
+``ArizeAxCreateRunExperimentTaskOperator`` per provider.
 """
 
 from __future__ import annotations
 
-import os
 from datetime import datetime, timedelta
 from typing import Any
 
 from airflow import DAG
+from airflow.models import Variable
 from airflow.providers.arize_ax.operators.datasets import (
     ArizeAxCreateDatasetOperator,
     ArizeAxDeleteDatasetOperator,
     ArizeAxGetDatasetOperator,
 )
+from airflow.providers.arize_ax.operators.evaluators import (
+    ArizeAxCreateEvaluatorOperator,
+    ArizeAxDeleteEvaluatorOperator,
+)
 from airflow.providers.arize_ax.operators.experiments import (
     ArizeAxListExperimentsOperator,
-    ArizeAxRunExperimentOperator,
-)
-from airflow.providers.arize_ax.operators.projects import (
-    ArizeAxCreateProjectOperator,
-    ArizeAxDeleteProjectOperator,
-)
-from airflow.providers.arize_ax.operators.prompts import (
-    ArizeAxCreatePromptOperator,
-    ArizeAxDeletePromptOperator,
 )
 from airflow.providers.arize_ax.operators.spaces import (
     ArizeAxListSpacesOperator,
 )
+from airflow.providers.arize_ax.operators.tasks import (
+    ArizeAxCreateRunExperimentTaskOperator,
+    ArizeAxCreateTaskOperator,
+    ArizeAxDeleteTaskOperator,
+)
 from airflow.providers.arize_ax.sensors.arize_ax import (
     ArizeAxDatasetReadySensor,
+)
+from airflow.providers.arize_ax.utils.task_groups import (
+    arize_ax_chained_experiment_eval,
 )
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
 
 INSPECTION_WINDOW_MINUTES = 15
+
+# Single source of truth for the space all resources live in. Avoids the
+# trap of letting `list_spaces`'s "first" entry pick a different space than
+# the connection's default_space — which causes `create_task` to 404 looking
+# for the evaluator in the wrong space.
+_SPACE_JINJA = "{{ var.value.get('arize_ax_space_id', '') or None }}"
+
+# Per-run suffix derived from run_id (works regardless of whether the DAG
+# was triggered with --logical-date). We use this to give every ephemeral
+# resource a name that's unique to the run, so we never collide with a
+# tombstoned resource from a prior run that the Arize API still treats as
+# name-taken (a soft-delete leakage we observed on evaluators).
+_RUN_SUFFIX = (
+    "{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') "
+    "| replace('.', '') | replace('_', '') }}"
+)
 
 PROMPT_CONCISE = (
     "You are a helpful assistant. Answer the question in as few words as "
@@ -94,12 +108,12 @@ PROMPT_DETAILED = (
     "line prefixed with 'Answer: '. Be precise and accurate."
 )
 
+# (name, model, system_prompt) — single-provider (OpenAI) to keep the demo
+# runnable on a single AI integration.
 EXPERIMENT_CONFIGS: list[dict[str, str]] = [
-    {"name": "gpt4omini-concise", "provider": "openai", "model": "gpt-4o-mini", "prompt": PROMPT_CONCISE},
-    {"name": "gpt4o-concise", "provider": "openai", "model": "gpt-4o", "prompt": PROMPT_CONCISE},
-    {"name": "haiku-concise", "provider": "anthropic", "model": "claude-3-haiku-20240307", "prompt": PROMPT_CONCISE},
-    {"name": "gpt4omini-detailed", "provider": "openai", "model": "gpt-4o-mini", "prompt": PROMPT_DETAILED},
-    {"name": "haiku-detailed", "provider": "anthropic", "model": "claude-3-haiku-20240307", "prompt": PROMPT_DETAILED},
+    {"name": "gpt4omini-concise",  "model": "gpt-4o-mini", "prompt": PROMPT_CONCISE},
+    {"name": "gpt41-concise",      "model": "gpt-4.1",     "prompt": PROMPT_CONCISE},
+    {"name": "gpt4omini-detailed", "model": "gpt-4o-mini", "prompt": PROMPT_DETAILED},
 ]
 
 DATASET_EXAMPLES = [
@@ -114,276 +128,136 @@ DATASET_EXAMPLES = [
 ]
 
 
-def _make_llm_task(provider: str, model: str, system_prompt: str):
-    """Return a task callable that calls the specified LLM."""
-
-    def _task(dataset_row: dict) -> str:
-        query = dataset_row.get("query", "")
-        if provider == "openai":
-            import openai
-
-            client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
-            response = client.chat.completions.create(
-                model=model,
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": query},
-                ],
-                max_tokens=200,
-                temperature=0.0,
-            )
-            return response.choices[0].message.content.strip()
-
-        elif provider == "anthropic":
-            import anthropic
-
-            client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
-            response = client.messages.create(
-                model=model,
-                max_tokens=200,
-                temperature=0.0,
-                system=system_prompt,
-                messages=[{"role": "user", "content": query}],
-            )
-            return response.content[0].text.strip()
-
-        raise ValueError(f"Unknown provider: {provider}")
-
-    _task.__name__ = f"task_{provider}_{model.replace('-', '_').replace('.', '_')}"
-    return _task
-
-
+# Evaluator template strings. The `template_evaluation` config uses
+# f-string single-brace substitution (server-validated at create time);
+# the `run_experiment` task's `messages` field uses mustache double-brace
+# substitution. The two surfaces have different rules.
 QA_CORRECTNESS_TEMPLATE = (
     "You are evaluating a question-answering system.\n\n"
-    "[BEGIN DATA]\n"
     "[Question]: {query}\n"
     "[Expected Answer]: {expected_output}\n"
-    "[System Output]: {output}\n"
-    "[END DATA]\n\n"
+    "[System Output]: {output}\n\n"
     "The system output is correct if it conveys the same factual answer as the "
     "expected answer, even if the phrasing differs. Minor wording differences "
-    "are acceptable.\n\n"
-    "Explain your reasoning in 1-2 sentences, then provide a single-word "
-    "LABEL on its own line: either 'correct' or 'incorrect'."
+    "are acceptable. Reply with ONLY 'correct' or 'incorrect'."
 )
 
 HALLUCINATION_TEMPLATE = (
     "You are evaluating whether an AI response contains hallucinated "
     "(fabricated or factually wrong) information.\n\n"
-    "[BEGIN DATA]\n"
     "[Question]: {query}\n"
     "[Expected Answer]: {expected_output}\n"
-    "[System Output]: {output}\n"
-    "[END DATA]\n\n"
-    "The output is 'factual' if all claims are accurate or consistent with "
-    "the expected answer. The output is 'hallucinated' if it contains any "
-    "made-up facts, wrong numbers, or fabricated details.\n\n"
-    "Explain your reasoning in 1-2 sentences, then provide a single-word "
-    "LABEL on its own line: either 'factual' or 'hallucinated'."
+    "[System Output]: {output}\n\n"
+    "Reply with ONLY 'factual' (all claims accurate or consistent with the "
+    "expected answer) or 'hallucinated' (contains made-up facts, wrong "
+    "numbers, or fabricated details)."
 )
 
 RELEVANCE_TEMPLATE = (
     "You are evaluating whether an AI response is relevant to the question.\n\n"
-    "[BEGIN DATA]\n"
     "[Question]: {query}\n"
-    "[System Output]: {output}\n"
-    "[END DATA]\n\n"
-    "The output is 'relevant' if it directly addresses the question, even if "
-    "it includes extra detail. The output is 'irrelevant' if it does not "
-    "attempt to answer the question or goes completely off-topic.\n\n"
-    "Explain your reasoning in 1-2 sentences, then provide a single-word "
-    "LABEL on its own line: either 'relevant' or 'irrelevant'."
+    "[System Output]: {output}\n\n"
+    "Reply with ONLY 'relevant' (directly addresses the question, even if it "
+    "includes extra detail) or 'irrelevant' (does not attempt to answer the "
+    "question or goes completely off-topic)."
 )
 
 
-# ---------------------------------------------------------------------------
-# LLM-as-Judge evaluator functions (arize-phoenix-evals >= 3.0.0)
-# Requires OPENAI_API_KEY env var. Falls back to keyword-heuristic scoring
-# when arize-phoenix-evals is unavailable or OPENAI_API_KEY is not set.
-# ---------------------------------------------------------------------------
-def _make_llm():
-    """Construct a phoenix.evals 3.x LLM instance (OpenAI gpt-4o-mini)."""
-    from phoenix.evals import LLM
-    return LLM(provider="openai", model="gpt-4o-mini", api_key=os.environ["OPENAI_API_KEY"])
+def _resolve_integration_id() -> str:
+    return (
+        Variable.get("arize_ai_integration_id", default_var="").strip()
+        or Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
+    )
 
 
-def _qa_correctness(output: str, dataset_row: dict):
-    """LLM-as-Judge correctness using arize-phoenix-evals 3.x create_classifier."""
-    from arize.experiments import EvaluationResult
+def _build_judge_template_config(name: str, template: str, choices: dict[str, float]):
+    """Factory: build a template_config dict for one of the three judges."""
 
-    if output is None:
-        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
+    def _callable(**_ctx) -> dict[str, Any]:
+        integration_id = _resolve_integration_id()
+        return {
+            "name": name,
+            "template": template,
+            "include_explanations": True,
+            "use_function_calling_if_available": False,
+            "classification_choices": choices,
+            "llm_config": {
+                "ai_integration_id": integration_id,
+                "model_name": "gpt-4o-mini",
+                "invocation_parameters": {"temperature": 0},
+                "provider_parameters": {},
+            },
+        }
 
-    try:
-        from phoenix.evals import create_classifier
-        evaluator = create_classifier(
-            name="qa_correctness",
-            prompt_template=QA_CORRECTNESS_TEMPLATE,
-            llm=_make_llm(),
-            choices={"correct": 1.0, "incorrect": 0.0},
-        )
-        scores = evaluator.evaluate({
-            "query": dataset_row.get("query", ""),
-            "expected_output": dataset_row.get("expected_output", ""),
-            "output": output,
-        })
-        s = scores[0]
-        return EvaluationResult(
-            score=float(s.score) if s.score is not None else 0.0,
-            label=s.label or "incorrect",
-            explanation=s.explanation or "LLM-as-judge (qa_correctness)",
-        )
-    except Exception as exc:
-        expected = str(dataset_row.get("expected_output", "")).strip().lower()
-        actual = str(output).strip().lower()
-        match = bool(expected and expected in actual)
-        return EvaluationResult(
-            score=1.0 if match else 0.0,
-            label="correct" if match else "incorrect",
-            explanation=f"Heuristic fallback ({exc.__class__.__name__}): expected in output={match}",
-        )
+    _callable.__name__ = f"_build_{name}_template_config"
+    return _callable
 
 
-def _hallucination_check(output: str, dataset_row: dict):
-    """LLM-as-Judge hallucination using arize-phoenix-evals 3.x create_classifier."""
-    from arize.experiments import EvaluationResult
+def _build_run_config(model: str, system_prompt: str):
+    """Factory: build a LlmGenerationRunConfig dict for one experiment variant."""
 
-    if output is None:
-        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
+    def _callable(**_ctx) -> dict[str, Any]:
+        integration_id = _resolve_integration_id()
+        return {
+            "experiment_type": "llm_generation",
+            "ai_integration_id": integration_id,
+            "model_name": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                # Mustache + double-brace: the run_experiment surface uses
+                # mustache substitution (different rule than the evaluator
+                # template, which uses single-brace f-string).
+                {"role": "user", "content": "{{query}}"},
+            ],
+            "input_variable_format": "mustache",
+            "invocation_parameters": {"temperature": 0},
+            "provider_parameters": {},
+        }
 
-    try:
-        from phoenix.evals import create_classifier
-        evaluator = create_classifier(
-            name="hallucination",
-            prompt_template=HALLUCINATION_TEMPLATE,
-            llm=_make_llm(),
-            choices={"factual": 1.0, "hallucinated": 0.0},
-        )
-        scores = evaluator.evaluate({
-            "query": dataset_row.get("query", ""),
-            "expected_output": dataset_row.get("expected_output", ""),
-            "output": output,
-        })
-        s = scores[0]
-        return EvaluationResult(
-            score=float(s.score) if s.score is not None else 0.0,
-            label=s.label or "hallucinated",
-            explanation=s.explanation or "LLM-as-judge (hallucination)",
-        )
-    except Exception as exc:
-        expected_words = {w.lower() for w in str(dataset_row.get("expected_output", "")).split() if len(w) > 4}
-        output_words = {w.lower() for w in str(output).split() if len(w) > 4}
-        overlap = expected_words & output_words
-        factual = bool(overlap) or not expected_words
-        return EvaluationResult(
-            score=1.0 if factual else 0.0,
-            label="factual" if factual else "hallucinated",
-            explanation=f"Heuristic fallback ({exc.__class__.__name__}): keyword overlap={overlap or 'none'}",
-        )
-
-
-def _relevance_check(output: str, dataset_row: dict):
-    """LLM-as-Judge relevance using arize-phoenix-evals 3.x create_classifier."""
-    from arize.experiments import EvaluationResult
-
-    if output is None:
-        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
-
-    try:
-        from phoenix.evals import create_classifier
-        evaluator = create_classifier(
-            name="relevance",
-            prompt_template=RELEVANCE_TEMPLATE,
-            llm=_make_llm(),
-            choices={"relevant": 1.0, "irrelevant": 0.0},
-        )
-        scores = evaluator.evaluate({
-            "query": dataset_row.get("query", ""),
-            "output": output,
-        })
-        s = scores[0]
-        return EvaluationResult(
-            score=float(s.score) if s.score is not None else 0.0,
-            label=s.label or "irrelevant",
-            explanation=s.explanation or "LLM-as-judge (relevance)",
-        )
-    except Exception as exc:
-        query_words = {w.lower() for w in str(dataset_row.get("query", "")).split() if len(w) > 3}
-        output_words = {w.lower() for w in str(output).split() if len(w) > 3}
-        overlap = query_words & output_words
-        relevant = bool(overlap)
-        return EvaluationResult(
-            score=1.0 if relevant else 0.0,
-            label="relevant" if relevant else "irrelevant",
-            explanation=f"Heuristic fallback ({exc.__class__.__name__}): query–output overlap={overlap or 'none'}",
-        )
+    _callable.__name__ = f"_build_run_config_{model.replace('-', '_')}"
+    return _callable
 
 
 def _verify_experiment_results(**ctx) -> dict[str, Any]:
-    """Summarise which experiment tasks produced non-None XCom values."""
+    """Log a summary of the chained experiment runs for the Airflow UI."""
     ti = ctx["ti"]
-    task_ids = [f"exp_{cfg['name'].replace('-', '_')}" for cfg in EXPERIMENT_CONFIGS]
-    task_ids += [
-        "create_project", "create_dataset", "list_experiments",
-        "create_prompt_concise", "create_prompt_detailed",
-    ]
-    checks = {tid: ti.xcom_pull(task_ids=tid) is not None for tid in task_ids}
-    passed = sum(checks.values())
-    print(f"Verification: {passed}/{len(checks)} tasks produced output")
-    for tid, ok in checks.items():
-        print(f"  {'PASS' if ok else 'FAIL'}: {tid}")
-    return {"passed": passed, "total": len(checks), "checks": checks}
-
-
-def _cleanup_experiments(**ctx) -> None:
-    """Delete all experiments for the dataset, then the dataset and project."""
-    from airflow.providers.arize_ax.hooks.arize_ax import ArizeAxHook
-
-    hook = ArizeAxHook()
-    ds_id = ctx["ti"].xcom_pull(task_ids="create_dataset")
-    if not ds_id or str(ds_id) == "None":
-        print("No dataset ID -- skipping experiment cleanup.")
-        return
-
-    try:
-        result = hook.list_experiments(dataset_id=str(ds_id), limit=50)
-        items = result.get("items", []) if isinstance(result, dict) else []
-        for exp in items:
-            exp_id = exp.get("id") if isinstance(exp, dict) else None
-            if exp_id:
-                try:
-                    hook.delete_experiment(experiment_id=str(exp_id))
-                    print(f"Deleted experiment {exp_id}")
-                except Exception as exc:
-                    print(f"Failed to delete experiment {exp_id} (non-fatal): {exc}")
-    except Exception as exc:
-        print(f"Failed to list experiments for cleanup (non-fatal): {exc}")
+    summary: dict[str, Any] = {}
+    for cfg in EXPERIMENT_CONFIGS:
+        group_id = f"exp_{cfg['name'].replace('-', '_')}"
+        triggered = ti.xcom_pull(task_ids=f"{group_id}.trigger", key="result") or {}
+        summary[cfg["name"]] = {
+            "experiment_id": triggered.get("experiment_id") if isinstance(triggered, dict) else None,
+            "chained_run_id": triggered.get("id") if isinstance(triggered, dict) else None,
+        }
+    print("=" * 60)
+    print("LLM EXPERIMENT COMPARISON COMPLETE (server-side)")
+    for name, info in summary.items():
+        print(f"  {name:25} experiment={info['experiment_id']}")
+    print("  Compare them in Arize: Datasets → <dataset> → Experiments tab.")
+    print("=" * 60)
+    return summary
 
 
 with DAG(
     dag_id="arize_ax_e2e_llm_experiment_comparison",
-    start_date=datetime(2025, 1, 1),
+    start_date=datetime(2026, 1, 1),
     schedule=None,
-    tags=["arize_ax", "e2e", "llm", "experiments"],
+    tags=["arize_ax", "e2e", "experiments", "llm", "comparison", "eval-hub"],
     catchup=False,
     doc_md=__doc__,
+    render_template_as_native_obj=True,
 ) as dag:
 
-    # Phase 1 -- Discovery
-    list_spaces = ArizeAxListSpacesOperator(task_id="list_spaces", limit=10)
-
-    # Phase 2 -- Resource setup
-    create_project = ArizeAxCreateProjectOperator(
-        task_id="create_project",
-        space_id="{{ ti.xcom_pull(task_ids='list_spaces', key='first_id') }}",
-        name="e2e-llm-{{ ts_nodash }}",
-        if_exists="skip",
+    # ----- Phase 1: dataset + space lookup ----------------------------------
+    list_spaces = ArizeAxListSpacesOperator(
+        task_id="list_spaces",
+        limit=10,
     )
 
     create_dataset = ArizeAxCreateDatasetOperator(
         task_id="create_dataset",
-        space_id="{{ ti.xcom_pull(task_ids='list_spaces', key='first_id') }}",
-        name="e2e-qa-{{ ts_nodash }}",
+        space_id=_SPACE_JINJA,
+        name="llm-experiments-{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') | replace('.', '') | replace('_', '') }}",
         examples=DATASET_EXAMPLES,
         if_exists="skip",
     )
@@ -393,40 +267,6 @@ with DAG(
         dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
     )
 
-    # Phase 3 -- Create prompts in Prompt Hub
-    create_prompt_concise = ArizeAxCreatePromptOperator(
-        task_id="create_prompt_concise",
-        space_id="{{ ti.xcom_pull(task_ids='list_spaces', key='first_id') }}",
-        name="e2e-concise-{{ ts_nodash }}",
-        messages=[
-            {"role": "system", "content": PROMPT_CONCISE},
-            {"role": "user", "content": "{query}"},
-        ],
-        provider="open_ai",
-        input_variable_format="f_string",
-        model="gpt-4o-mini",
-        commit_message="Concise prompt from e2e run {{ ts_nodash }}",
-        description="Auto-generated concise prompt",
-        if_exists="skip",
-    )
-
-    create_prompt_detailed = ArizeAxCreatePromptOperator(
-        task_id="create_prompt_detailed",
-        space_id="{{ ti.xcom_pull(task_ids='list_spaces', key='first_id') }}",
-        name="e2e-detailed-{{ ts_nodash }}",
-        messages=[
-            {"role": "system", "content": PROMPT_DETAILED},
-            {"role": "user", "content": "{query}"},
-        ],
-        provider="open_ai",
-        input_variable_format="f_string",
-        model="gpt-4o-mini",
-        commit_message="Detailed prompt from e2e run {{ ts_nodash }}",
-        description="Auto-generated detailed prompt",
-        if_exists="skip",
-    )
-
-    # Phase 4 -- Sensor gate
     dataset_ready = ArizeAxDatasetReadySensor(
         task_id="dataset_ready_sensor",
         dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
@@ -436,21 +276,159 @@ with DAG(
         mode="poke",
     )
 
-    # Phase 5 -- Run 5 experiments (parallel after dataset is ready)
-    experiment_tasks = []
-    for cfg in EXPERIMENT_CONFIGS:
-        task_id = f"exp_{cfg['name'].replace('-', '_')}"
-        exp_task = ArizeAxRunExperimentOperator(
-            task_id=task_id,
-            name=f"{cfg['name']}-{{{{ ts_nodash }}}}",
-            dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
-            task=_make_llm_task(cfg["provider"], cfg["model"], cfg["prompt"]),
-            evaluators=[_qa_correctness, _hallucination_check, _relevance_check],
-            concurrency=4,
-        )
-        experiment_tasks.append(exp_task)
+    # ----- Phase 2: three server-side judges (template_evaluation tasks) -----
+    build_qa_config = PythonOperator(
+        task_id="build_qa_config",
+        python_callable=_build_judge_template_config(
+            "qa_correctness", QA_CORRECTNESS_TEMPLATE,
+            {"correct": 1.0, "incorrect": 0.0},
+        ),
+    )
+    create_qa_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_qa_evaluator",
+        space_id=_SPACE_JINJA,
+        name=f"qa_correctness_{_RUN_SUFFIX}",
+        evaluator_type="template",
+        commit_message="initial qa_correctness judge",
+        template_config_task_id="build_qa_config",
+        description="LLM-as-judge for factual correctness.",
+    )
 
-    # Phase 5b -- List all experiments for the dataset
+    build_hallu_config = PythonOperator(
+        task_id="build_hallu_config",
+        python_callable=_build_judge_template_config(
+            "hallucination", HALLUCINATION_TEMPLATE,
+            {"factual": 1.0, "hallucinated": 0.0},
+        ),
+    )
+    create_hallu_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_hallu_evaluator",
+        space_id=_SPACE_JINJA,
+        name=f"hallucination_{_RUN_SUFFIX}",
+        evaluator_type="template",
+        commit_message="initial hallucination judge",
+        template_config_task_id="build_hallu_config",
+        description="LLM-as-judge for fabricated content.",
+    )
+
+    build_relevance_config = PythonOperator(
+        task_id="build_relevance_config",
+        python_callable=_build_judge_template_config(
+            "relevance", RELEVANCE_TEMPLATE,
+            {"relevant": 1.0, "irrelevant": 0.0},
+        ),
+    )
+    create_relevance_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_relevance_evaluator",
+        space_id=_SPACE_JINJA,
+        name=f"relevance_{_RUN_SUFFIX}",
+        evaluator_type="template",
+        commit_message="initial relevance judge",
+        template_config_task_id="build_relevance_config",
+        description="LLM-as-judge for question relevance.",
+    )
+
+    create_qa_task = ArizeAxCreateTaskOperator(
+        task_id="create_qa_task",
+        name="llm-exp-qa-{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') | replace('.', '') | replace('_', '') }}",
+        eval_task_type="template_evaluation",
+        evaluators=[
+            {"evaluator_id": "{{ ti.xcom_pull(task_ids='create_qa_evaluator') }}"},
+        ],
+        project_id="{{ var.value.get('arize_ax_project_id', '') or None }}",
+        is_continuous=False,
+        sampling_rate=1.0,
+    )
+    create_hallu_task = ArizeAxCreateTaskOperator(
+        task_id="create_hallu_task",
+        name="llm-exp-hallu-{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') | replace('.', '') | replace('_', '') }}",
+        eval_task_type="template_evaluation",
+        evaluators=[
+            {"evaluator_id": "{{ ti.xcom_pull(task_ids='create_hallu_evaluator') }}"},
+        ],
+        project_id="{{ var.value.get('arize_ax_project_id', '') or None }}",
+        is_continuous=False,
+        sampling_rate=1.0,
+    )
+    create_relevance_task = ArizeAxCreateTaskOperator(
+        task_id="create_relevance_task",
+        name="llm-exp-relevance-{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') | replace('.', '') | replace('_', '') }}",
+        eval_task_type="template_evaluation",
+        evaluators=[
+            {"evaluator_id": "{{ ti.xcom_pull(task_ids='create_relevance_evaluator') }}"},
+        ],
+        project_id="{{ var.value.get('arize_ax_project_id', '') or None }}",
+        is_continuous=False,
+        sampling_rate=1.0,
+    )
+
+    # ----- Phase 3: 3 run_experiment tasks (server-side LLM calls) ----------
+    build_run_config_tasks: dict[str, PythonOperator] = {}
+    create_run_exp_tasks: dict[str, ArizeAxCreateRunExperimentTaskOperator] = {}
+    chain_groups: list = []
+    cleanup_run_exp_tasks: list = []
+
+    for cfg in EXPERIMENT_CONFIGS:
+        suffix = cfg["name"].replace("-", "_")
+
+        build_cfg = PythonOperator(
+            task_id=f"build_run_config_{suffix}",
+            python_callable=_build_run_config(cfg["model"], cfg["prompt"]),
+        )
+        build_run_config_tasks[cfg["name"]] = build_cfg
+
+        create_task = ArizeAxCreateRunExperimentTaskOperator(
+            task_id=f"create_run_exp_task_{suffix}",
+            space_id=_SPACE_JINJA,
+            name=f"llm-exp-task-{cfg['name']}-{{{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') | replace('.', '') | replace('_', '') }}}}",
+            dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
+            run_configuration=(
+                f"{{{{ ti.xcom_pull(task_ids='build_run_config_{suffix}') }}}}"
+            ),
+            if_exists="skip",
+        )
+        create_run_exp_tasks[cfg["name"]] = create_task
+
+        # Chain all three evaluators after each run_experiment.
+        group = arize_ax_chained_experiment_eval(
+            group_id=f"exp_{suffix}",
+            task_id_param=(
+                f"{{{{ ti.xcom_pull(task_ids='create_run_exp_task_{suffix}') }}}}"
+            ),
+            experiment_name=f"{cfg['name']}-{{{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') | replace('.', '') | replace('_', '') }}}}",
+            space_id=_SPACE_JINJA,
+            evaluation_task_ids=[
+                "{{ ti.xcom_pull(task_ids='create_qa_task') }}",
+                "{{ ti.xcom_pull(task_ids='create_hallu_task') }}",
+                "{{ ti.xcom_pull(task_ids='create_relevance_task') }}",
+            ],
+            wait_for_completion=True,
+            sensor_timeout=900,
+            sensor_poke_interval=15,
+            fail_on_run_error=True,
+        )
+        chain_groups.append(group)
+
+        cleanup_run_exp_tasks.append(
+            ArizeAxDeleteTaskOperator(
+                task_id=f"cleanup_run_exp_task_{suffix}",
+                task_id_param=(
+                    f"{{{{ ti.xcom_pull(task_ids='create_run_exp_task_{suffix}') }}}}"
+                ),
+                ignore_if_missing=True,
+                trigger_rule="all_done",
+            )
+        )
+
+        # Wire deps within the per-experiment branch
+        [dataset_ready, build_cfg] >> create_task
+        [
+            create_task,
+            create_qa_task,
+            create_hallu_task,
+            create_relevance_task,
+        ] >> group
+
     list_experiments = ArizeAxListExperimentsOperator(
         task_id="list_experiments",
         dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
@@ -458,7 +436,6 @@ with DAG(
         trigger_rule="all_done",
     )
 
-    # Phase 6 -- Verification + Inspection
     verify = PythonOperator(
         task_id="verify_results",
         python_callable=_verify_experiment_results,
@@ -468,65 +445,67 @@ with DAG(
     inspection_window = TimeDeltaSensor(
         task_id="inspection_window",
         delta=timedelta(minutes=INSPECTION_WINDOW_MINUTES),
-        mode="reschedule",
-        trigger_rule="all_done",
     )
 
-    # Phase 7 -- Cleanup (always runs)
-    cleanup_exps = PythonOperator(
-        task_id="cleanup_experiments",
-        python_callable=_cleanup_experiments,
-        trigger_rule="all_done",
-    )
-
-    delete_prompt_concise = ArizeAxDeletePromptOperator(
-        task_id="cleanup_prompt_concise",
-        prompt_id="{{ ti.xcom_pull(task_ids='create_prompt_concise') }}",
-        trigger_rule="all_done",
-    )
-
-    delete_prompt_detailed = ArizeAxDeletePromptOperator(
-        task_id="cleanup_prompt_detailed",
-        prompt_id="{{ ti.xcom_pull(task_ids='create_prompt_detailed') }}",
-        trigger_rule="all_done",
-    )
-
-    cleanup_ds = ArizeAxDeleteDatasetOperator(
+    # ----- Phase 4: cleanup -------------------------------------------------
+    cleanup_dataset = ArizeAxDeleteDatasetOperator(
         task_id="cleanup_dataset",
         dataset_id="{{ ti.xcom_pull(task_ids='create_dataset') }}",
         ignore_if_missing=True,
         trigger_rule="all_done",
     )
-
-    cleanup_proj = ArizeAxDeleteProjectOperator(
-        task_id="cleanup_project",
-        project_id="{{ ti.xcom_pull(task_ids='create_project') }}",
+    cleanup_qa_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_qa_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_qa_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_hallu_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_hallu_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_hallu_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_relevance_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_relevance_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_relevance_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_qa_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_qa_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_qa_evaluator') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_hallu_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_hallu_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_hallu_evaluator') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_relevance_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_relevance_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_relevance_evaluator') }}",
         ignore_if_missing=True,
         trigger_rule="all_done",
     )
 
-    # Wiring
+    # ----- Top-level wiring -------------------------------------------------
+    list_spaces >> create_dataset >> [get_dataset, dataset_ready]
+    list_spaces >> [build_qa_config, build_hallu_config, build_relevance_config]
+    build_qa_config >> create_qa_evaluator >> create_qa_task
+    build_hallu_config >> create_hallu_evaluator >> create_hallu_task
+    build_relevance_config >> create_relevance_evaluator >> create_relevance_task
 
-    # Phase 1 → 2
-    list_spaces >> [create_project, create_dataset]
-    create_dataset >> get_dataset
-
-    # Phase 2 → 3 (create prompts after space_id is known)
-    list_spaces >> [create_prompt_concise, create_prompt_detailed]
-
-    # Phase 2 → 4 (sensor gate after dataset exists)
-    get_dataset >> dataset_ready
-
-    # Phase 4 → 5 (all experiments run in parallel after dataset is ready)
-    for exp_task in experiment_tasks:
-        dataset_ready >> exp_task
-
-    # Phase 5 → 5b (list all experiments after they complete)
-    experiment_tasks >> list_experiments
-
-    # Phase 5 + extras → 6 (verify after everything)
-    [list_experiments, create_prompt_concise, create_prompt_detailed, create_project] >> verify
-
-    # Phase 6 → 6b → 7
-    verify >> inspection_window
-    inspection_window >> cleanup_exps >> [delete_prompt_concise, delete_prompt_detailed] >> cleanup_ds >> cleanup_proj
+    chain_groups >> list_experiments >> verify >> inspection_window
+    inspection_window >> [
+        cleanup_dataset,
+        *cleanup_run_exp_tasks,
+        cleanup_qa_task,
+        cleanup_hallu_task,
+        cleanup_relevance_task,
+        cleanup_qa_evaluator,
+        cleanup_hallu_evaluator,
+        cleanup_relevance_evaluator,
+    ]

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_lifecycle_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_prompt_lifecycle_dag.py
@@ -1,70 +1,66 @@
 """
-Prompt Lifecycle Management DAG: version → evaluate → promote → monitor → rollback.
+Prompt Lifecycle Management DAG (server-side, self-contained):
+version → evaluate → promote → re-evaluate → promote → archive.
 
-This DAG implements a full prompt lifecycle, using only existing Arize AX
-operators.  It is designed to be triggered externally (e.g. on a new prompt
-commit or a CI event) and gates each promotion stage with evaluation scores.
+The DAG implements a two-stage gated promotion ladder for an LLM prompt.
+A *staging* experiment must clear an absolute accuracy threshold; if it
+does, the prompt is labelled ``"staging"``. A *production* experiment
+(with an improved system prompt) then runs and is compared against the
+staging experiment; if it doesn't regress, the prompt is labelled
+``"production"`` and a final archival notification fires.
+
+It is fully self-contained — no pre-existing prompt, dataset, baseline
+experiment, or thresholds Variable required. Everything is provisioned
+and torn down on every run.
 
 Lifecycle stages
 ----------------
-**Stage 1 — Setup**
-  - Fetch the latest version of the target prompt from Prompt Hub.
-  - Create (or reuse) the evaluation dataset.
-  - Append evaluation examples.
+0. **check_prereqs** — short-circuit if ``ARIZE_AI_INTEGRATION_ID`` isn't
+   resolvable.
+1. **create_eval_dataset** — provision the evaluation dataset.
+2. **build_accuracy_judge_config / create_accuracy_evaluator /
+   create_accuracy_eval_task** — the LLM-as-judge that scores each row.
+3. **create_demo_prompt** — the prompt whose lifecycle we manage.
+4. **Staging gate**:
+   - ``build_staging_run_config / create_staging_run_exp_task`` register a
+     ``run_experiment`` task driven by a *baseline* system prompt.
+   - ``run_staging_experiment.{trigger,wait,get_result}`` fire the
+     experiment with the accuracy judge chained server-side.
+   - ``score_staging`` aggregates the average accuracy.
+   - ``gate_passes_staging`` short-circuits if avg < ``STAGING_THRESHOLD``.
+   - ``promote_to_staging`` tags the prompt with the ``"staging"`` label.
+5. **Production gate** (runs *serially* after staging — avoids the Arize
+   concurrent-trigger stall):
+   - ``build_production_run_config / create_production_run_exp_task``
+     register a ``run_experiment`` task with an *improved* system prompt.
+   - ``run_production_experiment.{trigger,wait,get_result}`` fire it with
+     the same chained accuracy judge.
+   - ``score_production`` aggregates the average.
+   - ``compare_production_to_staging`` checks whether production beats
+     staging on the chained eval metric.
+   - ``gate_passes_production`` short-circuits unless
+     ``overall_passed=True``.
+   - ``promote_to_production`` tags the prompt with the ``"production"``
+     label.
+6. **archive_notification** — final placeholder that logs the lifecycle
+   outcome (Slack/webhook integration point).
+7. **cleanup_*** — delete the per-run-ephemeral evaluator, eval task, the
+   two run-experiment tasks, the dataset, and the demo prompt.
 
-**Stage 2 — Staging evaluation**
-  - Run an experiment against the staging dataset.
-  - Wait for runs to complete.
-  - Score the experiment.
-  - Gate: skip if avg score < ``arize_ax_staging_threshold`` Variable.
-  - Promote the prompt to the ``"staging"`` label.
-
-**Stage 3 — Production evaluation**
-  - Run a more rigorous experiment.
-  - Wait for runs to complete.
-  - Score the experiment.
-  - Compare the staging experiment against the configured baseline.
-  - Gate: skip if the comparison does not pass ``overall_passed=True``.
-  - Promote the prompt to the ``"production"`` label.
-
-**Stage 4 — Archival placeholder**
-  - Log that the previous version should be archived (implement with a
-    custom hook call or ArizeAxDeletePromptOperator in production).
-
-Pipeline
---------
-get_latest_prompt
-  → create_eval_dataset
-  → append_eval_examples
-  → run_staging_eval
-  → wait_for_staging_runs
-  → score_staging
-  → gate_passes_staging
-  → promote_to_staging
-  → run_production_eval
-  → wait_for_production_runs
-  → score_production
-  → compare_to_baseline
-  → gate_passes_production
-  → promote_to_production
-  → archive_old_version
-
-Schedule: ``None`` — triggered externally (e.g. on prompt commit).
+Schedule: ``None`` — triggered externally (e.g. on a prompt commit).
 
 Variables
 ---------
-- ``arize_ax_space_id`` — Arize space ID.
-- ``arize_ax_dataset_id`` — dataset ID used for evaluations.
-- ``arize_ax_prompt_name`` — name of the prompt to manage.
-- ``arize_ax_baseline_experiment_id`` — experiment ID of the known-good
-  production baseline.
-- ``arize_ax_staging_threshold`` — minimum avg score to pass staging gate
-  (default ``"0.7"``).
-- ``arize_ax_production_threshold`` — minimum avg score to pass production
-  gate (default ``"0.8"``).
+- ``arize_ax_space_id`` — Arize space ID (required).
+- ``arize_ax_project_id`` — project ID used to scope the accuracy eval task.
+- ``arize_ai_integration_id`` *or* env var ``ARIZE_AI_INTEGRATION_ID`` —
+  OpenAI integration in Arize with gpt-4.1 access.
 
-Requires:
-  - Airflow connection ``arize_ax_default`` with a valid API key.
+Constants:
+- ``STAGING_THRESHOLD`` — minimum staging accuracy to pass the staging
+  gate (default 0.6).
+- ``PRODUCTION_PASS_THRESHOLD`` — minimum delta production-over-staging
+  to pass the production gate (default 0.0, ties pass).
 """
 
 from __future__ import annotations
@@ -75,27 +71,35 @@ from typing import Any
 from airflow import DAG
 from airflow.models import Variable
 from airflow.providers.arize_ax.operators.datasets import (
-    ArizeAxAppendDatasetExamplesOperator,
     ArizeAxCreateDatasetOperator,
+    ArizeAxDeleteDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.evaluators import (
+    ArizeAxCreateEvaluatorOperator,
+    ArizeAxDeleteEvaluatorOperator,
 )
 from airflow.providers.arize_ax.operators.experiments import (
     ArizeAxCompareExperimentsOperator,
     ArizeAxGetExperimentScoreOperator,
-    ArizeAxRunExperimentOperator,
 )
 from airflow.providers.arize_ax.operators.prompts import (
-    ArizeAxGetPromptOperator,
+    ArizeAxCreatePromptOperator,
+    ArizeAxDeletePromptOperator,
     ArizeAxPromotePromptOperator,
 )
-from airflow.providers.arize_ax.sensors.arize_ax import (
-    ArizeAxExperimentRunCountSensor,
+from airflow.providers.arize_ax.operators.tasks import (
+    ArizeAxCreateRunExperimentTaskOperator,
+    ArizeAxCreateTaskOperator,
+    ArizeAxDeleteTaskOperator,
+)
+from airflow.providers.arize_ax.utils.task_groups import (
+    arize_ax_chained_experiment_eval,
 )
 from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 
-# ---------------------------------------------------------------------------
-# Constants — adjust to your environment
-# ---------------------------------------------------------------------------
-LIFECYCLE_MIN_RUNS = 5
+STAGING_THRESHOLD = 0.6
+PRODUCTION_PASS_THRESHOLD = 0.0  # production must be >= staging + threshold
+
 LIFECYCLE_EVAL_EXAMPLES = [
     {"query": "What is the capital of France?", "expected_output": "Paris"},
     {"query": "What is 7 multiplied by 8?", "expected_output": "56"},
@@ -104,255 +108,380 @@ LIFECYCLE_EVAL_EXAMPLES = [
     {"query": "How many continents are there?", "expected_output": "7"},
 ]
 
+_SPACE_JINJA = "{{ var.value.get('arize_ax_space_id', '') or None }}"
+
+_RUN_SUFFIX = (
+    "{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') "
+    "| replace('.', '') | replace('_', '') }}"
+)
+
+ACCURACY_TEMPLATE = (
+    "[Question]: {query}\n"
+    "[Expected]: {expected_output}\n"
+    "[Output]: {output}\n\n"
+    "Reply with ONLY 'correct' or 'incorrect'."
+)
+
+STAGING_SYSTEM_PROMPT = (
+    "You are an assistant. Answer the question briefly."
+)
+PRODUCTION_SYSTEM_PROMPT = (
+    "You are a helpful, accurate assistant. Answer the question with only "
+    "the direct factual answer — no extra explanation or punctuation."
+)
 
 
-def _check_pipeline_configured(**ctx) -> bool:
-    """Return True only when required Variables are set for prompt lifecycle."""
-    required = {
-        "arize_ax_space_id": "a valid space ID",
-        "arize_ax_prompt_name": "the prompt name to manage",
-        "arize_ax_baseline_experiment_id": "a baseline experiment ID",
-    }
-    missing = []
-    for key, description in required.items():
-        val = Variable.get(key, default_var=None)
-        if not val or val.strip() in ("", "your-space-id", "my-prompt", "your-baseline-id"):
-            missing.append(f"  - {key}: set to {description}")
-    if missing:
+def _resolve_integration_id() -> str:
+    return (
+        Variable.get("arize_ai_integration_id", default_var="").strip()
+        or Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
+    )
+
+
+def _check_prereqs(**_ctx) -> bool:
+    if not _resolve_integration_id():
         print(
-            "The following Variables must be set to run the prompt lifecycle pipeline:\n"
-            + "\n".join(missing)
+            "ARIZE_AI_INTEGRATION_ID env var or arize_ai_integration_id "
+            "Variable must be set."
         )
         return False
     return True
 
 
-def _lifecycle_task(dataset_row: dict) -> dict:
-    """Lifecycle evaluation task — stub that echoes expected output.
+def _build_accuracy_judge_config(**_ctx) -> dict[str, Any]:
+    return {
+        "name": "lifecycle_accuracy_judge",
+        "template": ACCURACY_TEMPLATE,
+        "include_explanations": True,
+        "use_function_calling_if_available": False,
+        "classification_choices": {"correct": 1.0, "incorrect": 0.0},
+        "llm_config": {
+            "ai_integration_id": _resolve_integration_id(),
+            "model_name": "gpt-4o-mini",
+            "invocation_parameters": {"temperature": 0},
+            "provider_parameters": {},
+        },
+    }
 
-    Replace with your real LLM call in production::
 
-        prompt_version = dataset_row.get("_prompt_version")
-        response = openai.chat.completions.create(
-            model="gpt-4o",
-            messages=prompt_version["messages"] + [
-                {"role": "user", "content": dataset_row["query"]}
+def _build_run_config(model: str, system_prompt: str):
+    def _callable(**_ctx) -> dict[str, Any]:
+        return {
+            "experiment_type": "llm_generation",
+            "ai_integration_id": _resolve_integration_id(),
+            "model_name": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                # run_experiment messages use mustache substitution.
+                {"role": "user", "content": "{{query}}"},
             ],
-        )
-        return {"output": response.choices[0].message.content}
-    """
-    return {"output": dataset_row.get("expected_output", "")}
+            "input_variable_format": "mustache",
+            "invocation_parameters": {"temperature": 0},
+            "provider_parameters": {},
+        }
 
-
-def _accuracy_evaluator(dataset_row: dict, output: Any) -> Any:
-    """Simple exact-match accuracy evaluator."""
-    from arize.experiments import EvaluationResult
-
-    if output is None:
-        return EvaluationResult(score=0.0, label="error", explanation="no output")
-    actual = output.get("output", "") if isinstance(output, dict) else str(output)
-    expected = dataset_row.get("expected_output", "")
-    match = str(actual).strip().lower() == str(expected).strip().lower()
-    return EvaluationResult(
-        score=1.0 if match else 0.0,
-        label="correct" if match else "incorrect",
-        explanation=f"expected={expected!r}, got={actual!r}",
-    )
+    _callable.__name__ = f"_build_run_config_{model.replace('-', '_').replace('.', '_')}"
+    return _callable
 
 
 def _gate_passes_staging(**ctx) -> bool:
-    """Return True iff staging avg score >= arize_ax_staging_threshold."""
+    """Return True iff staging avg score >= STAGING_THRESHOLD."""
     scores = ctx["ti"].xcom_pull(task_ids="score_staging") or {}
     if not isinstance(scores, dict) or not scores:
         print("[gate_passes_staging] No scores returned — failing gate.")
         return False
     avg_score = sum(scores.values()) / len(scores)
-    threshold = float(Variable.get("arize_ax_staging_threshold", default_var="0.7"))
-    print(f"[gate_passes_staging] avg_score={avg_score:.4f}, threshold={threshold}")
-    return avg_score >= threshold
+    print(f"[gate_passes_staging] avg={avg_score:.4f} threshold={STAGING_THRESHOLD}")
+    return avg_score >= STAGING_THRESHOLD
 
 
 def _gate_passes_production(**ctx) -> bool:
-    """Return True iff compare_to_baseline overall_passed=True."""
-    result = ctx["ti"].xcom_pull(task_ids="compare_to_baseline")
+    """Return True iff compare_production_to_staging overall_passed=True."""
+    result = ctx["ti"].xcom_pull(task_ids="compare_production_to_staging") or {}
     if not isinstance(result, dict):
-        print(f"[gate_passes_production] compare_to_baseline XCom not a dict: {result!r} — failing gate.")
-        return False
-    overall_passed = result.get("overall_passed", False)
-    results = result.get("results", {})
-    print(f"[gate_passes_production] overall_passed={overall_passed}")
-    for metric, data in results.items():
         print(
-            f"  {metric}: staging={data.get('candidate'):.4f}  "
-            f"baseline={data.get('baseline'):.4f}  "
+            f"[gate_passes_production] compare XCom not a dict: {result!r} — "
+            "failing gate."
+        )
+        return False
+    overall_passed = bool(result.get("overall_passed", False))
+    print(f"[gate_passes_production] overall_passed={overall_passed}")
+    for metric, data in (result.get("results") or {}).items():
+        print(
+            f"  {metric}: production={data.get('candidate'):.4f}  "
+            f"staging={data.get('baseline'):.4f}  "
             f"delta={data.get('delta'):.4f}  passed={data.get('passed')}"
         )
-    return bool(overall_passed)
+    return overall_passed
 
 
-def _archive_old_version(**ctx) -> dict[str, Any]:
-    """Placeholder: log that the previous production version should be archived.
-
-    In production, replace this stub with a call to tag or delete the old
-    version.  For example::
-
-        from airflow.providers.arize_ax.hooks.arize_ax import ArizeAxHook
-        hook = ArizeAxHook()
-        hook.promote_prompt(
-            space_id=space_id,
-            prompt_id=prompt_id,
-            label="archived",
-            version_id=old_version_id,
-        )
-    """
-    production_result = ctx["ti"].xcom_pull(task_ids="promote_to_production") or {}
-    prompt_id = production_result.get("prompt_id")
-
+def _archive_notification(**ctx) -> dict[str, Any]:
+    """Final placeholder: log the lifecycle outcome."""
+    promote_prod = ctx["ti"].xcom_pull(task_ids="promote_to_production") or {}
+    prompt_id = (
+        promote_prod.get("prompt_id") if isinstance(promote_prod, dict) else None
+    )
     print("=" * 60)
     print("PROMPT LIFECYCLE COMPLETE")
-    print(f"  Prompt ID : {prompt_id}")
-    print("  Label     : production")
-    print("  Archive   : previous production version should now be labelled 'archived'.")
-    print("              Implement via ArizeAxPromotePromptOperator with label='archived'.")
+    print(f"  Prompt ID         : {prompt_id}")
+    print("  Promoted to label : production")
+    print(
+        "  Archive step      : the prior 'production' version would be "
+        "tagged 'archived' in production deployments."
+    )
     print("=" * 60)
-    return {"prompt_id": prompt_id, "archived": False}  # stub
+    return {"prompt_id": prompt_id, "archived": False}
+
+
+_STAGING_EXP_ID = (
+    "{{ ti.xcom_pull(task_ids='run_staging_experiment.trigger', "
+    "key='result')['experiment_id'] }}"
+)
+_PRODUCTION_EXP_ID = (
+    "{{ ti.xcom_pull(task_ids='run_production_experiment.trigger', "
+    "key='result')['experiment_id'] }}"
+)
 
 
 with DAG(
     dag_id="arize_ax_prompt_lifecycle",
-    start_date=datetime(2025, 1, 1),
+    start_date=datetime(2026, 1, 1),
     schedule=None,
-    tags=["arize_ax", "prompts", "lifecycle", "experiments"],
+    tags=["arize_ax", "prompts", "lifecycle", "experiments", "eval-hub", "self-contained"],
     catchup=False,
     doc_md=__doc__,
+    render_template_as_native_obj=True,
 ) as dag:
 
-    # Stage 0 — Guard: skip DAG if required Variables are not configured
-    check_pipeline_configured = ShortCircuitOperator(
-        task_id="check_pipeline_configured",
-        python_callable=_check_pipeline_configured,
+    check_prereqs = ShortCircuitOperator(
+        task_id="check_prereqs",
+        python_callable=_check_prereqs,
     )
 
-    # Stage 1 — Dataset setup
-    get_latest_prompt = ArizeAxGetPromptOperator(
-        task_id="get_latest_prompt",
-        prompt_name="{{ var.value.get('arize_ax_prompt_name', '') }}",
-        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
-    )
-
+    # ----- Phase 1: ephemeral dataset --------------------------------------
     create_eval_dataset = ArizeAxCreateDatasetOperator(
         task_id="create_eval_dataset",
-        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
-        name="lifecycle-eval-{{ ts_nodash }}",
-        # SDK 8.25+ rejects empty examples list at create time. Seed with a
-        # single placeholder; real examples are added by the subsequent
-        # append step.
-        examples=[{"input": "_seed_", "expected": "_seed_"}],
+        space_id=_SPACE_JINJA,
+        name=f"lifecycle-eval-dataset-{_RUN_SUFFIX}",
+        examples=LIFECYCLE_EVAL_EXAMPLES,
         if_exists="skip",
     )
 
-    append_eval_examples = ArizeAxAppendDatasetExamplesOperator(
-        task_id="append_eval_examples",
+    # ----- Phase 2: accuracy judge ------------------------------------------
+    build_accuracy_judge_config = PythonOperator(
+        task_id="build_accuracy_judge_config",
+        python_callable=_build_accuracy_judge_config,
+    )
+    create_accuracy_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_accuracy_evaluator",
+        space_id=_SPACE_JINJA,
+        name=f"lifecycle_accuracy_judge_{_RUN_SUFFIX}",
+        evaluator_type="template",
+        commit_message="initial lifecycle accuracy judge",
+        template_config_task_id="build_accuracy_judge_config",
+        description="LLM-as-judge for prompt lifecycle gates.",
+    )
+    create_accuracy_eval_task = ArizeAxCreateTaskOperator(
+        task_id="create_accuracy_eval_task",
+        name=f"lifecycle-accuracy-task-{_RUN_SUFFIX}",
+        eval_task_type="template_evaluation",
+        evaluators=[
+            {"evaluator_id": "{{ ti.xcom_pull(task_ids='create_accuracy_evaluator') }}"},
+        ],
+        project_id="{{ var.value.get('arize_ax_project_id', '') or None }}",
+        is_continuous=False,
+        sampling_rate=1.0,
+    )
+
+    # ----- Phase 3: demo prompt (target of promotion labels) ----------------
+    create_demo_prompt = ArizeAxCreatePromptOperator(
+        task_id="create_demo_prompt",
+        space_id=_SPACE_JINJA,
+        name=f"lifecycle-demo-prompt-{_RUN_SUFFIX}",
+        messages=[
+            {"role": "system", "content": PRODUCTION_SYSTEM_PROMPT},
+            {"role": "user", "content": "{query}"},
+        ],
+        model="gpt-4.1",
+        commit_message="initial lifecycle prompt version",
+        input_variable_format="f_string",
+    )
+
+    # ----- Phase 4: staging experiment (baseline-quality prompt) ------------
+    build_staging_run_config = PythonOperator(
+        task_id="build_staging_run_config",
+        python_callable=_build_run_config("gpt-4.1", STAGING_SYSTEM_PROMPT),
+    )
+    create_staging_run_exp_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_staging_run_exp_task",
+        space_id=_SPACE_JINJA,
+        name=f"lifecycle-staging-task-{_RUN_SUFFIX}",
         dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
-        examples=LIFECYCLE_EVAL_EXAMPLES,
+        run_configuration="{{ ti.xcom_pull(task_ids='build_staging_run_config') }}",
+        if_exists="skip",
     )
-
-    # Stage 2 — Staging evaluation
-    run_staging_eval = ArizeAxRunExperimentOperator(
-        task_id="run_staging_eval",
-        name="lifecycle-staging-{{ ts_nodash }}",
-        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
-        task=_lifecycle_task,
-        evaluators=[_accuracy_evaluator],
-        concurrency=4,
+    run_staging_experiment = arize_ax_chained_experiment_eval(
+        group_id="run_staging_experiment",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_staging_run_exp_task') }}",
+        experiment_name=f"lifecycle-staging-{_RUN_SUFFIX}",
+        space_id=_SPACE_JINJA,
+        evaluation_task_ids=[
+            "{{ ti.xcom_pull(task_ids='create_accuracy_eval_task') }}",
+        ],
+        wait_for_completion=True,
+        sensor_timeout=900,
+        sensor_poke_interval=15,
+        fail_on_run_error=True,
     )
-
-    wait_for_staging_runs = ArizeAxExperimentRunCountSensor(
-        task_id="wait_for_staging_runs",
-        experiment_id="{{ ti.xcom_pull(task_ids='run_staging_eval') }}",
-        min_runs=LIFECYCLE_MIN_RUNS,
-        poke_interval=15,
-        timeout=600,
-        mode="poke",
-        soft_fail=True,
-    )
-
     score_staging = ArizeAxGetExperimentScoreOperator(
         task_id="score_staging",
-        experiment_id="{{ ti.xcom_pull(task_ids='run_staging_eval') }}",
+        experiment_id=_STAGING_EXP_ID,
         aggregation="mean",
     )
-
     gate_passes_staging = ShortCircuitOperator(
         task_id="gate_passes_staging",
         python_callable=_gate_passes_staging,
+        # Without this, the ShortCircuit cascades skip to ALL downstream
+        # tasks (including the trigger_rule="all_done" cleanups) when the
+        # gate doesn't pass — leaving ephemeral resources behind.
+        ignore_downstream_trigger_rules=False,
     )
-
     promote_to_staging = ArizeAxPromotePromptOperator(
         task_id="promote_to_staging",
-        prompt_name="{{ var.value.get('arize_ax_prompt_name', '') }}",
+        prompt_name=f"lifecycle-demo-prompt-{_RUN_SUFFIX}",
         label="staging",
-        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        space_id=_SPACE_JINJA,
     )
 
-    # Stage 3 — Production evaluation
-    run_production_eval = ArizeAxRunExperimentOperator(
-        task_id="run_production_eval",
-        name="lifecycle-production-{{ ts_nodash }}",
+    # ----- Phase 5: production experiment (improved prompt) -----------------
+    # Serially follows staging — avoids the Arize concurrent-trigger stall
+    # we observed under parallel fan-out.
+    build_production_run_config = PythonOperator(
+        task_id="build_production_run_config",
+        python_callable=_build_run_config("gpt-4.1", PRODUCTION_SYSTEM_PROMPT),
+    )
+    create_production_run_exp_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_production_run_exp_task",
+        space_id=_SPACE_JINJA,
+        name=f"lifecycle-production-task-{_RUN_SUFFIX}",
         dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
-        task=_lifecycle_task,
-        evaluators=[_accuracy_evaluator],
-        concurrency=4,
+        run_configuration="{{ ti.xcom_pull(task_ids='build_production_run_config') }}",
+        if_exists="skip",
     )
-
-    wait_for_production_runs = ArizeAxExperimentRunCountSensor(
-        task_id="wait_for_production_runs",
-        experiment_id="{{ ti.xcom_pull(task_ids='run_production_eval') }}",
-        min_runs=LIFECYCLE_MIN_RUNS,
-        poke_interval=15,
-        timeout=600,
-        mode="poke",
-        soft_fail=True,
+    run_production_experiment = arize_ax_chained_experiment_eval(
+        group_id="run_production_experiment",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_production_run_exp_task') }}",
+        experiment_name=f"lifecycle-production-{_RUN_SUFFIX}",
+        space_id=_SPACE_JINJA,
+        evaluation_task_ids=[
+            "{{ ti.xcom_pull(task_ids='create_accuracy_eval_task') }}",
+        ],
+        wait_for_completion=True,
+        sensor_timeout=900,
+        sensor_poke_interval=15,
+        fail_on_run_error=True,
     )
-
     score_production = ArizeAxGetExperimentScoreOperator(
         task_id="score_production",
-        experiment_id="{{ ti.xcom_pull(task_ids='run_production_eval') }}",
+        experiment_id=_PRODUCTION_EXP_ID,
         aggregation="mean",
     )
-
-    compare_to_baseline = ArizeAxCompareExperimentsOperator(
-        task_id="compare_to_baseline",
-        candidate_experiment_id="{{ ti.xcom_pull(task_ids='run_production_eval') }}",
-        baseline_experiment_id="{{ var.value.get('arize_ax_baseline_experiment_id', '') }}",
-        pass_threshold=0.0,
+    compare_production_to_staging = ArizeAxCompareExperimentsOperator(
+        task_id="compare_production_to_staging",
+        candidate_experiment_id=_PRODUCTION_EXP_ID,
+        baseline_experiment_id=_STAGING_EXP_ID,
+        pass_threshold=PRODUCTION_PASS_THRESHOLD,
         aggregation="mean",
     )
-
     gate_passes_production = ShortCircuitOperator(
         task_id="gate_passes_production",
         python_callable=_gate_passes_production,
+        ignore_downstream_trigger_rules=False,
     )
-
     promote_to_production = ArizeAxPromotePromptOperator(
         task_id="promote_to_production",
-        prompt_name="{{ var.value.get('arize_ax_prompt_name', '') }}",
+        prompt_name=f"lifecycle-demo-prompt-{_RUN_SUFFIX}",
         label="production",
-        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
+        space_id=_SPACE_JINJA,
     )
 
-    # Stage 4 — Archival placeholder
-    archive_old_version = PythonOperator(
-        task_id="archive_old_version",
-        python_callable=_archive_old_version,
+    archive_notification = PythonOperator(
+        task_id="archive_notification",
+        python_callable=_archive_notification,
+    )
+
+    # ----- Phase 6: cleanup -------------------------------------------------
+    cleanup_accuracy_eval_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_accuracy_eval_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_accuracy_eval_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_staging_run_exp_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_staging_run_exp_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_staging_run_exp_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_production_run_exp_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_production_run_exp_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_production_run_exp_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_accuracy_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_accuracy_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_accuracy_evaluator') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_dataset = ArizeAxDeleteDatasetOperator(
+        task_id="cleanup_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_eval_dataset') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_demo_prompt = ArizeAxDeletePromptOperator(
+        task_id="cleanup_demo_prompt",
+        prompt_id="{{ ti.xcom_pull(task_ids='create_demo_prompt') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
     )
 
     # Wiring
-    check_pipeline_configured >> get_latest_prompt >> create_eval_dataset >> append_eval_examples
+    check_prereqs >> [
+        create_eval_dataset,
+        build_accuracy_judge_config,
+        build_staging_run_config,
+        build_production_run_config,
+        create_demo_prompt,
+    ]
+    build_accuracy_judge_config >> create_accuracy_evaluator >> create_accuracy_eval_task
+    [create_eval_dataset, build_staging_run_config] >> create_staging_run_exp_task
+    [create_eval_dataset, build_production_run_config] >> create_production_run_exp_task
 
-    append_eval_examples >> run_staging_eval >> wait_for_staging_runs >> score_staging
-    score_staging >> gate_passes_staging >> promote_to_staging
+    [create_staging_run_exp_task, create_accuracy_eval_task] >> run_staging_experiment
+    run_staging_experiment >> score_staging >> gate_passes_staging
+    [gate_passes_staging, create_demo_prompt] >> promote_to_staging
 
-    promote_to_staging >> run_production_eval >> wait_for_production_runs >> score_production
-    score_production >> compare_to_baseline >> gate_passes_production
-    gate_passes_production >> promote_to_production >> archive_old_version
+    # Production stage waits for the staging gate (and chain) to terminate
+    # before triggering — avoids concurrent run_experiment triggers.
+    [
+        promote_to_staging,
+        create_production_run_exp_task,
+        create_accuracy_eval_task,
+    ] >> run_production_experiment
+    run_production_experiment >> score_production
+    [score_staging, score_production] >> compare_production_to_staging
+    compare_production_to_staging >> gate_passes_production
+    [gate_passes_production, create_demo_prompt] >> promote_to_production
+    promote_to_production >> archive_notification
+
+    archive_notification >> [
+        cleanup_accuracy_eval_task,
+        cleanup_staging_run_exp_task,
+        cleanup_production_run_exp_task,
+        cleanup_accuracy_evaluator,
+        cleanup_dataset,
+        cleanup_demo_prompt,
+    ]

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_rag_evaluation_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_rag_evaluation_dag.py
@@ -1,42 +1,55 @@
 """
-RAG Quality Evaluation DAG: automated daily faithfulness and relevance scoring.
+RAG Quality Evaluation DAG (server-side, self-contained):
+faithfulness and context-relevance scoring for a context-augmented LLM.
 
-This DAG implements an automated daily pipeline that:
-1. Exports production RAG spans (RETRIEVER + LLM) from the previous 24 hours.
-2. Packages them into an evaluation dataset.
-3. Runs two Python evaluator experiments:
-   - **faithfulness**: does the LLM output stay grounded in the retrieved
-     context?  Score 1.0 = fully grounded, 0.0 = hallucinated.
-   - **context_relevance**: is the retrieved context actually relevant to the
-     user query?  Score 1.0 = highly relevant, 0.0 = irrelevant.
-4. Scores both experiments and logs a quality summary.
+This DAG demonstrates RAG-style evaluation end-to-end without depending on
+any production span pipeline. It builds a small synthetic dataset of
+``(query, context, expected_output)`` rows, registers a server-side
+``run_experiment`` task that drives a context-aware ``gpt-4.1`` LLM call,
+and chains two ``template_evaluation`` LLM-as-judges that run server-side
+after each row's LLM response is produced:
 
-Metrics computed
-----------------
-- ``faithfulness``: mean faithfulness score across all evaluated spans.
-- ``context_relevance``: mean context relevance score across evaluated spans.
+- **faithfulness** — does the model's answer stay grounded in the
+  retrieved context, or does it hallucinate beyond it?
+- **context_relevance** — was the retrieved context actually relevant to
+  the user query in the first place?
 
-The ``report_rag_quality`` task pushes a summary dict to XCom so downstream
-alerting DAGs (e.g. a Slack notifier) can read it with
-``xcom_pull(dag_id="arize_ax_rag_evaluation", task_ids="report_rag_quality")``.
+It is fully self-contained — no pre-existing project, dataset, evaluator,
+or production spans required. Everything is provisioned and torn down on
+every run.
+
+Pipeline stages
+---------------
+0. **check_prereqs** — short-circuit if ``ARIZE_AI_INTEGRATION_ID`` isn't
+   resolvable.
+1. **create_rag_dataset** — provision a tiny synthetic RAG dataset.
+2. **build_faithfulness_judge_config / create_faithfulness_evaluator /
+   create_faithfulness_eval_task** — the LLM-as-judge that scores whether
+   each response is grounded in its context.
+3. **build_relevance_judge_config / create_relevance_evaluator /
+   create_relevance_eval_task** — the LLM-as-judge that scores whether
+   each context is relevant to its query.
+4. **build_rag_run_config / create_rag_run_exp_task** — register a
+   ``run_experiment`` task whose system prompt asks the model to answer
+   strictly from the provided context.
+5. **run_rag_experiment.{trigger,wait,get_result}** — fire the experiment
+   with **both** judges chained via ``evaluation_task_ids``; Arize
+   executes faithfulness + context_relevance server-side after each row.
+6. **score_faithfulness / score_context_relevance** — aggregate the two
+   eval metrics from the chained experiment runs.
+7. **report_rag_quality** — log a quality summary and push it to XCom for
+   downstream alerting.
+8. **cleanup_*** — delete the per-run-ephemeral evaluators, eval tasks,
+   run-experiment task, and dataset.
+
+Schedule: ``@daily`` (each manual or scheduled run is fully self-contained).
 
 Variables
 ---------
-- ``arize_ax_project_name`` — Arize project **name** containing production RAG spans.
-  If absent, the first project returned by list_projects is used.
-- ``arize_ax_space_id``     — Arize space ID used to export spans and create datasets.
-  Required: ArizeAxListProjectsOperator and ArizeAxCreateDatasetOperator will raise
-  AirflowException with a clear message if this Variable is absent.
-
-Schedule
---------
-Daily at midnight UTC (``@daily``).  Each run evaluates the spans from the
-previous calendar day via the Jinja macros ``data_interval_start`` and
-``data_interval_end``.
-
-Requires:
-  - Airflow connection ``arize_ax_default`` with a valid API key.
-  - Variable ``arize_ax_space_id`` — required by list_projects and create_dataset operators.
+- ``arize_ax_space_id`` — Arize space ID (required).
+- ``arize_ax_project_id`` — project ID used to scope the eval tasks.
+- ``arize_ai_integration_id`` *or* env var ``ARIZE_AI_INTEGRATION_ID`` —
+  OpenAI integration in Arize with gpt-4.1 access.
 """
 
 from __future__ import annotations
@@ -47,351 +60,383 @@ from typing import Any
 from airflow import DAG
 from airflow.models import Variable
 from airflow.providers.arize_ax.operators.datasets import (
-    ArizeAxAppendDatasetExamplesOperator,
     ArizeAxCreateDatasetOperator,
+    ArizeAxDeleteDatasetOperator,
+)
+from airflow.providers.arize_ax.operators.evaluators import (
+    ArizeAxCreateEvaluatorOperator,
+    ArizeAxDeleteEvaluatorOperator,
 )
 from airflow.providers.arize_ax.operators.experiments import (
     ArizeAxGetExperimentScoreOperator,
-    ArizeAxRunExperimentOperator,
 )
-from airflow.providers.arize_ax.operators.projects import (
-    ArizeAxListProjectsOperator,
+from airflow.providers.arize_ax.operators.tasks import (
+    ArizeAxCreateRunExperimentTaskOperator,
+    ArizeAxCreateTaskOperator,
+    ArizeAxDeleteTaskOperator,
 )
-from airflow.providers.arize_ax.operators.spans import (
-    ArizeAxSpansExportToParquetOperator,
+from airflow.providers.arize_ax.utils.task_groups import (
+    arize_ax_chained_experiment_eval,
 )
 from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 
-_TMP_PARQUET = "/tmp/rag_spans_{{ ds }}.parquet"
-_RAG_SPAN_WHERE = (
-    "attributes.openinference.span.kind='RETRIEVER' "
-    "OR attributes.openinference.span.kind='LLM'"
+# Synthetic RAG-style dataset: each row has a query, a retrieved context
+# block, and a reference answer. The LLM is asked to answer from the
+# context; the two judges score faithfulness (output vs context) and
+# context_relevance (context vs query).
+RAG_EVAL_EXAMPLES = [
+    {
+        "query": "What is the capital of France?",
+        "context": (
+            "France is a country in Western Europe. Its capital and "
+            "largest city is Paris, on the Seine river."
+        ),
+        "expected_output": "Paris",
+    },
+    {
+        "query": "How many continents are there?",
+        "context": (
+            "Geographers traditionally divide the world into seven "
+            "continents: Africa, Antarctica, Asia, Australia, Europe, "
+            "North America, and South America."
+        ),
+        "expected_output": "7",
+    },
+    {
+        "query": "Who wrote Hamlet?",
+        "context": (
+            "Hamlet is a tragedy written by the English playwright "
+            "William Shakespeare around the year 1600."
+        ),
+        "expected_output": "William Shakespeare",
+    },
+    {
+        "query": "What element has atomic number 1?",
+        "context": (
+            "Hydrogen, with chemical symbol H and atomic number 1, is "
+            "the lightest element in the periodic table."
+        ),
+        "expected_output": "Hydrogen",
+    },
+    {
+        "query": "What is the largest planet in our solar system?",
+        "context": (
+            "Jupiter is the fifth planet from the Sun and the largest "
+            "in our solar system — over twice as massive as all the "
+            "other planets combined."
+        ),
+        "expected_output": "Jupiter",
+    },
+]
+
+_SPACE_JINJA = "{{ var.value.get('arize_ax_space_id', '') or None }}"
+
+_RUN_SUFFIX = (
+    "{{ run_id | replace(':', '') | replace('-', '') | replace('+', '') "
+    "| replace('.', '') | replace('_', '') }}"
 )
 
+FAITHFULNESS_TEMPLATE = (
+    "[Context]: {context}\n"
+    "[Output]: {output}\n\n"
+    "Is the output fully grounded in the context (every claim supported), "
+    "or does it introduce information not present in the context?\n"
+    "Reply with ONLY 'faithful' (no fabricated content) or 'hallucinated' "
+    "(includes claims not supported by the context)."
+)
 
-def _extract_project_name(**ctx) -> str:
-    """Return the project name from ``arize_ax_project_name`` Variable.
+CONTEXT_RELEVANCE_TEMPLATE = (
+    "[Question]: {query}\n"
+    "[Context]: {context}\n\n"
+    "Is the context relevant to answering the question?\n"
+    "Reply with ONLY 'relevant' (the context contains information that "
+    "addresses the question) or 'irrelevant' (the context does not help "
+    "answer the question)."
+)
 
-    Falls back to the name of the first project returned by
-    ArizeAxListProjectsOperator if the Variable is not set.
-    """
-    project_name_var = Variable.get("arize_ax_project_name", default_var=None)
-    if project_name_var:
-        return project_name_var
-
-    result = ctx["ti"].xcom_pull(task_ids="check_project_exists")
-    items = result.get("items", []) if isinstance(result, dict) else []
-    if not items:
-        raise ValueError(
-            "No projects found. Set Variable 'arize_ax_project_name' to your project name."
-        )
-    first_item = items[0]
-    name = first_item.get("name") if isinstance(first_item, dict) else None
-    if not name:
-        raise ValueError(
-            "Project item has no 'name' field. "
-            "Set Variable 'arize_ax_project_name' explicitly."
-        )
-    return str(name)
-
-
-def _check_has_spans(**ctx) -> bool:
-    """Return True if the parquet export produced at least one span."""
-    parquet_path = ctx["ti"].xcom_pull(task_ids="export_rag_spans")
-    if not parquet_path:
-        print("[check_has_spans] export task returned no path -- short-circuiting.")
-        return False
-    try:
-        import pandas as pd
-
-        df = pd.read_parquet(parquet_path)
-        count = len(df)
-        print(f"[check_has_spans] parquet has {count} rows.")
-        return count > 0
-    except Exception as exc:
-        print(f"[check_has_spans] could not read parquet: {exc} -- short-circuiting.")
-        return False
+# The run_experiment system prompt enforces the RAG contract: answer only
+# from the provided context. The user message bundles query + context
+# together using mustache substitution.
+RAG_SYSTEM_PROMPT = (
+    "You are a careful assistant that answers questions using ONLY the "
+    "provided context. If the context does not contain the answer, say "
+    "you don't know. Give only the direct factual answer — no extra "
+    "explanation or punctuation."
+)
+RAG_USER_TEMPLATE = "Context: {{context}}\n\nQuestion: {{query}}"
 
 
-def _prepare_rag_examples(**ctx) -> list[dict[str, Any]]:
-    """Load the exported parquet and extract input / output / context fields.
-
-    Returns a list of dataset example dicts ready for
-    ArizeAxAppendDatasetExamplesOperator.
-
-    Expected span columns (best-effort -- missing columns yield empty strings):
-    - ``input.value``   — the user query sent to the LLM / retriever
-    - ``output.value``  — the LLM response
-    - ``attributes.retrieval.documents`` — JSON list of retrieved document texts
-    """
-    import json
-
-    import pandas as pd
-
-    parquet_path = ctx["ti"].xcom_pull(task_ids="export_rag_spans")
-    if not parquet_path:
-        raise ValueError("No parquet path in XCom from export_rag_spans.")
-
-    df = pd.read_parquet(parquet_path)
-    examples: list[dict[str, Any]] = []
-    for _, row in df.iterrows():
-        input_val = str(row.get("input.value", row.get("input", "")))
-        output_val = str(row.get("output.value", row.get("output", "")))
-        raw_docs = row.get("attributes.retrieval.documents", row.get("retrieval.documents", ""))
-        if isinstance(raw_docs, str):
-            try:
-                docs = json.loads(raw_docs)
-                context = " ".join(
-                    d.get("document.content", "") if isinstance(d, dict) else str(d)
-                    for d in (docs if isinstance(docs, list) else [])
-                )
-            except (json.JSONDecodeError, TypeError):
-                context = raw_docs
-        elif isinstance(raw_docs, list):
-            context = " ".join(
-                d.get("document.content", "") if isinstance(d, dict) else str(d)
-                for d in raw_docs
-            )
-        else:
-            context = ""
-
-        if not input_val and not output_val:
-            continue  # skip empty rows
-
-        examples.append({
-            "query": input_val,
-            "response": output_val,
-            "context": context,
-        })
-
-    print(f"[prepare_rag_examples] produced {len(examples)} dataset examples.")
-    return examples
-
-
-def _faithfulness_evaluator(dataset_row: dict, output: Any) -> Any:
-    """Score whether the LLM response stays grounded in the retrieved context.
-
-    Uses a simple heuristic: if any non-trivial word from the response also
-    appears in the context, score = 1.0 (grounded); otherwise 0.0 (potential
-    hallucination).  Replace this with a real LLM-as-judge in production.
-    """
-    from arize.experiments import EvaluationResult
-
-    if output is None:
-        return EvaluationResult(score=0.0, label="error", explanation="task produced no output")
-
-    response = dataset_row.get("response", "")
-    context = dataset_row.get("context", "")
-
-    if not response or not context:
-        return EvaluationResult(
-            score=0.5,
-            label="unknown",
-            explanation="insufficient data to evaluate faithfulness",
-        )
-
-    response_words = {
-        w.lower() for w in response.split() if len(w) > 4
-    }
-    context_words = {
-        w.lower() for w in context.split() if len(w) > 4
-    }
-    overlap = response_words & context_words
-    grounded = len(overlap) >= max(1, len(response_words) // 4)
-
-    return EvaluationResult(
-        score=1.0 if grounded else 0.0,
-        label="grounded" if grounded else "hallucinated",
-        explanation=(
-            f"Overlap {len(overlap)}/{len(response_words)} meaningful words; "
-            f"threshold={max(1, len(response_words) // 4)}."
-        ),
+def _resolve_integration_id() -> str:
+    return (
+        Variable.get("arize_ai_integration_id", default_var="").strip()
+        or Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
     )
 
 
-def _context_relevance_evaluator(dataset_row: dict, output: Any) -> Any:
-    """Score whether the retrieved context is relevant to the user query.
-
-    Uses a simple heuristic: if any word from the query (>3 chars) appears in
-    the context, score = 1.0 (relevant); otherwise 0.0 (irrelevant).  Replace
-    this with a real LLM-as-judge in production.
-    """
-    from arize.experiments import EvaluationResult
-
-    query = dataset_row.get("query", "")
-    context = dataset_row.get("context", "")
-
-    if not query or not context:
-        return EvaluationResult(
-            score=0.5,
-            label="unknown",
-            explanation="insufficient data to evaluate context relevance",
+def _check_prereqs(**_ctx) -> bool:
+    if not _resolve_integration_id():
+        print(
+            "ARIZE_AI_INTEGRATION_ID env var or arize_ai_integration_id "
+            "Variable must be set."
         )
-
-    query_words = {w.lower() for w in query.split() if len(w) > 3}
-    context_words = {w.lower() for w in context.split() if len(w) > 3}
-    overlap = query_words & context_words
-    relevant = bool(overlap)
-
-    return EvaluationResult(
-        score=1.0 if relevant else 0.0,
-        label="relevant" if relevant else "irrelevant",
-        explanation=f"Query–context word overlap: {overlap or 'none'}.",
-    )
+        return False
+    return True
 
 
-# ---------------------------------------------------------------------------
-# Identity task: passes span data through to the experiment
-# ---------------------------------------------------------------------------
-def _rag_task(dataset_row: dict) -> dict:
-    """Identity task: surface the span's response field as the experiment output."""
+def _build_judge_config(name: str, template: str, choices: dict[str, float]):
+    """Factory: build a template_config dict for one of the two RAG judges."""
+
+    def _callable(**_ctx) -> dict[str, Any]:
+        return {
+            "name": name,
+            "template": template,
+            "include_explanations": True,
+            "use_function_calling_if_available": False,
+            "classification_choices": choices,
+            "llm_config": {
+                "ai_integration_id": _resolve_integration_id(),
+                "model_name": "gpt-4o-mini",
+                "invocation_parameters": {"temperature": 0},
+                "provider_parameters": {},
+            },
+        }
+
+    _callable.__name__ = f"_build_{name}_judge_config"
+    return _callable
+
+
+def _build_rag_run_config(**_ctx) -> dict[str, Any]:
     return {
-        "output": dataset_row.get("response", ""),
-        "query": dataset_row.get("query", ""),
-        "context": dataset_row.get("context", ""),
+        "experiment_type": "llm_generation",
+        "ai_integration_id": _resolve_integration_id(),
+        "model_name": "gpt-4.1",
+        "messages": [
+            {"role": "system", "content": RAG_SYSTEM_PROMPT},
+            {"role": "user", "content": RAG_USER_TEMPLATE},
+        ],
+        "input_variable_format": "mustache",
+        "invocation_parameters": {"temperature": 0},
+        "provider_parameters": {},
     }
 
 
 def _report_rag_quality(**ctx) -> dict[str, Any]:
-    """Log a RAG quality summary and push scores to XCom for downstream alerting."""
+    """Log RAG quality summary; push to XCom for downstream alerting."""
     ti = ctx["ti"]
     ds = ctx.get("ds", "unknown")
     faithfulness_scores = ti.xcom_pull(task_ids="score_faithfulness") or {}
-    relevance_scores = ti.xcom_pull(task_ids="score_relevance") or {}
-
-    faithfulness = faithfulness_scores.get("_faithfulness_evaluator")
-    relevance = relevance_scores.get("_context_relevance_evaluator")
+    relevance_scores = ti.xcom_pull(task_ids="score_context_relevance") or {}
 
     summary = {
         "date": ds,
-        "faithfulness_score": faithfulness,
-        "context_relevance_score": relevance,
+        "faithfulness_scores": faithfulness_scores,
+        "context_relevance_scores": relevance_scores,
     }
 
     print("=" * 60)
     print(f"RAG QUALITY REPORT — {ds}")
-    print(f"  Faithfulness score   : {faithfulness}")
-    print(f"  Context relevance    : {relevance}")
-    if faithfulness is not None and faithfulness < 0.7:
-        print("  WARNING: faithfulness below 0.7 — possible hallucination increase.")
-    if relevance is not None and relevance < 0.7:
-        print("  WARNING: context relevance below 0.7 — retrieval quality degraded.")
+    print(f"  Faithfulness        : {faithfulness_scores}")
+    print(f"  Context relevance   : {relevance_scores}")
     print("=" * 60)
     return summary
 
 
 with DAG(
     dag_id="arize_ax_rag_evaluation",
-    start_date=datetime(2025, 1, 1),
+    start_date=datetime(2026, 1, 1),
     schedule="@daily",
-    tags=["arize_ax", "rag", "evaluation", "daily"],
+    tags=["arize_ax", "rag", "evaluation", "eval-hub", "self-contained"],
     catchup=False,
     doc_md=__doc__,
     render_template_as_native_obj=True,
 ) as dag:
 
-    # Stage 1 — Discover project
-    check_project_exists = ArizeAxListProjectsOperator(
-        task_id="check_project_exists",
-        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
-        limit=50,
+    check_prereqs = ShortCircuitOperator(
+        task_id="check_prereqs",
+        python_callable=_check_prereqs,
     )
 
-    extract_project_name = PythonOperator(
-        task_id="extract_project_name",
-        python_callable=_extract_project_name,
-    )
-
-    # Stage 2 — Export RAG spans from the previous 24 hours
-    export_rag_spans = ArizeAxSpansExportToParquetOperator(
-        task_id="export_rag_spans",
-        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
-        project_name="{{ ti.xcom_pull(task_ids='extract_project_name') }}",
-        path=_TMP_PARQUET,
-        where=_RAG_SPAN_WHERE,
-        # Manual triggers leave data_interval_start == data_interval_end (both
-        # equal logical_date), and the SDK's exporter validates start < end
-        # strictly. Compute a 24h window off logical_date so manual triggers
-        # work; scheduled runs still see (close to) one schedule interval.
-        start_time="{{ (logical_date - macros.timedelta(hours=24)).isoformat() }}",
-        end_time="{{ logical_date.isoformat() }}",
-    )
-
-    check_has_spans = ShortCircuitOperator(
-        task_id="check_has_spans",
-        python_callable=_check_has_spans,
-    )
-
-    # Stage 3 — Build evaluation dataset
-    create_rag_eval_dataset = ArizeAxCreateDatasetOperator(
-        task_id="create_rag_eval_dataset",
-        space_id="{{ var.value.get('arize_ax_space_id', None) }}",
-        name="rag-eval-{{ ds }}",
-        # SDK 8.25+ rejects empty examples list at create time. Seed with a
-        # single placeholder; real RAG examples are appended by
-        # prepare_rag_examples once spans are exported.
-        examples=[{"input": "_seed_", "expected": "_seed_"}],
+    # ----- Phase 1: ephemeral RAG dataset ----------------------------------
+    create_rag_dataset = ArizeAxCreateDatasetOperator(
+        task_id="create_rag_dataset",
+        space_id=_SPACE_JINJA,
+        name=f"rag-eval-dataset-{_RUN_SUFFIX}",
+        examples=RAG_EVAL_EXAMPLES,
         if_exists="skip",
     )
 
-    prepare_rag_examples = PythonOperator(
-        task_id="prepare_rag_examples",
-        python_callable=_prepare_rag_examples,
+    # ----- Phase 2: two LLM-as-judges (faithfulness + context_relevance) ----
+    build_faithfulness_judge_config = PythonOperator(
+        task_id="build_faithfulness_judge_config",
+        python_callable=_build_judge_config(
+            "faithfulness", FAITHFULNESS_TEMPLATE,
+            {"faithful": 1.0, "hallucinated": 0.0},
+        ),
+    )
+    create_faithfulness_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_faithfulness_evaluator",
+        space_id=_SPACE_JINJA,
+        name=f"rag_faithfulness_{_RUN_SUFFIX}",
+        evaluator_type="template",
+        commit_message="initial faithfulness judge",
+        template_config_task_id="build_faithfulness_judge_config",
+        description="LLM-as-judge for RAG response groundedness in context.",
+    )
+    create_faithfulness_eval_task = ArizeAxCreateTaskOperator(
+        task_id="create_faithfulness_eval_task",
+        name=f"rag-faithfulness-task-{_RUN_SUFFIX}",
+        eval_task_type="template_evaluation",
+        evaluators=[
+            {"evaluator_id": "{{ ti.xcom_pull(task_ids='create_faithfulness_evaluator') }}"},
+        ],
+        project_id="{{ var.value.get('arize_ax_project_id', '') or None }}",
+        is_continuous=False,
+        sampling_rate=1.0,
     )
 
-    append_rag_examples = ArizeAxAppendDatasetExamplesOperator(
-        task_id="append_rag_examples",
-        dataset_id="{{ ti.xcom_pull(task_ids='create_rag_eval_dataset') }}",
-        examples="{{ ti.xcom_pull(task_ids='prepare_rag_examples') }}",
+    build_relevance_judge_config = PythonOperator(
+        task_id="build_relevance_judge_config",
+        python_callable=_build_judge_config(
+            "context_relevance", CONTEXT_RELEVANCE_TEMPLATE,
+            {"relevant": 1.0, "irrelevant": 0.0},
+        ),
+    )
+    create_relevance_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_relevance_evaluator",
+        space_id=_SPACE_JINJA,
+        name=f"rag_context_relevance_{_RUN_SUFFIX}",
+        evaluator_type="template",
+        commit_message="initial context_relevance judge",
+        template_config_task_id="build_relevance_judge_config",
+        description="LLM-as-judge for RAG retrieval-context relevance.",
+    )
+    create_relevance_eval_task = ArizeAxCreateTaskOperator(
+        task_id="create_relevance_eval_task",
+        name=f"rag-context-relevance-task-{_RUN_SUFFIX}",
+        eval_task_type="template_evaluation",
+        evaluators=[
+            {"evaluator_id": "{{ ti.xcom_pull(task_ids='create_relevance_evaluator') }}"},
+        ],
+        project_id="{{ var.value.get('arize_ax_project_id', '') or None }}",
+        is_continuous=False,
+        sampling_rate=1.0,
     )
 
-    # Stage 4 — Run evaluation experiments
-    run_faithfulness_eval = ArizeAxRunExperimentOperator(
-        task_id="run_faithfulness_eval",
-        name="rag-faithfulness-{{ ds }}",
-        dataset_id="{{ ti.xcom_pull(task_ids='create_rag_eval_dataset') }}",
-        task=_rag_task,
-        evaluators=[_faithfulness_evaluator],
-        concurrency=4,
+    # ----- Phase 3: RAG run_experiment task ---------------------------------
+    build_rag_run_config = PythonOperator(
+        task_id="build_rag_run_config",
+        python_callable=_build_rag_run_config,
+    )
+    create_rag_run_exp_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_rag_run_exp_task",
+        space_id=_SPACE_JINJA,
+        name=f"rag-run-exp-task-{_RUN_SUFFIX}",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_rag_dataset') }}",
+        run_configuration="{{ ti.xcom_pull(task_ids='build_rag_run_config') }}",
+        if_exists="skip",
     )
 
-    run_relevance_eval = ArizeAxRunExperimentOperator(
-        task_id="run_relevance_eval",
-        name="rag-relevance-{{ ds }}",
-        dataset_id="{{ ti.xcom_pull(task_ids='create_rag_eval_dataset') }}",
-        task=_rag_task,
-        evaluators=[_context_relevance_evaluator],
-        concurrency=4,
+    # ----- Phase 4: chained trigger + wait + get_result ---------------------
+    # Both judges fan out server-side after each row's LLM response is
+    # generated. Eval Hub executes them and writes per-row labels/scores
+    # into experiment_runs.additional_properties["eval.<name>.*"].
+    run_rag_experiment = arize_ax_chained_experiment_eval(
+        group_id="run_rag_experiment",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_rag_run_exp_task') }}",
+        experiment_name=f"rag-eval-{_RUN_SUFFIX}",
+        space_id=_SPACE_JINJA,
+        evaluation_task_ids=[
+            "{{ ti.xcom_pull(task_ids='create_faithfulness_eval_task') }}",
+            "{{ ti.xcom_pull(task_ids='create_relevance_eval_task') }}",
+        ],
+        wait_for_completion=True,
+        sensor_timeout=900,
+        sensor_poke_interval=15,
+        fail_on_run_error=True,
     )
 
-    # Stage 5 — Score experiments
+    # ----- Phase 5: score both metrics --------------------------------------
+    _RAG_EXP_ID = (
+        "{{ ti.xcom_pull(task_ids='run_rag_experiment.trigger', "
+        "key='result')['experiment_id'] }}"
+    )
     score_faithfulness = ArizeAxGetExperimentScoreOperator(
         task_id="score_faithfulness",
-        experiment_id="{{ ti.xcom_pull(task_ids='run_faithfulness_eval') }}",
+        experiment_id=_RAG_EXP_ID,
+        aggregation="mean",
+    )
+    score_context_relevance = ArizeAxGetExperimentScoreOperator(
+        task_id="score_context_relevance",
+        experiment_id=_RAG_EXP_ID,
         aggregation="mean",
     )
 
-    score_relevance = ArizeAxGetExperimentScoreOperator(
-        task_id="score_relevance",
-        experiment_id="{{ ti.xcom_pull(task_ids='run_relevance_eval') }}",
-        aggregation="mean",
-    )
-
-    # Stage 6 — Report
+    # ----- Phase 6: report --------------------------------------------------
     report_rag_quality = PythonOperator(
         task_id="report_rag_quality",
         python_callable=_report_rag_quality,
         trigger_rule="all_done",
     )
 
+    # ----- Phase 7: cleanup -------------------------------------------------
+    cleanup_faithfulness_eval_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_faithfulness_eval_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_faithfulness_eval_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_relevance_eval_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_relevance_eval_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_relevance_eval_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_rag_run_exp_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_rag_run_exp_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_rag_run_exp_task') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_faithfulness_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_faithfulness_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_faithfulness_evaluator') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_relevance_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_relevance_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_relevance_evaluator') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+    cleanup_dataset = ArizeAxDeleteDatasetOperator(
+        task_id="cleanup_dataset",
+        dataset_id="{{ ti.xcom_pull(task_ids='create_rag_dataset') }}",
+        ignore_if_missing=True,
+        trigger_rule="all_done",
+    )
+
     # Wiring
-    check_project_exists >> extract_project_name >> export_rag_spans >> check_has_spans
-
-    check_has_spans >> create_rag_eval_dataset >> prepare_rag_examples >> append_rag_examples
-
-    append_rag_examples >> [run_faithfulness_eval, run_relevance_eval]
-
-    run_faithfulness_eval >> score_faithfulness
-    run_relevance_eval >> score_relevance
-
-    [score_faithfulness, score_relevance] >> report_rag_quality
+    check_prereqs >> [
+        create_rag_dataset,
+        build_faithfulness_judge_config,
+        build_relevance_judge_config,
+        build_rag_run_config,
+    ]
+    build_faithfulness_judge_config >> create_faithfulness_evaluator >> create_faithfulness_eval_task
+    build_relevance_judge_config >> create_relevance_evaluator >> create_relevance_eval_task
+    [create_rag_dataset, build_rag_run_config] >> create_rag_run_exp_task
+    [
+        create_rag_run_exp_task,
+        create_faithfulness_eval_task,
+        create_relevance_eval_task,
+    ] >> run_rag_experiment
+    run_rag_experiment >> [score_faithfulness, score_context_relevance] >> report_rag_quality
+    report_rag_quality >> [
+        cleanup_faithfulness_eval_task,
+        cleanup_relevance_eval_task,
+        cleanup_rag_run_exp_task,
+        cleanup_faithfulness_evaluator,
+        cleanup_relevance_evaluator,
+        cleanup_dataset,
+    ]

--- a/python/cookbooks/airflow_example_dags/example_arize_ax_self_optimizing_loop_dag.py
+++ b/python/cookbooks/airflow_example_dags/example_arize_ax_self_optimizing_loop_dag.py
@@ -1,8 +1,9 @@
 """Self-Optimizing Loop demo — fully self-contained closed-loop prompt
-improvement: create a deliberately-broken starter prompt, run a baseline
-experiment, optimize the prompt from baseline feedback via the Arize
-Prompt Learning SDK, run a candidate experiment with the optimized
-prompt, gate promotion on an LLM-as-judge metric, and promote on win.
+improvement, **executed server-side via the Arize Eval Hub**: create a
+deliberately-broken starter prompt, run a baseline experiment server-side,
+optimize the prompt from baseline feedback via the Arize Prompt Learning
+SDK, run a candidate experiment with the optimized prompt server-side,
+gate promotion on an LLM-as-judge metric, and promote on win.
 
 The demo is designed to **reliably end green** when prerequisites are
 configured: the verbose starter prompt produces multi-paragraph answers
@@ -11,101 +12,126 @@ the prompt to a concise form; the candidate scores high. If you change
 the starter prompt or the dataset, the gate may fire and the DAG will
 end red — that is correct behavior, not a bug.
 
-Pipeline (12 stages)::
+Pipeline (server-side variant)::
 
-    check_prereqs               (ShortCircuit — OPENAI_API_KEY + space + SDK import)
+    check_prereqs                   (ShortCircuit — AI integration + space + SDK)
         │
         ▼
-    create_demo_dataset         (10 terse-answer trivia rows; if_exists="skip")
+    create_demo_dataset             (10 terse-answer trivia rows; if_exists="skip")
         │
         ▼
-    create_initial_prompt       (verbose-by-design starter; if_exists="skip")
+    create_initial_prompt           (verbose-by-design starter; if_exists="skip")
         │
         ▼
-    run_baseline_experiment     (ArizeAxRunExperimentOperator, baseline_task + LLM judge)
+    create_terseness_evaluator      (server-side template_evaluation evaluator)
         │
         ▼
-    optimize_and_store          (PythonOperator — Prompt Learning SDK + Variable.set)
+    create_terseness_eval_task      (template_evaluation task wrapping the evaluator)
         │
         ▼
-    push_optimized_prompt       (ArizeAxCreatePromptOperator if_exists="add_version" — pushes v2 under same name)
+    create_baseline_run_exp_task    (run_experiment task with v1 prompt baked in)
         │
         ▼
-    run_candidate_experiment    (ArizeAxRunExperimentOperator, candidate_task + LLM judge)
+    baseline.{trigger,wait,get_result}   (TaskGroup — server-side chained eval)
         │
         ▼
-    compare_experiments         (ArizeAxCompareExperimentsOperator, fail_on_regression=True)
+    fetch_baseline_records          (PythonOperator — list_experiment_runs into df)
         │
         ▼
-    promote_prompt              (ArizeAxPromotePromptOperator, label="production")
+    optimize_and_store              (Prompt Learning SDK + Variable.set)
         │
         ▼
-    summarize_loop              (PythonOperator — print baseline/candidate/delta)
+    push_optimized_prompt           (ArizeAxCreatePromptOperator if_exists="add_version")
         │
         ▼
-    cleanup_dataset             (ArizeAxDeleteDatasetOperator, trigger_rule="all_done",
-                                 gated by arize_ax_self_optimizing_cleanup Variable)
+    create_candidate_run_exp_task   (run_experiment task with v2 prompt baked in; dynamic)
+        │
+        ▼
+    candidate.{trigger,wait,get_result}  (TaskGroup — server-side chained eval)
+        │
+        ▼
+    compare_experiments             (gate on terseness metric; fail_on_regression=True)
+        │
+        ▼
+    promote_prompt                  (label="production")
+        │
+        ▼
+    summarize_loop                  (print baseline/candidate/delta)
+        │
+        ▼
+    should_cleanup → cleanup_*      (delete dataset + ephemeral tasks/evaluator)
 
 Prerequisites
 -------------
 1. Airflow connection ``arize_ax_default`` with a valid API key.
 2. Airflow Variable ``arize_ax_space_id`` (or ``default_space`` on the connection extras).
-3. ``OPENAI_API_KEY`` in the **worker environment** — used both by the
-   experiment tasks (worker-side LLM call) and by the Prompt Learning SDK
-   during optimization.
-4. ``prompt-learning-enhanced`` installed on the worker (separate install
-   because PyPI rejects direct-URL deps, so the provider can no longer
-   declare it as an extra)::
+3. Airflow Variable ``arize_ai_integration_id`` (or env-var
+   ``ARIZE_AI_INTEGRATION_ID``) pointing at an AI integration with a real
+   provider API key. Used for **both** the run_experiment LLM call AND
+   the chained terseness evaluator. Server-side execution means there's
+   no ``OPENAI_API_KEY`` on the Airflow worker.
+4. ``prompt-learning-enhanced`` installed on the worker (the optimizer
+   step still runs locally; only the experiments + eval go server-side)::
 
        pip install 'arize-phoenix-evals>=2.0,<3.0' \\
                    'prompt-learning-enhanced @ git+https://github.com/Arize-ai/prompt-learning.git'
 
-5. ``openai`` Python SDK installed on the worker (typically already present).
-
 Optional Variables
 ------------------
 - ``arize_ax_self_optimizing_cleanup`` — set to ``"true"`` to delete the
-  demo dataset on DAG completion. Default ``"false"`` so you can inspect
-  the artifacts in the Arize UI between runs.
-- ``arize_ax_self_optimizing_model`` — the OpenAI model used by the
+  demo dataset + ephemeral task resources on DAG completion. Default
+  ``"false"`` so you can inspect the artifacts in the Arize UI between
+  runs.
+- ``arize_ax_self_optimizing_model`` — the model used by the server-side
   experiment tasks (default ``"gpt-4o-mini"``). The optimizer always
   uses ``gpt-4o`` regardless.
-
-This demo runs **client-side experiments** via ``ArizeAxRunExperimentOperator``.
-For a server-side (Eval Hub) variant, see ``example_arize_ax_e2e_dag.py``,
-which uses the ``arize_ax_chained_experiment_eval`` TaskGroup helper to
-trigger a ``run_experiment`` task with chained evaluation tasks via
-``evaluation_task_ids``.
 """
 
 from __future__ import annotations
 
 import json
-import os
+import time
 from datetime import datetime
 from typing import Any
 
 from airflow import DAG
 from airflow.models import Variable
+from airflow.providers.arize_ax.hooks.arize_ax import ArizeAxHook
 from airflow.providers.arize_ax.operators.datasets import (
     ArizeAxCreateDatasetOperator,
     ArizeAxDeleteDatasetOperator,
 )
+from airflow.providers.arize_ax.operators.evaluators import (
+    ArizeAxCreateEvaluatorOperator,
+    ArizeAxDeleteEvaluatorOperator,
+)
 from airflow.providers.arize_ax.operators.experiments import (
     ArizeAxCompareExperimentsOperator,
-    ArizeAxRunExperimentOperator,
 )
 from airflow.providers.arize_ax.operators.prompts import (
     ArizeAxCreatePromptOperator,
     ArizeAxPromotePromptOperator,
 )
+from airflow.providers.arize_ax.operators.tasks import (
+    ArizeAxCreateRunExperimentTaskOperator,
+    ArizeAxCreateTaskOperator,
+    ArizeAxDeleteTaskOperator,
+)
+from airflow.providers.arize_ax.utils.task_groups import (
+    arize_ax_chained_experiment_eval,
+)
 from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
 
 _SPACE_JINJA = "{{ var.value.get('arize_ax_space_id', '') or None }}"
+_INTEGRATION_ID_JINJA = (
+    "{{ var.value.get('arize_ai_integration_id', '') "
+    "or var.value.get('ARIZE_AI_INTEGRATION_ID', '') }}"
+)
 
 _PROMPT_NAME = "arize-ax-self-optimizing-loop-demo"
 _DATASET_NAME_TEMPLATE = "arize-ax-self-optimizing-loop-{{ ds_nodash }}"
 _OPTIMIZED_MESSAGES_VAR = "arize_ax_self_optimizing_optimized_messages"
+_EVAL_NAME = "terseness_judge"  # column name on experiment runs / metric name for compare
 
 # Deliberately verbose starter — produces multi-paragraph answers that fail
 # an exact-match evaluator over terse expected answers. The optimizer
@@ -132,17 +158,43 @@ _DEMO_EXAMPLES = [
     {"input": "Year humans first landed on the Moon?", "expected_output": "1969"},
 ]
 
+# Terseness judge rubric, encoded as a server-side template_evaluation
+# template. The evaluator template uses **f-string single-brace**
+# substitution (Arize backend validates this at create time). Note that
+# the `run_experiment` task's `messages` field uses **mustache
+# double-brace** — the two surfaces have different substitution rules.
+_TERSENESS_JUDGE_TEMPLATE = (
+    "You are a strict evaluator scoring an assistant's response to a "
+    "trivia question. Score the response on BOTH correctness AND terseness.\n\n"
+    "Question: {input}\n"
+    "Expected answer: {expected_output}\n"
+    "Assistant response: {output}\n\n"
+    "First count the words in the assistant response, then choose a label "
+    "using the rubric below.\n\n"
+    "Rubric (response word count matters — count carefully):\n"
+    "  - concise: 1-30 words AND contains the expected answer.\n"
+    "  - brief: 31-100 words AND contains the expected answer.\n"
+    "  - verbose: more than 100 words (regardless of correctness).\n"
+    "  - incorrect: response does not contain the expected answer at all.\n\n"
+    "Be strict about word count. Reply with ONLY the label."
+)
 
-# ---------------------------------------------------------------------------
-# Prereq guard
-# ---------------------------------------------------------------------------
+
 def _check_prereqs(**_ctx) -> bool:
     """Return True iff every prerequisite is satisfied; otherwise short-circuit."""
-    if not os.environ.get("OPENAI_API_KEY", "").strip():
-        print("OPENAI_API_KEY not set in worker environment — skipping demo.")
-        return False
     if not Variable.get("arize_ax_space_id", default_var="").strip():
         print("Airflow Variable arize_ax_space_id not set — skipping demo.")
+        return False
+    integration = (
+        Variable.get("arize_ai_integration_id", default_var="").strip()
+        or Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
+    )
+    if not integration:
+        print(
+            "AI integration Variable not set — set 'arize_ai_integration_id' or "
+            "'ARIZE_AI_INTEGRATION_ID' to point at an integration with a real "
+            "provider API key."
+        )
         return False
     try:
         import optimizer_sdk.prompt_learning_optimizer  # noqa: F401
@@ -153,155 +205,149 @@ def _check_prereqs(**_ctx) -> bool:
             "'prompt-learning-enhanced @ git+https://github.com/Arize-ai/prompt-learning.git'"
         )
         return False
-    try:
-        import openai  # noqa: F401
-    except ImportError:
-        print("openai SDK is not installed on the worker — required for experiment tasks.")
-        return False
     return True
 
 
-# ---------------------------------------------------------------------------
-# Task callables for the experiments
-# ---------------------------------------------------------------------------
-def _call_openai_with_messages(messages: list[dict[str, str]]) -> str:
-    """Single LLM call. Kept tiny so the demo is easy to read."""
-    import openai
-
-    model = Variable.get("arize_ax_self_optimizing_model", default_var="gpt-4o-mini")
-    response = openai.OpenAI().chat.completions.create(
-        model=model,
-        messages=messages,
-        temperature=0,
+def _build_evaluator_template_config(**ctx) -> dict[str, Any]:
+    """Build the terseness-judge template_config — referenced by create_terseness_evaluator."""
+    integration_id = (
+        Variable.get("arize_ai_integration_id", default_var="").strip()
+        or Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
     )
-    return (response.choices[0].message.content or "").strip()
+    return {
+        "name": _EVAL_NAME,
+        "template": _TERSENESS_JUDGE_TEMPLATE,
+        "include_explanations": True,
+        "use_function_calling_if_available": False,
+        "classification_choices": {
+            "concise": 1.0,
+            "brief": 0.5,
+            "verbose": 0.0,
+            "incorrect": 0.0,
+        },
+        "llm_config": {
+            "ai_integration_id": integration_id,
+            "model_name": Variable.get(
+                "arize_ax_self_optimizing_model", default_var="gpt-4o-mini",
+            ),
+            "invocation_parameters": {"temperature": 0},
+            "provider_parameters": {},
+        },
+    }
 
 
-def baseline_task(dataset_row: dict) -> dict[str, Any]:
-    """Run the deliberately-verbose starter prompt against a dataset row."""
-    messages = [
-        {"role": "system", "content": _INITIAL_SYSTEM_PROMPT},
-        {"role": "user", "content": dataset_row.get("input", "")},
-    ]
-    return {"output": _call_openai_with_messages(messages)}
+def _run_configuration_for_messages(messages: list[dict[str, str]]) -> dict[str, Any]:
+    """Shared helper: build a LlmGenerationRunConfig dict around a messages list."""
+    integration_id = (
+        Variable.get("arize_ai_integration_id", default_var="").strip()
+        or Variable.get("ARIZE_AI_INTEGRATION_ID", default_var="").strip()
+    )
+    return {
+        "experiment_type": "llm_generation",
+        "ai_integration_id": integration_id,
+        "model_name": Variable.get(
+            "arize_ax_self_optimizing_model", default_var="gpt-4o-mini",
+        ),
+        # Mustache + double-brace: matches Arize backend substitution.
+        "messages": messages,
+        "input_variable_format": "mustache",
+        "invocation_parameters": {"temperature": 0},
+        "provider_parameters": {},
+    }
 
 
-def candidate_task(dataset_row: dict) -> dict[str, Any]:
-    """Run the optimized prompt (stored in Airflow Variable) against a dataset row."""
+def _build_baseline_run_config(**_ctx) -> dict[str, Any]:
+    """run_configuration for the baseline experiment (verbose-by-design starter)."""
+    return _run_configuration_for_messages(
+        [
+            {"role": "system", "content": _INITIAL_SYSTEM_PROMPT},
+            {"role": "user", "content": "{{input}}"},
+        ],
+    )
+
+
+def _build_candidate_run_config(**_ctx) -> dict[str, Any]:
+    """run_configuration for the candidate experiment using the optimized prompt.
+
+    Reads optimized messages from the Variable stored by ``optimize_and_store``;
+    appends a user-role line that pulls the dataset's ``input`` column via
+    mustache substitution.
+    """
     raw = Variable.get(_OPTIMIZED_MESSAGES_VAR, default_var=None)
     if not raw:
         raise RuntimeError(
-            f"Variable {_OPTIMIZED_MESSAGES_VAR!r} is not set — "
-            "the store_optimized_prompt stage must run before candidate_task."
+            f"Variable {_OPTIMIZED_MESSAGES_VAR!r} not set — "
+            "optimize_and_store must run before this step."
         )
     optimized_messages = json.loads(raw)
-    user_msg = {"role": "user", "content": dataset_row.get("input", "")}
-    # Optimizer typically returns a single system message; append the user
-    # question so the call has both roles.
-    messages = list(optimized_messages) + [user_msg]
-    return {"output": _call_openai_with_messages(messages)}
+    return _run_configuration_for_messages(
+        list(optimized_messages) + [{"role": "user", "content": "{{input}}"}],
+    )
 
 
-_JUDGE_SYSTEM_PROMPT = (
-    "You are a strict evaluator scoring an assistant's response to a "
-    "trivia question. Score the response on BOTH correctness AND "
-    "terseness. First count the words in the response, then score using "
-    "the rubric below. Reply with ONLY a single line in the exact form: "
-    "score=<float between 0.0 and 1.0>; label=<concise|brief|verbose|incorrect>; "
-    "reason=<word count + short explanation>.\n\n"
-    "Scoring rubric (response word count matters — count words carefully):\n"
-    "  - score=1.0, label=concise: response is 1-30 words AND contains the "
-    "expected answer. A short factual answer with at most one supporting "
-    "sentence fits here.\n"
-    "  - score=0.5, label=brief: response is 31-100 words AND contains the "
-    "expected answer. A short paragraph with limited context fits here.\n"
-    "  - score=0.0, label=verbose: response is MORE THAN 100 words "
-    "(regardless of correctness). Multi-paragraph explanations, historical "
-    "context tangents, or textbook-style answers fall here.\n"
-    "  - score=0.0, label=incorrect: response does not contain the "
-    "expected answer at all.\n\n"
-    "Be strict about word count: count every word, do not round generously. "
-    "The grade reflects format quality, not just factual accuracy."
-)
+def _records_from_experiment_runs(experiment_id: str) -> list[dict[str, Any]]:
+    """Flatten experiment runs (server-side) into a list of dicts the
+    Prompt Learning optimizer can ingest.
 
-
-def _parse_judge_response(text: str) -> tuple[float, str, str]:
-    """Parse 'score=...; label=...; reason=...' into (score, label, reason)."""
-    score = 0.0
-    label = "incorrect"
-    reason = text.strip()
-    for part in text.split(";"):
-        key, _, value = part.partition("=")
-        key = key.strip().lower()
-        value = value.strip()
-        if key == "score":
-            try:
-                score = float(value)
-            except (TypeError, ValueError):
-                score = 0.0
-        elif key == "label":
-            label = value or label
-        elif key == "reason":
-            reason = value or reason
-    score = max(0.0, min(1.0, score))
-    return score, label, reason
-
-
-def llm_judge_terseness(dataset_row: dict, output: Any) -> Any:
-    """LLM-as-judge: scores response on correctness AND terseness via gpt-4o-mini.
-
-    Cheap and fast (one extra LLM call per dataset row, gpt-4o-mini at
-    temperature=0). The rubric narrows variance enough that the demo
-    reliably ends green when the optimizer wins.
+    For each run, combines the dataset-example fields (input,
+    expected_output) with the LLM output and chained-eval columns
+    (label, explanation). The optimizer reads `feedback_columns` from
+    the resulting DataFrame.
     """
-    from arize.experiments import EvaluationResult
+    hook = ArizeAxHook()
+    # Brief grace period for eval scores to attach to runs after the
+    # experiment terminates (the chained eval task fires async on the
+    # backend; helper's wait_for_completion gates on task-run status
+    # but not on eval score persistence).
+    time.sleep(15)
+    response = hook.list_experiment_runs(experiment_id=experiment_id, limit=50, all=True)
+    items = response.get("items", []) if isinstance(response, dict) else []
+    records: list[dict[str, Any]] = []
+    for r in items:
+        if not isinstance(r, dict):
+            continue
+        ap = r.get("additional_properties") or {}
+        ap = ap if isinstance(ap, dict) else {}
+        rec: dict[str, Any] = {
+            "output": r.get("output"),
+            # Dataset example fields land in additional_properties under
+            # their original column names on server-side runs.
+            "input": ap.get("input"),
+            "expected_output": ap.get("expected_output"),
+        }
+        # Eval columns from the chained template_evaluation task:
+        # eval.<name>.label / .score / .explanation.
+        for key in ap.keys():
+            if key.startswith("eval."):
+                rec[key] = ap[key]
+        records.append(rec)
+    return records
 
-    expected = str(dataset_row.get("expected_output", "")).strip()
-    question = str(dataset_row.get("input", "")).strip()
-    actual = str((output or {}).get("output", "") if isinstance(output, dict) else (output or "")).strip()
 
-    user_msg = (
-        f"Question: {question}\n"
-        f"Expected answer: {expected}\n"
-        f"Assistant response: {actual}"
-    )
-    raw = _call_openai_with_messages(
-        [
-            {"role": "system", "content": _JUDGE_SYSTEM_PROMPT},
-            {"role": "user", "content": user_msg},
-        ],
-    )
-    score, label, reason = _parse_judge_response(raw)
-    return EvaluationResult(score=score, label=label, explanation=reason)
-
-
-# ---------------------------------------------------------------------------
-# Optimization step — runs ArizeAxOptimizePromptOperator under the hood and
-# persists the result in an Airflow Variable so candidate_task can pick it up
-# without an Airflow context (Arize SDK task callables only receive the
-# dataset row).
-# ---------------------------------------------------------------------------
 def _optimize_and_store(**ctx) -> dict[str, Any]:
-    """Optimize the starter prompt against baseline feedback and store the result.
-
-    The Prompt Learning SDK's ``PromptLearningOptimizer.optimize`` requires a
-    pandas DataFrame (it calls ``dataset.columns`` during input validation),
-    so we materialize the baseline's row-dict records into one here.
-    """
+    """Optimize the starter prompt against server-side baseline feedback."""
     import pandas as pd
-    from airflow.providers.arize_ax.hooks.arize_ax import ArizeAxHook
 
-    baseline_result = ctx["ti"].xcom_pull(task_ids="run_baseline_experiment", key="result") or {}
-    if not isinstance(baseline_result, dict):
+    # Fetch the chained get_result XCom (TaskGroup .get_result task pushes
+    # the get_task_run dict; experiment_id lives on its sibling .trigger
+    # XCom under the 'result' key).
+    ti = ctx["ti"]
+    triggered = ti.xcom_pull(
+        task_ids="run_baseline_experiment.trigger", key="result",
+    ) or {}
+    experiment_id = triggered.get("experiment_id") if isinstance(triggered, dict) else None
+    if not experiment_id:
         raise RuntimeError(
-            f"Unexpected baseline result XCom shape: {type(baseline_result).__name__}."
+            "Could not resolve baseline experiment_id from "
+            "run_baseline_experiment.trigger XCom."
         )
-    records = baseline_result.get("dataframe_records") or []
+
+    records = _records_from_experiment_runs(experiment_id)
     if not records:
         raise RuntimeError(
-            "Baseline experiment produced no dataframe_records — cannot optimize."
+            f"Baseline experiment {experiment_id} returned no runs — "
+            "cannot optimize."
         )
-
     df = pd.DataFrame(records)
     print(f"[optimize] Baseline DataFrame: {len(df)} rows, columns={list(df.columns)}")
 
@@ -311,8 +357,8 @@ def _optimize_and_store(**ctx) -> dict[str, Any]:
         dataset=df,
         output_column="output",
         feedback_columns=[
-            "eval.llm_judge_terseness.label",
-            "eval.llm_judge_terseness.explanation",
+            f"eval.{_EVAL_NAME}.label",
+            f"eval.{_EVAL_NAME}.explanation",
         ],
         model_choice="gpt-4o",
     )
@@ -329,17 +375,21 @@ def _optimize_and_store(**ctx) -> dict[str, Any]:
     return optimization
 
 
-# ---------------------------------------------------------------------------
-# Summary callable
-# ---------------------------------------------------------------------------
 def _summarize_loop(**ctx) -> dict[str, Any]:
     """Log baseline / candidate / delta and a Prompt Hub pointer."""
-    baseline_id = ctx["ti"].xcom_pull(task_ids="run_baseline_experiment")
-    candidate_id = ctx["ti"].xcom_pull(task_ids="run_candidate_experiment")
-    compare = ctx["ti"].xcom_pull(task_ids="compare_experiments") or {}
-    promoted_version_id = ctx["ti"].xcom_pull(task_ids="promote_prompt")
+    ti = ctx["ti"]
+    baseline_triggered = ti.xcom_pull(
+        task_ids="run_baseline_experiment.trigger", key="result",
+    ) or {}
+    candidate_triggered = ti.xcom_pull(
+        task_ids="run_candidate_experiment.trigger", key="result",
+    ) or {}
+    baseline_id = baseline_triggered.get("experiment_id") if isinstance(baseline_triggered, dict) else None
+    candidate_id = candidate_triggered.get("experiment_id") if isinstance(candidate_triggered, dict) else None
+    compare = ti.xcom_pull(task_ids="compare_experiments") or {}
+    promoted_version_id = ti.xcom_pull(task_ids="promote_prompt")
     print("=" * 60)
-    print("SELF-OPTIMIZING LOOP COMPLETE")
+    print("SELF-OPTIMIZING LOOP COMPLETE (server-side)")
     print(f"  Baseline experiment id : {baseline_id}")
     print(f"  Candidate experiment id: {candidate_id}")
     print(f"  Comparison verdict     : {compare}")
@@ -357,17 +407,16 @@ def _summarize_loop(**ctx) -> dict[str, Any]:
 
 
 def _should_cleanup(**_ctx) -> bool:
-    return Variable.get("arize_ax_self_optimizing_cleanup", default_var="false").strip().lower() == "true"
+    return Variable.get(
+        "arize_ax_self_optimizing_cleanup", default_var="false",
+    ).strip().lower() == "true"
 
 
-# ---------------------------------------------------------------------------
-# DAG
-# ---------------------------------------------------------------------------
 with DAG(
     dag_id="arize_ax_self_optimizing_loop",
     start_date=datetime(2026, 1, 1),
     schedule=None,
-    tags=["arize_ax", "demo", "prompt", "optimization", "self-learning"],
+    tags=["arize_ax", "demo", "prompt", "optimization", "self-learning", "eval-hub"],
     catchup=False,
     doc_md=__doc__,
     render_template_as_native_obj=True,
@@ -396,13 +445,69 @@ with DAG(
         if_exists="skip",
     )
 
-    run_baseline_experiment = ArizeAxRunExperimentOperator(
-        task_id="run_baseline_experiment",
-        name="self-optimizing-baseline-{{ ts_nodash }}",
+    build_evaluator_config = PythonOperator(
+        task_id="build_evaluator_config",
+        python_callable=_build_evaluator_template_config,
+    )
+
+    create_terseness_evaluator = ArizeAxCreateEvaluatorOperator(
+        task_id="create_terseness_evaluator",
+        space_id=_SPACE_JINJA,
+        name=_EVAL_NAME,
+        evaluator_type="template",
+        commit_message="initial terseness judge for self-optimizing-loop demo",
+        template_config_task_id="build_evaluator_config",
+        description="Word-count + correctness rubric for trivia-style answers.",
+        if_exists="skip",
+    )
+
+    create_terseness_eval_task = ArizeAxCreateTaskOperator(
+        task_id="create_terseness_eval_task",
+        name="self-optimizing-terseness-task-{{ ts_nodash }}",
+        eval_task_type="template_evaluation",
+        evaluators=[
+            {"evaluator_id": "{{ ti.xcom_pull(task_ids='create_terseness_evaluator') }}"},
+        ],
+        # Project-scoped: server-side eval runs against the run's spans.
+        # We point at the experiment_traces_project_id created by the
+        # baseline run_experiment task at trigger time (via the chained
+        # path); for a project-scoped template_eval the project_id is
+        # required at creation. The baseline run_experiment creates its
+        # own ephemeral project; we use the configured arize_ax_project_id
+        # Variable as the scoping target so the eval task can be created
+        # before the experiments fire.
+        project_id="{{ var.value.get('arize_ax_project_id', '') or None }}",
+        is_continuous=False,
+        sampling_rate=1.0,
+    )
+
+    build_baseline_run_config = PythonOperator(
+        task_id="build_baseline_run_config",
+        python_callable=_build_baseline_run_config,
+    )
+
+    create_baseline_run_exp_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_baseline_run_exp_task",
+        space_id=_SPACE_JINJA,
+        name="self-optimizing-baseline-task-{{ ts_nodash }}",
         dataset_id="{{ ti.xcom_pull(task_ids='create_demo_dataset') }}",
-        task=baseline_task,
-        evaluators=[llm_judge_terseness],
-        concurrency=4,
+        run_configuration="{{ ti.xcom_pull(task_ids='build_baseline_run_config') }}",
+        if_exists="skip",
+    )
+
+    # Baseline server-side experiment + chained terseness eval.
+    run_baseline_experiment = arize_ax_chained_experiment_eval(
+        group_id="run_baseline_experiment",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_baseline_run_exp_task') }}",
+        experiment_name="self-optimizing-baseline-{{ ts_nodash }}",
+        space_id=_SPACE_JINJA,
+        evaluation_task_ids=[
+            "{{ ti.xcom_pull(task_ids='create_terseness_eval_task') }}",
+        ],
+        wait_for_completion=True,
+        sensor_timeout=900,
+        sensor_poke_interval=15,
+        fail_on_run_error=True,
     )
 
     optimize_and_store = PythonOperator(
@@ -410,10 +515,6 @@ with DAG(
         python_callable=_optimize_and_store,
     )
 
-    # Reuse ArizeAxCreatePromptOperator with ``if_exists="add_version"``:
-    # when the prompt name already exists, the operator catches the 409,
-    # resolves the existing prompt_id, and pushes the new messages as a
-    # fresh version (visible in Prompt Hub as v2 alongside the original).
     push_optimized_prompt = ArizeAxCreatePromptOperator(
         task_id="push_optimized_prompt",
         space_id=_SPACE_JINJA,
@@ -425,20 +526,45 @@ with DAG(
         if_exists="add_version",
     )
 
-    run_candidate_experiment = ArizeAxRunExperimentOperator(
-        task_id="run_candidate_experiment",
-        name="self-optimizing-candidate-{{ ts_nodash }}",
+    build_candidate_run_config = PythonOperator(
+        task_id="build_candidate_run_config",
+        python_callable=_build_candidate_run_config,
+    )
+
+    create_candidate_run_exp_task = ArizeAxCreateRunExperimentTaskOperator(
+        task_id="create_candidate_run_exp_task",
+        space_id=_SPACE_JINJA,
+        name="self-optimizing-candidate-task-{{ ts_nodash }}",
         dataset_id="{{ ti.xcom_pull(task_ids='create_demo_dataset') }}",
-        task=candidate_task,
-        evaluators=[llm_judge_terseness],
-        concurrency=4,
+        run_configuration="{{ ti.xcom_pull(task_ids='build_candidate_run_config') }}",
+        if_exists="skip",
+    )
+
+    run_candidate_experiment = arize_ax_chained_experiment_eval(
+        group_id="run_candidate_experiment",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_candidate_run_exp_task') }}",
+        experiment_name="self-optimizing-candidate-{{ ts_nodash }}",
+        space_id=_SPACE_JINJA,
+        evaluation_task_ids=[
+            "{{ ti.xcom_pull(task_ids='create_terseness_eval_task') }}",
+        ],
+        wait_for_completion=True,
+        sensor_timeout=900,
+        sensor_poke_interval=15,
+        fail_on_run_error=True,
     )
 
     compare_experiments = ArizeAxCompareExperimentsOperator(
         task_id="compare_experiments",
-        candidate_experiment_id="{{ ti.xcom_pull(task_ids='run_candidate_experiment') }}",
-        baseline_experiment_id="{{ ti.xcom_pull(task_ids='run_baseline_experiment') }}",
-        metric_names=["llm_judge_terseness"],
+        candidate_experiment_id=(
+            "{{ ti.xcom_pull(task_ids='run_candidate_experiment.trigger', "
+            "key='result')['experiment_id'] }}"
+        ),
+        baseline_experiment_id=(
+            "{{ ti.xcom_pull(task_ids='run_baseline_experiment.trigger', "
+            "key='result')['experiment_id'] }}"
+        ),
+        metric_names=[_EVAL_NAME],
         pass_threshold=0.0,
         fail_on_regression=True,
     )
@@ -466,10 +592,43 @@ with DAG(
         dataset_id="{{ ti.xcom_pull(task_ids='create_demo_dataset') }}",
         ignore_if_missing=True,
     )
+    cleanup_baseline_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_baseline_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_baseline_run_exp_task') }}",
+        ignore_if_missing=True,
+    )
+    cleanup_candidate_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_candidate_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_candidate_run_exp_task') }}",
+        ignore_if_missing=True,
+    )
+    cleanup_eval_task = ArizeAxDeleteTaskOperator(
+        task_id="cleanup_eval_task",
+        task_id_param="{{ ti.xcom_pull(task_ids='create_terseness_eval_task') }}",
+        ignore_if_missing=True,
+    )
+    cleanup_evaluator = ArizeAxDeleteEvaluatorOperator(
+        task_id="cleanup_evaluator",
+        evaluator_id="{{ ti.xcom_pull(task_ids='create_terseness_evaluator') }}",
+        ignore_if_missing=True,
+    )
 
     # Wiring
     check_prereqs >> create_demo_dataset >> create_initial_prompt
-    create_initial_prompt >> run_baseline_experiment >> optimize_and_store
-    optimize_and_store >> push_optimized_prompt >> run_candidate_experiment
+    create_initial_prompt >> build_evaluator_config >> create_terseness_evaluator
+    create_terseness_evaluator >> create_terseness_eval_task
+    [create_demo_dataset, build_baseline_run_config] >> create_baseline_run_exp_task
+    [create_terseness_eval_task, create_baseline_run_exp_task] >> run_baseline_experiment
+    run_baseline_experiment >> optimize_and_store >> push_optimized_prompt
+    push_optimized_prompt >> build_candidate_run_config >> create_candidate_run_exp_task
+    [create_terseness_eval_task, create_candidate_run_exp_task] >> run_candidate_experiment
     run_candidate_experiment >> compare_experiments >> promote_prompt
-    promote_prompt >> summarize_loop >> should_cleanup >> cleanup_dataset
+    promote_prompt >> summarize_loop
+    summarize_loop >> should_cleanup
+    should_cleanup >> [
+        cleanup_dataset,
+        cleanup_baseline_task,
+        cleanup_candidate_task,
+        cleanup_eval_task,
+        cleanup_evaluator,
+    ]


### PR DESCRIPTION
Follow-up to #53.

## Summary
Migrates 7 example DAGs from **client-side `ArizeAxRunExperimentOperator`** (worker-side LLM calls) to **server-side Eval Hub** via `ArizeAxCreateRunExperimentTaskOperator` + the `arize_ax_chained_experiment_eval` TaskGroup helper. Worker-side LLM/judge callables are gone; LLM generation and evaluation now run on the Arize backend.

All seven DAGs are also now **fully self-contained** — they provision their own dataset / prompt / evaluator / tasks per run (suffixed by run_id) and tear everything down on completion, so they no longer need external Variables pointing at pre-existing baseline experiments or dataset IDs.

### Per-DAG highlights

- **`drift_detection`** — deliberately provisions a degraded current prompt so drift fires reliably; rollback re-promotes the baseline prompt version under the `production` label.
- **`llm_cicd_gate`** — provisions baseline + candidate prompts in-run (both `gpt-4.1`) to isolate prompt-engineering impact from model choice.
- **`prompt_lifecycle`** — compares production vs staging prompts from the same run instead of an external baseline; both gates now correctly use `ignore_downstream_trigger_rules=False`.
- **`rag_evaluation`** — replaces the production-span export path with a synthetic RAG dataset and real LLM-as-judge faithfulness + context-relevance evaluators. (For real-spans workflows, use `dataset_curation_dag`.)
- **`llm_experiments`** — matrix trimmed from 5 → 3 experiments, single-provider OpenAI; drops Anthropic/Haiku rows and the `ANTHROPIC_API_KEY` worker dependency.
- **`self_optimizing_loop`** — keeps client-side experiments for the optimizer loop; now requires `ARIZE_AI_INTEGRATION_ID` + `arize_ax_project_id` for the chained evaluator task.
- **`experiment`** — clean Eval Hub migration with full cleanup of judge task / run-exp task / judge evaluator.

### README

- Bump DAG count to 22, refresh "Last Updated" to 2026-05-21.
- Document the new common `arize_ai_integration_id` + `arize_ax_project_id` Variables (used by 9 DAGs total).
- Drop the now-unused `arize_ax_baseline_experiment_id` / `arize_ax_candidate_experiment_id` / `arize_ax_prompt_name` / `arize_ax_prompt_label` rows for `drift_detection`, `llm_cicd_gate`, and `prompt_lifecycle`.
- Add the `cloud_export_dag` Variables + pattern row that were missing from #53.