### PR TITLE
Add OpenInference best practices cookbook

### DIFF
--- a/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
+++ b/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
@@ -1,0 +1,1412 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "<center>\n",
+    "    <p style=\"text-align:center\">\n",
+    "    <img alt=\"arize logo\" src=\"https://storage.googleapis.com/arize-assets/arize-logo-white.jpg\" width=\"300\"/>\n",
+    "        <br>\n",
+    "        <a href=\"https://docs.arize.com/arize/\">Docs</a>\n",
+    "        |\n",
+    "        <a href=\"https://github.com/Arize-ai/client_python\">GitHub</a>\n",
+    "        |\n",
+    "        <a href=\"https://arize-ai.slack.com/join/shared_invite/zt-11t1vbu4x-xkBIHmOREQnYnYDH1GDfCg\">Community</a>\n",
+    "    </p>\n",
+    "</center>\n",
+    "\n",
+    "# <center>OpenInference Best Practices</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09a56820",
+   "metadata": {},
+   "source": [
+    "This notebook is a hands-on tour of OpenInference best practices for tracing AI applications with Arize AX. You will learn:\n",
+    "\n",
+    "- How OpenInference layers on top of OpenTelemetry to add AI-aware semantics\n",
+    "- The hierarchy of sessions, traces, and spans that organizes your telemetry\n",
+    "- Three ways to capture spans — auto-instrumentation, manual instrumentation, and the hybrid approach that combines them\n",
+    "- The common attributes every span carries, and the kind-specific attributes for the four core span kinds (LLM, chain, agent, and tool)\n",
+    "- How to add or override attributes on spans, including auto-instrumented spans you cannot access directly\n",
+    "\n",
+    "Each section runs a small piece of code, then guides you through what to look for in the Arize AX trace view."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cc4be9e",
+   "metadata": {},
+   "source": [
+    "## Initial setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba2bec83",
+   "metadata": {},
+   "source": [
+    "You will need an Arize AX account to run this notebook. [Sign up now for free](https://app.arize.com/auth/join) if you don't have an account."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "808e5fea",
+   "metadata": {},
+   "source": [
+    "### Install libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "212beb4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -qq openai openai-agents\n",
+    "!pip install -qq arize-otel openinference-instrumentation-openai openinference-instrumentation-openai-agents opentelemetry-sdk opentelemetry-exporter-otlp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f193e3c7",
+   "metadata": {},
+   "source": [
+    "### Setup keys\n",
+    "\n",
+    "Copy the Arize `API_KEY` and `SPACE_ID` from your Space Settings page (shown below) to the variables in the cell below.\n",
+    "\n",
+    "![](apikey.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "94a0ad81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "ARIZE_SPACE_ID = globals().get(\"ARIZE_SPACE_ID\") or getpass(\n",
+    "    \"🔑 Enter your Arize Space ID: \"\n",
+    ")\n",
+    "ARIZE_API_KEY = globals().get(\"ARIZE_API_KEY\") or getpass(\"🔑 Enter your Arize API Key: \")\n",
+    "OPENAI_API_KEY = globals().get(\"OPENAI_API_KEY\") or getpass(\n",
+    "    \"🔑 Enter your OpenAI API key: \"\n",
+    ")\n",
+    "os.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35091b8c",
+   "metadata": {},
+   "source": [
+    "### Setup tracing\n",
+    "\n",
+    "Use the `arize-otel` convenience function to register a tracer provider that sends spans to Arize AX, then enable the OpenAI auto-instrumentor so calls to the OpenAI SDK are traced automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cba74baa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🔭 OpenTelemetry Tracing Details 🔭\n",
+      "|  Arize Project: otel-best-practices\n",
+      "|  Span Processor: SimpleSpanProcessor\n",
+      "|  Collector Endpoint: otlp.arize.com\n",
+      "|  Transport: gRPC\n",
+      "|  Transport Headers: {'authorization': '****', 'api_key': '****', 'arize-space-id': '****', 'space_id': '****', 'arize-interface': '****'}\n",
+      "|  \n",
+      "|  Using a default SpanProcessor. `add_span_processor` will overwrite this default.\n",
+      "|  \n",
+      "|  `register` has set this TracerProvider as the global OpenTelemetry default.\n",
+      "|  To disable this behavior, call `register` with `set_global_tracer_provider=False`.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from arize.otel import register\n",
+    "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
+    "\n",
+    "tracer_provider = register(\n",
+    "    space_id=ARIZE_SPACE_ID,\n",
+    "    api_key=ARIZE_API_KEY,\n",
+    "    project_name=\"otel-best-practices\",\n",
+    "    batch=False,\n",
+    ")\n",
+    "\n",
+    "OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9dda9a8",
+   "metadata": {},
+   "source": [
+    "## Introduction to OpenInference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa9ac7f7",
+   "metadata": {},
+   "source": [
+    "[OpenInference](https://github.com/Arize-ai/openinference) is an open-source set of conventions and instrumentation libraries for tracing AI applications. It is maintained by Arize and is the standard that Arize AX uses to render LLM, tool, agent, chain, retriever, and other AI-specific spans in the trace view.\n",
+    "\n",
+    "OpenInference is an **extension to [OpenTelemetry](https://opentelemetry.io/docs/)**, not a replacement for it. It uses the standard OpenTelemetry SDK and libraries under the hood — the same `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` you would use for any OTel-instrumented service. What OpenInference adds is:\n",
+    "\n",
+    "- A set of **semantic conventions** that describe how to represent AI concepts (LLM calls, prompts, messages, tool invocations, retrieval, agent steps, sessions) as span attributes\n",
+    "- A library of **auto-instrumentors** for popular LLM SDKs and orchestration frameworks (OpenAI, Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many more)\n",
+    "\n",
+    "Because OpenInference is built on OpenTelemetry, any tool that speaks OTel can consume the spans — but a backend that understands the OpenInference conventions (like Arize AX) can render them as a rich, AI-aware trace view rather than a generic span list.\n",
+    "\n",
+    "**Read more:**\n",
+    "\n",
+    "- [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) — the formal definitions for span kinds, attributes, and message structure.\n",
+    "- [OpenInference repository](https://github.com/Arize-ai/openinference) — auto-instrumentors, examples, and source for every supported language and framework.\n",
+    "- [OpenTelemetry documentation](https://opentelemetry.io/docs/) — the underlying observability framework that OpenInference builds on."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c4ff5f2",
+   "metadata": {},
+   "source": [
+    "The code below simulates having a conversation with a chatbot and asking it two related questions. It will create traces in AX for a simple set of OpenAI calls.\n",
+    "\n",
+    "Run this code. Don't worry for now about what the code is doing, we will dive into the details later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e2952ced",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "OpenInference is an open standard for **instrumenting and tracing AI applications**, especially LLM apps and agent workflows.\n",
+       "\n",
+       "It helps you:\n",
+       "- **Capture spans, prompts, tool calls, outputs, and metadata**\n",
+       "- **Trace** how an app or agent made decisions\n",
+       "- **Debug** failures and weird model behavior\n",
+       "- **Analyze** performance, latency, cost, and quality\n",
+       "- **Export** data to observability tools like OpenTelemetry-compatible backends\n",
+       "\n",
+       "In short: **OpenInference gives you a common way to observe and understand AI systems end to end**.\n",
+       "\n",
+       "If you want, I can also explain how it compares to OpenTelemetry or show a simple example."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "OpenInference is built on top of **OpenTelemetry (OTel)**.\n",
+       "\n",
+       "Relationship:\n",
+       "- **OpenTelemetry** provides the general-purpose standard for tracing, metrics, and logs.\n",
+       "- **OpenInference** defines **AI/LLM-specific conventions** for those traces, like:\n",
+       "  - prompts\n",
+       "  - completions\n",
+       "  - tool calls\n",
+       "  - embeddings\n",
+       "  - token counts\n",
+       "  - model/provider metadata\n",
+       "\n",
+       "So:\n",
+       "- OTel = the **observability framework**\n",
+       "- OpenInference = the **AI semantic conventions / instrumentation layer** for OTel\n",
+       "\n",
+       "This means OpenInference traces can usually be sent to any **OpenTelemetry-compatible backend**.\n",
+       "\n",
+       "If you want, I can give a concrete example of an OpenInference trace in OTel terms."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import uuid\n",
+    "from IPython.display import Markdown, display\n",
+    "from openai import OpenAI\n",
+    "from opentelemetry import trace\n",
+    "from openinference.instrumentation import using_session\n",
+    "from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes\n",
+    "\n",
+    "client = OpenAI()\n",
+    "session_id = str(uuid.uuid4())\n",
+    "tracer = trace.get_tracer(__name__)\n",
+    "messages = [{\"role\": \"system\", \"content\": \"You are a helpful assistant. Answer in a concise manner.\"}]\n",
+    "\n",
+    "\n",
+    "def ask_llm(question: str) -> None:\n",
+    "    messages.append({\"role\": \"user\", \"content\": question})\n",
+    "\n",
+    "    with tracer.start_as_current_span(\"openinference-intro-chain\") as chain_span:\n",
+    "        chain_span.set_attribute(\n",
+    "            SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "            OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "        )\n",
+    "        chain_span.set_attribute(SpanAttributes.INPUT_VALUE, question)\n",
+    "\n",
+    "        response = client.responses.create(\n",
+    "            model=\"gpt-5.4-mini\",\n",
+    "            input=messages,\n",
+    "        )\n",
+    "        answer = response.output_text\n",
+    "\n",
+    "        messages.append({\"role\": \"assistant\", \"content\": answer})\n",
+    "        chain_span.set_attribute(SpanAttributes.OUTPUT_VALUE, answer)\n",
+    "        display(Markdown(answer))\n",
+    "\n",
+    "\n",
+    "with using_session(session_id=session_id):\n",
+    "    ask_llm(\"What is OpenInference?\")\n",
+    "    ask_llm(\"How does it relate to OpenTelemetry?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6dbcbc81",
+   "metadata": {},
+   "source": [
+    "Open [Arize AX](https://app.arize.com) and navigate to the `otel-best-practices` project to view your traces."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96fcd2ea",
+   "metadata": {},
+   "source": [
+    "### Sessions, traces, and spans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b440652",
+   "metadata": {},
+   "source": [
+    "Three concepts shape how OpenInference (and OpenTelemetry) organize tracing data, and they nest inside each other:\n",
+    "\n",
+    "- **Span** — a single step in your application, such as an LLM call, a tool invocation, or a chain stage. Each span has a name, start and end timestamps, attributes, and a potentially a parent — spans nest to form a tree. The root of the tree is known as the root span, and has no parent.\n",
+    "- **Trace** — a collection of spans tied together by a shared `trace_id`. A trace represents one end-to-end request through your agent.\n",
+    "- **Session** — a collection of traces tied together by a shared `session.id`. A session is a logical grouping of traces based on a shared concept, such as multiple agent interactions to solve the same task, or to help with a continuous conversation.\n",
+    "\n",
+    "Picture a customer-support chatbot. The user has a multi-turn conversation, and that whole conversation is one **session**. Each turn — one user message and the app's response — is one **trace**. Inside each trace, the app does several things to produce the response (classify intent, call a tool, format a reply), and each of those steps is a **span**.\n",
+    "\n",
+    "```\n",
+    "Session: support-chat-7a3f\n",
+    "│\n",
+    "├── Trace 1: \"Where is my order?\"\n",
+    "│   └── Chain span: handle_message\n",
+    "│       ├── LLM span:  classify_intent\n",
+    "│       ├── Tool span: lookup_order(order_id=\"A123\")\n",
+    "│       └── LLM span:  format_response\n",
+    "│\n",
+    "├── Trace 2: \"When will it arrive?\"\n",
+    "│   └── Chain span: handle_message\n",
+    "│       ├── LLM span:  classify_intent\n",
+    "│       ├── Tool span: get_shipping_status(order_id=\"A123\")\n",
+    "│       └── LLM span:  format_response\n",
+    "│\n",
+    "└── Trace 3: \"Thanks!\"\n",
+    "    └── Chain span: handle_message\n",
+    "        └── LLM span: generate_acknowledgement\n",
+    "```\n",
+    "\n",
+    "Three traces, one session. In Arize AX you can open a single trace to debug what happened in one turn, or use the session view to see all the turns together."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "376a7a01",
+   "metadata": {},
+   "source": [
+    "#### Sessions\n",
+    "\n",
+    "In Arize AX, start with the **Sessions** tab. You should see a single session that represents the entire two step conversation.\n",
+    "\n",
+    "![The sessions tab](sessions.png)\n",
+    "\n",
+    "If you select the session, a pane will appear with details of the session, including both steps in the conversation, showing the input to and the output from the agent. It will also show the latency, so the time the agent took to run, as well as the total number of tokens used and the estimated cost based off published token pricing from the LLM provider if available.\n",
+    "\n",
+    "![A single session in Arize AX](session.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b56747fc",
+   "metadata": {},
+   "source": [
+    "#### Traces\n",
+    "\n",
+    "Select the **Traces** tab. You should see both of the steps in the conversation as distinct traces, showing the input and output to the agent.\n",
+    "\n",
+    "The code you ran just makes a single LLM call, so the trace has the input set to what was sent to the LLM, and the output set to the response from the LLM. In a more complicated trace, the input is what was sent to the agent, and the output is the final response sent by the agent after it has completed its entire processing, including calling LLMs or tools.\n",
+    "\n",
+    "![](traces.png)\n",
+    "\n",
+    "If you select a trace, a pane will appear with details of the trace. It will show a tree of spans, along with latency, token counts, and estimated cost.\n",
+    "\n",
+    "![](trace.png)\n",
+    "\n",
+    "> You can also navigate to the individual traces directly from the session view."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "458070aa",
+   "metadata": {},
+   "source": [
+    "#### Spans\n",
+    "\n",
+    "In the trace view you will see a tree of the spans that make up the trace. Spans are grouped into traces by having the same `trace_id` set on them. A trace is a tree of spans, so one span will be the root span at the top of the tree, and the rest of the spans will be under that tree. The hierarchy is defined using the `parent_id` on the span — each child span has its `parent_id` set to the id of the parent span.\n",
+    "\n",
+    "In the trace we have 2 spans:\n",
+    "\n",
+    "![](trace.png)\n",
+    "\n",
+    "The root span is a **Chain** span. Chain spans are starting points for a set of related spans, you can think of them as a folder that groups spans together. In this example, the chain span isn't really necessary, it's just here to help show a tree.\n",
+    "\n",
+    "Under the root span is an **LLM** span called `ChatCompletion`. This span represents a call to an LLM, in our case OpenAI.\n",
+    "\n",
+    "![](llm-span.png)\n",
+    "\n",
+    "Against each span is an **Attributes** tab that has JSON containing all the attributes associated with the span, such as the input and output, number of tokens used for an LLM span, and so on. We will cover these attributes in the rest of this tutorial.\n",
+    "\n",
+    "![](span-attributes.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67de03ca",
+   "metadata": {},
+   "source": [
+    "OpenInference defines a fixed set of span kinds:\n",
+    "\n",
+    "| Span kind | Description |\n",
+    "| --- | --- |\n",
+    "| `LLM` | A call to a large language model. Captures the model, input messages, output messages, token counts, and cost. |\n",
+    "| `CHAIN` | A starting point or link between application steps. Commonly used as a parent span to group related work into a logical block. |\n",
+    "| `AGENT` | A span representing an agent's work — typically wraps LLM and tool spans together |\n",
+    "| `TOOL` | A call to an external tool or function, often invoked in response to a tool-use request from an LLM |\n",
+    "| `RETRIEVER` | A retrieval operation, such as fetching documents from a vector store or search index |\n",
+    "| `EMBEDDING` | A call to an embedding model |\n",
+    "| `RERANKER` | A reranking step that reorders a set of retrieved documents |\n",
+    "| `GUARDRAIL` | A safety or policy check, such as content moderation, PII detection, or input validation |\n",
+    "| `EVALUATOR` | An evaluation step that scores or judges an LLM output |\n",
+    "| `PROMPT` | A prompt definition or templating step |\n",
+    "| `UNKNOWN` | Used when no other kind applies |\n",
+    "\n",
+    "In this tutorial, we will be looking at LLM, chain, agent, and tool spans."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6499ee46",
+   "metadata": {},
+   "source": [
+    "## Configuring sessions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fecc96b9",
+   "metadata": {},
+   "source": [
+    "**Sessions** are a logical grouping of traces based on a continuous set of interactions with an agent. For example, in a chatbot, the entire multi-turn conversation that a single user has with the agent would be a session. When the same user starts a brand new conversation with no previous context, or a new user starts a conversation, this would be a new session.\n",
+    "\n",
+    "Sessions are explicitly managed by the engineer building the agent; they are not created automatically when sending traces.\n",
+    "\n",
+    "Sessions are set with the `using_session` function. This sets the session id for any spans created in any code run in this block.\n",
+    "\n",
+    "The following code contains a call to OpenAI inside a session. The session id is hardcoded here, so if you run this code multiple times, each run will be a new trace inside the same session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7801593f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "In OpenInference, **sessions** are a way to **group related traces and spans** that belong to the same user interaction, workflow, or conversation.\n",
+       "\n",
+       "They help you:\n",
+       "- **organize observability data** across multiple requests\n",
+       "- **track stateful experiences** like chats or agent runs\n",
+       "- **analyze behavior over time** within one logical session\n",
+       "\n",
+       "Typically, a session represents something like:\n",
+       "- a chat conversation\n",
+       "- a user visit\n",
+       "- a single end-to-end task or workflow\n",
+       "\n",
+       "If you want, I can also explain how sessions relate to **traces** and **spans**."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "with using_session(session_id=\"My Session\"):\n",
+    "    response = client.responses.create(\n",
+    "        model=\"gpt-5.4-mini\",\n",
+    "        input=\"What are sessions in OpenInference? Be concise.\",\n",
+    "    )\n",
+    "    display(Markdown(response.output_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69000de7",
+   "metadata": {},
+   "source": [
+    "Look up this session in Arize AX. You will see a single session with multiple traces depending on how many times you ran the code.\n",
+    "\n",
+    "![](sessions-1-session.png)\n",
+    "\n",
+    "Now run the following code. This has a different session Id, so will create a new session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "27614472",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "In OpenInference, a **session** is a way to **group related traces/runs from the same user interaction or workflow** into a single logical unit.\n",
+       "\n",
+       "Commonly, a session represents things like:\n",
+       "- one chat conversation,\n",
+       "- one experiment,\n",
+       "- one end-to-end task or workflow.\n",
+       "\n",
+       "It helps you:\n",
+       "- **associate multiple spans/traces together**,\n",
+       "- **analyze behavior over time** within that interaction,\n",
+       "- **filter and inspect** all activity tied to the same session.\n",
+       "\n",
+       "Typically, a session is identified by a **session ID** attached as trace/span metadata."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "with using_session(session_id=\"My Session 2\"):\n",
+    "    response = client.responses.create(\n",
+    "        model=\"gpt-5.4-mini\",\n",
+    "        input=\"What are sessions in OpenInference? Be concise.\",\n",
+    "    )\n",
+    "    display(Markdown(response.output_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d38f8db",
+   "metadata": {},
+   "source": [
+    "You will now see a new session in the sessions list.\n",
+    "\n",
+    "![](sessions-2-sessions.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a27ae35",
+   "metadata": {},
+   "source": [
+    "## Capturing spans and traces"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ed92cc0",
+   "metadata": {},
+   "source": [
+    "In the examples so far you have already seen both ways that OpenInference creates spans:\n",
+    "\n",
+    "- **Auto-instrumentors** wrap a specific library or framework (such as the OpenAI SDK, or LangChain) and emit a span for every call to that library automatically, along with spans for the different actions that the framework performs, such as tool calling. Each call to the library or framework is a separate trace.\n",
+    "- **Manual instrumentation** lets you create your own traces and spans by calling the tracer directly in your application code\n",
+    "\n",
+    "Most real-world applications use both. The auto-instrumentor handles the standard SDK calls; manual instrumentation captures your application's own logic that wraps around those calls."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98808595",
+   "metadata": {},
+   "source": [
+    "### Auto-instrumentors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd1cb351",
+   "metadata": {},
+   "source": [
+    "Auto-instrumentors are libraries that instrument an SDK or framework, and automatically emit spans for every call, and every action taken by the SDK or framework.\n",
+    "\n",
+    "You already set up an auto-instrumentor in the Initial setup section:\n",
+    "\n",
+    "```python\n",
+    "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
+    "\n",
+    "OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)\n",
+    "```\n",
+    "\n",
+    "After that single call, every `client.responses.create()` and `client.chat.completions.create()` in your code creates an LLM span automatically in a new trace. If you are using a more advanced framework that handles tool calling for example, then each call to the framework would be a new trace, with spans for the LLM and tool calls, grouped under a chain span.\n",
+    "\n",
+    "OpenInference provides auto-instrumentors for most popular AI SDKs and orchestration frameworks: OpenAI, Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many more. See the [OpenInference repository](https://github.com/Arize-ai/openinference) for the full list.\n",
+    "\n",
+    "If you run the code below, the auto-instrumentor will create a trace with a single span. You can see this in Arize AX."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4707bbda",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "In OpenInference, **sessions** are **groupings of related traces/spans** that represent a single user interaction or workflow over time.\n",
+       "\n",
+       "- They help tie together multiple requests, tool calls, or agent actions.\n",
+       "- Usually identified by a **session ID**.\n",
+       "- Useful for **tracking conversation history, debugging, and analytics** across a user’s whole experience, not just one span.\n",
+       "\n",
+       "In short: **a session is the higher-level context that contains multiple traces/spans from the same user or task.**"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "response = client.responses.create(\n",
+    "    model=\"gpt-5.4-mini\",\n",
+    "    input=\"What are sessions in OpenInference? Be concise.\",\n",
+    ")\n",
+    "display(Markdown(response.output_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22c017fd",
+   "metadata": {},
+   "source": [
+    "### Manual instrumentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc732984",
+   "metadata": {},
+   "source": [
+    "Manual instrumentation gives you full control. You call the OpenTelemetry tracer directly to start a span, set its attributes (including its OpenInference span kind), and end it when the work is done. The recommended pattern is the context-manager form, which sets the span as the active span on the OpenTelemetry context (so any spans created inside the block automatically become its children) and ends the span when the block exits:\n",
+    "\n",
+    "```python\n",
+    "with tracer.start_as_current_span(\"my-span\") as span:\n",
+    "    span.set_attribute(\n",
+    "        SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "        OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "    )\n",
+    "    span.set_attribute(SpanAttributes.INPUT_VALUE, \"input data\")\n",
+    "    # do work here\n",
+    "    span.set_attribute(SpanAttributes.OUTPUT_VALUE, \"result\")\n",
+    "```\n",
+    "\n",
+    "You can manually create spans of any OpenInference kind, such as chain, LLM, or tool — by setting the `openinference.span.kind` attribute on the span. The kind controls how Arize AX renders the span (the icon and the detail view) and which set of OpenInference attributes the span is expected to carry.\n",
+    "\n",
+    "The following code creates a trace with three manually-created spans: a parent `data-pipeline` chain span with two child spans (`step-1-validate` and `step-2-format`) nested inside. There are no LLM or tool calls — every span is created by your code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "397c1102",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with tracer.start_as_current_span(\"data-pipeline\") as pipeline:\n",
+    "    pipeline.set_attribute(\n",
+    "        SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "        OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "    )\n",
+    "    pipeline.set_attribute(SpanAttributes.INPUT_VALUE, \"raw request\")\n",
+    "\n",
+    "    with tracer.start_as_current_span(\"step-1-validate\") as step:\n",
+    "        step.set_attribute(\n",
+    "            SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "            OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "        )\n",
+    "        step.set_attribute(SpanAttributes.INPUT_VALUE, \"raw request\")\n",
+    "        step.set_attribute(SpanAttributes.OUTPUT_VALUE, \"validated request\")\n",
+    "\n",
+    "    with tracer.start_as_current_span(\"step-2-format\") as step:\n",
+    "        step.set_attribute(\n",
+    "            SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "            OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "        )\n",
+    "        step.set_attribute(SpanAttributes.INPUT_VALUE, \"validated request\")\n",
+    "        step.set_attribute(SpanAttributes.OUTPUT_VALUE, \"formatted output\")\n",
+    "\n",
+    "    pipeline.set_attribute(SpanAttributes.OUTPUT_VALUE, \"formatted output\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3c876d2",
+   "metadata": {},
+   "source": [
+    "Open the new trace in Arize AX. You will see a single chain span called `data-pipeline` with two child chain spans (`step-1-validate` and `step-2-format`) nested underneath.\n",
+    "\n",
+    "![](data-pipeline.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad48a62a",
+   "metadata": {},
+   "source": [
+    "### Hybrid instrumentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "519f8c10",
+   "metadata": {},
+   "source": [
+    "The most powerful pattern is to use both approaches together. **Hybrid instrumentation** lets you wrap auto-instrumented calls in your own manually-created spans, so you can group SDK calls into logical units, add custom attributes, and build the trace tree that best represents your application — without losing any of the rich attributes that the auto-instrumentor captures.\n",
+    "\n",
+    "Auto-instrumented spans and manually-created spans nest together naturally because they share the same OpenTelemetry context. When you open a manual span with `tracer.start_as_current_span(...)`, it becomes the active span on the context. Any call to an auto-instrumented SDK inside that block will create its span as a child of your manual span.\n",
+    "\n",
+    "You have already seen hybrid instrumentation in the Introduction to OpenInference section. The `ask_llm` function wraps each OpenAI call in a manually-created chain span.\n",
+    "\n",
+    "The manually-created chain span is the parent; the LLM span that the OpenAI auto-instrumentor produces around `client.responses.create()` automatically becomes its child. That is what gives you the tree structure you saw in Arize AX when you ran the introduction example — a chain span at the top, with an LLM span nested inside.\n",
+    "\n",
+    "This pattern is the typical shape of a real-world traced application: manual chain or agent spans give you the high-level structure of your business logic; auto-instrumented spans fill in the low-level detail of every SDK call you make inside them.\n",
+    "\n",
+    "Run this code to see an example of hybrid instrumentation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "2da697be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with tracer.start_as_current_span(\"manual-chain\") as chain_span:\n",
+    "    chain_span.set_attribute(\n",
+    "        SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "        OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "    )\n",
+    "    chain_span.set_attribute(SpanAttributes.INPUT_VALUE, \"What are sessions in OpenInference? Be concise.\")\n",
+    "\n",
+    "    response = client.responses.create(\n",
+    "        model=\"gpt-5.4-mini\",\n",
+    "        input=\"What are sessions in OpenInference? Be concise.\",\n",
+    "    )\n",
+    "\n",
+    "    chain_span.set_attribute(SpanAttributes.OUTPUT_VALUE, response.output_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aee9f027",
+   "metadata": {},
+   "source": [
+    "## Span attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c34337b",
+   "metadata": {},
+   "source": [
+    "Every OpenInference span carries a small set of **common attributes** that apply regardless of the span kind, plus a **kind-specific set** added on top.\n",
+    "\n",
+    "The common attributes available on any span kind are:\n",
+    "\n",
+    "| Attribute | Description |\n",
+    "| --- | --- |\n",
+    "| `openinference.span.kind` | The span kind: `LLM`, `CHAIN`, `AGENT`, `TOOL`, `RETRIEVER`, `EMBEDDING`, `RERANKER`, `GUARDRAIL`, `EVALUATOR`, `PROMPT`, or `UNKNOWN`. Controls how Arize AX renders the span. |\n",
+    "| `input.value` | The input to the span as a string. If the value is structured, serialize it to JSON and set `input.mime_type` accordingly. |\n",
+    "| `input.mime_type` | The mime type of `input.value`. Defaults to `text/plain`; set to `application/json` if the value is a JSON string. |\n",
+    "| `output.value` | The output from the span as a string |\n",
+    "| `output.mime_type` | The mime type of `output.value`. Same convention as `input.mime_type`. |\n",
+    "| `metadata` | A JSON dictionary of your own fields. Use it to attach domain-specific context such as user tier, feature flag, or request id. |\n",
+    "| `session.id` | Groups multiple traces into a session. Set with `using_session(...)` or directly via `span.set_attribute(SpanAttributes.SESSION_ID, ...)`. |\n",
+    "| `user.id` | Identifies the user the trace belongs to. Set with `using_user(...)` or directly. |\n",
+    "| `tag.tags` | A list of string tags for filtering. Set with `using_tags(...)`. |\n",
+    "\n",
+    "Arize AX uses several of these directly in the UI: `openinference.span.kind` drives the span icon and the kind-specific detail view; `input.value` and `output.value` on the root span feed the trace-level input and output preview in the Traces and Sessions tabs; `session.id` groups traces into sessions; `metadata` and `tag.tags` are filterable across spans."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1196cb90",
+   "metadata": {},
+   "source": [
+    "## The core span types"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36369ffb",
+   "metadata": {},
+   "source": [
+    "OpenInference defines 11 span kinds, but most AI applications use just four: **LLM**, **chain**, **agent**, and **tool**. These show up in almost every real-world trace — an agent makes LLM calls, LLM calls trigger tool calls, and chain spans group the related work together.\n",
+    "\n",
+    "The following example uses the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) to produce a single trace containing all four kinds. The SDK has its own auto-instrumentor — `openinference-instrumentation-openai-agents` — which emits the full set of span kinds for every agent run.\n",
+    "\n",
+    "Attach the Agents SDK instrumentor to the existing tracer provider. You can leave the OpenAI auto-instrumentor active alongside it — the Agents SDK creates its own LLM spans, so the two cooperate without duplicating work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e92eae93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor\n",
+    "\n",
+    "OpenAIAgentsInstrumentor().instrument(tracer_provider=tracer_provider)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c078bd26",
+   "metadata": {},
+   "source": [
+    "Define a simple travel assistant with two tools, then ask it a question that requires both tools to be called. Wrap the run in a session so the trace is easy to find in Arize AX."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de04adec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agents import Agent, Runner, function_tool\n",
+    "\n",
+    "\n",
+    "@function_tool\n",
+    "def get_weather(city: str) -> str:\n",
+    "    \"\"\"Get the current weather for a city.\"\"\"\n",
+    "    return f\"The weather in {city} is sunny and 22°C.\"\n",
+    "\n",
+    "\n",
+    "@function_tool\n",
+    "def get_time_zone(city: str) -> str:\n",
+    "    \"\"\"Get the time zone for a city.\"\"\"\n",
+    "    zones = {\n",
+    "        \"Tokyo\": \"JST (UTC+9)\",\n",
+    "        \"London\": \"GMT (UTC+0)\",\n",
+    "        \"New York\": \"EST (UTC-5)\",\n",
+    "    }\n",
+    "    return zones.get(city, \"unknown\")\n",
+    "\n",
+    "\n",
+    "travel_agent = Agent(\n",
+    "    name=\"TravelAssistant\",\n",
+    "    instructions=(\n",
+    "        \"You are a helpful travel assistant. \"\n",
+    "        \"Use get_weather to look up the weather for a city, \"\n",
+    "        \"and get_time_zone to look up its time zone. \"\n",
+    "        \"Give a concise final answer.\"\n",
+    "    ),\n",
+    "    tools=[get_weather, get_time_zone],\n",
+    ")\n",
+    "\n",
+    "with using_session(session_id=\"Travel Agent Example\"):\n",
+    "    result = await Runner.run(\n",
+    "        travel_agent,\n",
+    "        \"What's the weather and time zone in Tokyo?\",\n",
+    "    )\n",
+    "\n",
+    "display(Markdown(result.final_output))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "629abd18",
+   "metadata": {},
+   "source": [
+    "Open the trace in Arize AX under the `otel-best-practices` project. A single agent run produces a trace containing all four core span kinds:\n",
+    "\n",
+    "- Two **agent** spans — an outer `Agent workflow` wrapper and an inner `TravelAssistant`\n",
+    "- Three **chain** spans — one wrapping the whole workflow plus one per agent turn\n",
+    "- Two **tool** spans, one for each call to `get_weather` and `get_time_zone`\n",
+    "- Four **LLM** spans — each agent turn produces a Responses API call from the SDK with the underlying OpenAI client call nested inside it\n",
+    "\n",
+    "![](agent-trace.png)\n",
+    "\n",
+    "This is the trace shape you will see from most non-trivial agents: an outer agent/chain workflow, tool spans for each external call, and LLM spans for every model call inside."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5db075b5",
+   "metadata": {},
+   "source": [
+    "### LLM spans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "876a3cdf",
+   "metadata": {},
+   "source": [
+    "**LLM spans** represent a call to a large language model. They capture everything you need to debug or analyze the call: the model that was used, the input messages, the output, tools, token counts, costs, and more.\n",
+    "\n",
+    "In the agent trace are several LLM spans. Select one of these, and you will see the input and output from that LLM call. Against the span in the tree you will also see the number of tokens used, the latency, and the cost. In the **Attributes** tab, you can see the full attributes for the span.\n",
+    "\n",
+    "![](llm-span-attributes.png)\n",
+    "\n",
+    "The relevant attributes for this example are:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"openinference\": {\n",
+    "        \"span\": {\n",
+    "            \"kind\": \"LLM\"\n",
+    "        }\n",
+    "    },\n",
+    "    \"llm\": {\n",
+    "        \"cost\": {\n",
+    "            \"completion\": 0.0002205,\n",
+    "            \"completion_details\": {\n",
+    "                \"output\": 0.0002205,\n",
+    "                \"reasoning\": 0\n",
+    "            },\n",
+    "            \"prompt\": 0.00009975,\n",
+    "            \"prompt_details\": {\n",
+    "                \"cache_read\": 0,\n",
+    "                \"input\": 0.00009975\n",
+    "            },\n",
+    "            \"total\": 0.00032025\n",
+    "        },\n",
+    "        \"input_messages\": [\n",
+    "            {\n",
+    "                \"message.content\": \"You are a helpful travel assistant. Use get_weather to look up the weather for a city, and get_time_zone to look up its time zone. Give a concise final answer.\",\n",
+    "                \"message.role\": \"system\"\n",
+    "            },\n",
+    "            {\n",
+    "                \"message.content\": \"What's the weather and time zone in Tokyo?\",\n",
+    "                \"message.role\": \"user\"\n",
+    "            }\n",
+    "        ],\n",
+    "        \"invocation_parameters\": \"{\\\"include\\\": [], \\\"model\\\": \\\"gpt-5.4-mini\\\", \\\"prompt_cache_key\\\": \\\"agents-sdk:run:1fc4521fe6f248beafa82586c8b0fa3e\\\", \\\"reasoning\\\": {\\\"effort\\\": \\\"none\\\"}, \\\"text\\\": {\\\"verbosity\\\": \\\"low\\\"}}\",\n",
+    "        \"model_name\": \"gpt-5.4-mini-2026-03-17\",\n",
+    "        \"output_messages\": [\n",
+    "            {\n",
+    "                \"message.role\": \"assistant\",\n",
+    "                \"message.tool_calls\": [\n",
+    "                    {\n",
+    "                        \"tool_call.function.arguments\": \"{\\\"city\\\":\\\"Tokyo\\\"}\",\n",
+    "                        \"tool_call.function.name\": \"get_weather\",\n",
+    "                        \"tool_call.id\": \"call_OdvgB0fVwTcdKy6mqxV3cmuB\"\n",
+    "                    }\n",
+    "                ]\n",
+    "            },\n",
+    "            {\n",
+    "                \"message.role\": \"assistant\",\n",
+    "                \"message.tool_calls\": [\n",
+    "                    {\n",
+    "                        \"tool_call.function.arguments\": \"{\\\"city\\\":\\\"Tokyo\\\"}\",\n",
+    "                        \"tool_call.function.name\": \"get_time_zone\",\n",
+    "                        \"tool_call.id\": \"call_cnCgrd4Js5bErfROFdIoc68j\"\n",
+    "                    }\n",
+    "                ]\n",
+    "            }\n",
+    "        ],\n",
+    "        \"provider\": \"openai\",\n",
+    "        \"system\": \"openai\",\n",
+    "        \"token_count\": {\n",
+    "            \"completion\": \"49\",\n",
+    "            \"completion_details\": {\n",
+    "                \"output\": \"49\",\n",
+    "                \"reasoning\": \"0\"\n",
+    "            },\n",
+    "            \"prompt\": \"133\",\n",
+    "            \"prompt_details\": {\n",
+    "                \"cache_read\": \"0\",\n",
+    "                \"input\": \"133\"\n",
+    "            },\n",
+    "            \"total\": \"182\"\n",
+    "        },\n",
+    "        \"tools\": [\n",
+    "            {\n",
+    "                \"tool.json_schema\": \"{\\\"name\\\":\\\"get_weather\\\",\\\"parameters\\\":{\\\"properties\\\":{\\\"city\\\":{\\\"title\\\":\\\"City\\\",\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"city\\\"],\\\"title\\\":\\\"get_weather_args\\\",\\\"type\\\":\\\"object\\\",\\\"additionalProperties\\\":false},\\\"strict\\\":true,\\\"type\\\":\\\"function\\\",\\\"defer_loading\\\":null,\\\"description\\\":\\\"Get the current weather for a city.\\\"}\"\n",
+    "            },\n",
+    "            {\n",
+    "                \"tool.json_schema\": \"{\\\"name\\\":\\\"get_time_zone\\\",\\\"parameters\\\":{\\\"properties\\\":{\\\"city\\\":{\\\"title\\\":\\\"City\\\",\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"city\\\"],\\\"title\\\":\\\"get_time_zone_args\\\",\\\"type\\\":\\\"object\\\",\\\"additionalProperties\\\":false},\\\"strict\\\":true,\\\"type\\\":\\\"function\\\",\\\"defer_loading\\\":null,\\\"description\\\":\\\"Get the time zone for a city.\\\"}\"\n",
+    "            }\n",
+    "        ]\n",
+    "    }\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "578de536",
+   "metadata": {},
+   "source": [
+    "#### LLM-specific attributes\n",
+    "\n",
+    "Beyond the common attributes that any span carries (covered in the Span attributes section above), the OpenAI auto-instrumentor adds an LLM-specific set on every LLM span — all under the `llm.*` namespace and following the OpenInference semantic conventions:\n",
+    "\n",
+    "| Attribute | Description |\n",
+    "| --- | --- |\n",
+    "| `llm.model_name` | The exact model identifier returned by OpenAI, for example `gpt-5.4-mini-2026-03-17`. This is the resolved snapshot version, not the alias you passed in. |\n",
+    "| `llm.provider` | The LLM provider, here `openai` |\n",
+    "| `llm.system` | The AI system identifier, also `openai` |\n",
+    "| `llm.invocation_parameters` | A JSON string of the parameters passed to the API: `{\"model\": \"gpt-5.4-mini\"}` |\n",
+    "| `llm.input_messages` | The messages sent to the API as a structured array. Each entry has `message.role` and `message.content`. |\n",
+    "| `llm.output_messages` | The messages returned by the API as a structured array. Each entry has `message.role` and a `message.contents` list of structured content items (with `message_content.text` and `message_content.type`). This shape is multimodal-aware — text, image, audio, and reasoning content all fit the same structure. |\n",
+    "| `llm.token_count.prompt` / `.completion` / `.total` | Token counts for the call, with detail breakdowns under `llm.token_count.prompt_details.*` (`cache_read`, `input`) and `llm.token_count.completion_details.*` (`output`, `reasoning`) |\n",
+    "| `llm.cost.prompt` / `.completion` / `.total` | Estimated cost in USD with the same `_details` breakdowns. Arize AX computes these from the token counts and the published pricing for the model. |\n",
+    "\n",
+    "Arize AX uses the LLM-specific attributes to drive the token-count and cost columns in the trace and session views, and to populate the LLM detail view (input messages, output messages, model name)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14f52e71",
+   "metadata": {},
+   "source": [
+    "### Tool spans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc996b12",
+   "metadata": {},
+   "source": [
+    "**Tool spans** represent a call to an external tool or function — typically a function the LLM has decided to call. They capture the tool's name, the arguments the LLM passed in, and the value the tool returned.\n",
+    "\n",
+    "In the agent trace above you have two tool spans: `get_weather` and `get_time_zone`, one for each tool the agent invoked. Select one of them in the trace tree to see the tool-specific attributes — the tool name, the arguments the LLM passed in (`{\"city\": \"Tokyo\"}`), and the value the tool returned.\n",
+    "\n",
+    "![](tool-span-attributes.png)\n",
+    "\n",
+    "The relevant attributes for this example are:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"openinference\": {\n",
+    "        \"span\": {\n",
+    "            \"kind\": \"TOOL\"\n",
+    "        }\n",
+    "    },\n",
+    "    \"tool\": {\n",
+    "        \"name\": \"get_weather\"\n",
+    "    }\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49782a71",
+   "metadata": {},
+   "source": [
+    "#### Tool-specific attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0e94ab2",
+   "metadata": {},
+   "source": [
+    "Beyond the common attributes that any span carries, tool spans carry a small set of tool-specific attributes under the `tool.*` namespace:\n",
+    "\n",
+    "| Attribute | Description |\n",
+    "| --- | --- |\n",
+    "| `tool.id` | The identifier for the result of the tool call. Corresponds to the `tool_call.id` emitted by the LLM, which lets Arize AX link the tool span back to the LLM call that requested it. |\n",
+    "| `tool.name` | The name of the tool |\n",
+    "| `tool.description` | The tool's description. The LLM uses this when deciding which tool to call. |\n",
+    "| `tool.parameters` | A JSON string of the parameter values the LLM passed to the tool |\n",
+    "| `tool.json_schema` | The full JSON schema of the tool's input, typically in OpenAI tool-calling format. Tells the LLM what shape of arguments the tool expects. |\n",
+    "\n",
+    "Arize AX uses these to populate the tool detail view: the tool name and description appear at the top, the arguments and return value are surfaced from `input.value` and `output.value`, and the tool span links back to the parent LLM span via `tool.id`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cd747b9",
+   "metadata": {},
+   "source": [
+    "### Agent spans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2e53c6e",
+   "metadata": {},
+   "source": [
+    "**Agent spans** represent the work of an autonomous agent — the orchestration that decides when to call the LLM, when to call tools, when to call the LLM again, and when to stop. An agent span is typically the parent of the LLM, tool, and chain spans that make up the agent's loop.\n",
+    "\n",
+    "In the agent trace above, the `TravelAssistant` span is an agent span. Select it to see how it wraps both of the agent's turns, with all of the LLM and tool calls nested inside it.\n",
+    "\n",
+    "![](agent-span-attributes.png)\n",
+    "\n",
+    "The relevant attributes for this example are:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"openinference\": {\n",
+    "        \"span\": {\n",
+    "            \"kind\": \"AGENT\"\n",
+    "        }\n",
+    "    },\n",
+    "    \"graph\": {\n",
+    "        \"node\": {\n",
+    "            \"id\": \"TravelAssistant\"\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Note that the OpenAI Agents SDK auto-instrumentor uses `graph.node.id` to carry the agent's name (`TravelAssistant`) rather than the convention's `agent.name`. This is so Arize AX can render multi-agent systems with handoffs as a graph view. When you create agent spans manually, set `agent.name` (and optionally the `graph.node.*` attributes if you want the graph view)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a80d7aae",
+   "metadata": {},
+   "source": [
+    "#### Agent-specific attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "266e51af",
+   "metadata": {},
+   "source": [
+    "Agent spans carry a small set of agent-specific attributes:\n",
+    "\n",
+    "| Attribute | Description |\n",
+    "| --- | --- |\n",
+    "| `agent.name` | The name of the agent. Agents that perform the same logical role should share a name so you can group their traces together. |\n",
+    "| `graph.node.id` | The id of this agent's node in an execution graph. Optional — set when you want to visualize a multi-agent system as a graph in Arize AX. |\n",
+    "| `graph.node.name` | A human-readable name for the graph node |\n",
+    "| `graph.node.parent_id` | The id of the parent node. Leave unset for a root agent. |\n",
+    "\n",
+    "The `graph.node.*` attributes are how Arize AX renders multi-agent systems (LangGraph, AutoGen, CrewAI, etc.) as a graph view alongside the trace tree."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b8eb38f",
+   "metadata": {},
+   "source": [
+    "### Chain spans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a5e91b5",
+   "metadata": {},
+   "source": [
+    "**Chain spans** are general-purpose grouping spans. Use a chain span when you want to group a set of related work under a single parent in the trace tree — a multi-step pipeline, one agent turn, an LLM call with pre- and post-processing, or just a logical block in your application code.\n",
+    "\n",
+    "In the agent trace above the outer `Agent workflow` is a chain span, and each agent turn is also wrapped in a chain span called `turn`. Select a `turn` span to see how it groups the LLM and tool calls for that turn together.\n",
+    "\n",
+    "![](chain-span-attributes.png)\n",
+    "\n",
+    "The relevant attributes for this example are:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"openinference\": {\n",
+    "        \"span\": {\n",
+    "            \"kind\": \"CHAIN\"\n",
+    "        }\n",
+    "    },\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "The chain span carries only the kind and the common attributes — its value is purely structural, giving you a named parent in the trace tree."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "896e9f95",
+   "metadata": {},
+   "source": [
+    "#### Chain-specific attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea30b7b2",
+   "metadata": {},
+   "source": [
+    "Chain spans have no kind-specific attributes. They rely on the common attributes covered in the Span attributes section above — `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, and so on. The chain span's value is purely structural: it gives you a named parent in the trace tree, with whatever input and output you choose to attach to it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "758f099b",
+   "metadata": {},
+   "source": [
+    "## Overriding or adding attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "efa8149c",
+   "metadata": {},
+   "source": [
+    "Auto-instrumentors capture the standard OpenInference attributes for every span they create, but you often want to add your own. Common reasons:\n",
+    "\n",
+    "- **Tag the call for filtering** — for example `experiment=\"v2-prompt\"` or `tenant=\"acme\"`\n",
+    "- **Attach domain metadata** — user tier, request id, feature flag value\n",
+    "- **Record a prompt template** — the template string, version, and variables you used, separate from the final flattened prompt\n",
+    "\n",
+    "With manually-created spans you can call `span.set_attribute(...)` directly inside the `with` block, as you saw in the manual instrumentation example. With auto-instrumented spans you do not have direct access to the span object — but you can still enrich it by putting attributes into the OpenTelemetry context using the **OpenInference context managers**. The auto-instrumentor reads from that context when it creates the span. This means the attributes are applied to every span created inside the block, no matter who creates it.\n",
+    "\n",
+    "The available context managers are:\n",
+    "\n",
+    "| Context manager | Sets |\n",
+    "| --- | --- |\n",
+    "| `using_session(session_id)` | `session.id` |\n",
+    "| `using_user(user_id)` | `user.id` |\n",
+    "| `using_metadata(metadata)` | `metadata` (a JSON dictionary of your own fields) |\n",
+    "| `using_tags(tags)` | `tag.tags` (a list of strings) |\n",
+    "| `using_prompt_template(template=, variables=, version=)` | The `llm.prompt_template.*` attributes. Most useful on LLM spans. |\n",
+    "| `using_attributes(...)` | A convenience wrapper that combines all of the above into a single call |\n",
+    "\n",
+    "The following code uses `using_metadata` to attach a domain-specific metadata dictionary. The example here wraps an OpenAI call so the metadata ends up on an LLM span, but the same pattern works for any span — auto-instrumented or manual — created inside the block."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d6bd68c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "In OpenInference, **LLM spans** are **trace spans that represent a single interaction with a large language model**—for example, a prompt/completion, chat turn, or model call.\n",
+       "\n",
+       "They typically capture things like:\n",
+       "- **Input**: prompts, messages, parameters\n",
+       "- **Output**: completions or responses\n",
+       "- **Model metadata**: model name, provider, temperature, etc.\n",
+       "- **Usage**: token counts, latency, cost-related info\n",
+       "- **Trace context**: parent/child relationships with other spans\n",
+       "\n",
+       "They’re used to **observe, debug, and evaluate LLM apps** across frameworks and providers."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from openinference.instrumentation import using_metadata\n",
+    "\n",
+    "with using_session(session_id=\"LLM Span Example\"):\n",
+    "    with using_metadata({\"user_tier\": \"premium\", \"request_source\": \"cookbook\"}):\n",
+    "        response = client.responses.create(\n",
+    "            model=\"gpt-5.4-mini\",\n",
+    "            input=\"What are LLM spans in OpenInference? Be concise.\",\n",
+    "        )\n",
+    "        display(Markdown(response.output_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d0f10a4",
+   "metadata": {},
+   "source": [
+    "Open the new trace in Arize AX. The LLM span now has an additional attribute:\n",
+    "\n",
+    "- `metadata` — a JSON string containing `{\"user_tier\": \"premium\", \"request_source\": \"cookbook\"}`\n",
+    "\n",
+    "It appears in the **Attributes** tab alongside the standard `llm.*` attributes.\n",
+    "\n",
+    "![](llm-span-metadata.png)\n",
+    "\n",
+    "You can also filter spans by `metadata` values in the Arize AX trace view, which makes it easy to slice traces by tenant, feature flag, or any other domain dimension. In the **Spans** tab, set the filter to `attributes.metadata.request_source = \"cookbook\"` to only see spans created with the `request_source` metadata set to `cookbook`.\n",
+    "\n",
+    "![](metadata-filter.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "371062a8",
+   "metadata": {},
+   "source": [
+    "### Overriding a tool attribute"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5991f49",
+   "metadata": {},
+   "source": [
+    "You can also override attributes that an auto-instrumentor has set, or add attributes that it left out. The OpenAI Agents SDK auto-instrumentor only sets `tool.name` on tool spans — it does not populate `tool.description`. The following code redefines `get_weather` to set a custom `tool.description` attribute on the active tool span, then recreates the agent and re-runs it.\n",
+    "\n",
+    "The pattern works because the auto-instrumentor opens the tool span before calling your function, so the tool span is the active span when your function body runs. Calling `set_attribute(...)` on it inside the function body either overrides the attribute (if the instrumentor set it) or adds it (if the instrumentor did not)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "48396d17",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Tokyo: sunny, 22°C. Time zone: JST (UTC+9)."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "@function_tool\n",
+    "def get_weather(city: str) -> str:\n",
+    "    \"\"\"Get the current weather for a city.\"\"\"\n",
+    "\n",
+    "    # Set a custom tool.description on the active tool span.\n",
+    "    trace.get_current_span().set_attribute(\n",
+    "        SpanAttributes.TOOL_DESCRIPTION,\n",
+    "        \"Looks up the current weather conditions for a given city.\",\n",
+    "    )\n",
+    "\n",
+    "    return f\"The weather in {city} is sunny and 22°C.\"\n",
+    "\n",
+    "\n",
+    "travel_agent = Agent(\n",
+    "    name=\"TravelAssistant\",\n",
+    "    instructions=(\n",
+    "        \"You are a helpful travel assistant. \"\n",
+    "        \"Use get_weather to look up the weather for a city, \"\n",
+    "        \"and get_time_zone to look up its time zone. \"\n",
+    "        \"Give a concise final answer.\"\n",
+    "    ),\n",
+    "    tools=[get_weather, get_time_zone],\n",
+    ")\n",
+    "\n",
+    "with using_session(session_id=\"Tool Override Example\"):\n",
+    "    result = await Runner.run(\n",
+    "        travel_agent,\n",
+    "        \"What's the weather and time zone in Tokyo?\",\n",
+    "    )\n",
+    "\n",
+    "display(Markdown(result.final_output))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16fe069b",
+   "metadata": {},
+   "source": [
+    "Open the new trace in Arize AX under the `otel-best-practices` project (find it via the `Tool Override Example` session). Select the `get_weather` tool span and open its **Attributes** tab. You will now see `tool.description` populated with the string you set inside the function body, alongside the standard `tool.name` the auto-instrumentor produced.\n",
+    "\n",
+    "![](tool-override-attributes.png)\n",
+    "\n",
+    "The relevant attributes for this example are:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"openinference\": {\n",
+    "        \"span\": {\n",
+    "            \"kind\": \"TOOL\"\n",
+    "        }\n",
+    "    },\n",
+    "    \"tool\": {\n",
+    "        \"description\": \"Looks up the current weather conditions for a given city.\",\n",
+    "        \"name\": \"get_weather\"\n",
+    "    }\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "The `get_time_zone` tool span in the same trace still has only `tool.name`, which is a good visual confirmation that the override applies only to the span you set attributes on."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.14.4)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
+++ b/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "- How OpenInference layers on top of OpenTelemetry to add AI-aware semantics\n",
     "- The hierarchy of sessions, traces, and spans that organizes your telemetry\n",
-    "- Three ways to capture spans — auto-instrumentation, manual instrumentation, and the hybrid approach that combines them\n",
+    "- Three ways to capture spans \u2014 auto-instrumentation, manual instrumentation, and the hybrid approach that combines them\n",
     "- The common attributes every span carries, and the kind-specific attributes for the four core span kinds (LLM, chain, agent, and tool)\n",
     "- How to add or override attributes on spans, including auto-instrumented spans you cannot access directly\n",
     "\n",
@@ -94,11 +94,11 @@
     "from getpass import getpass\n",
     "\n",
     "ARIZE_SPACE_ID = globals().get(\"ARIZE_SPACE_ID\") or getpass(\n",
-    "    \"🔑 Enter your Arize Space ID: \"\n",
+    "    \"\ud83d\udd11 Enter your Arize Space ID: \"\n",
     ")\n",
-    "ARIZE_API_KEY = globals().get(\"ARIZE_API_KEY\") or getpass(\"🔑 Enter your Arize API Key: \")\n",
+    "ARIZE_API_KEY = globals().get(\"ARIZE_API_KEY\") or getpass(\"\ud83d\udd11 Enter your Arize API Key: \")\n",
     "OPENAI_API_KEY = globals().get(\"OPENAI_API_KEY\") or getpass(\n",
-    "    \"🔑 Enter your OpenAI API key: \"\n",
+    "    \"\ud83d\udd11 Enter your OpenAI API key: \"\n",
     ")\n",
     "os.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY"
    ]
@@ -110,7 +110,9 @@
    "source": [
     "### Setup tracing\n",
     "\n",
-    "Use the `arize-otel` convenience function to register a tracer provider that sends spans to Arize AX, then enable the OpenAI auto-instrumentor so calls to the OpenAI SDK are traced automatically."
+    "Use the `arize-otel` convenience function to register a tracer provider that sends spans to Arize AX, then enable the OpenAI auto-instrumentor so calls to the OpenAI SDK are traced automatically.\n",
+    "\n",
+    "See [The arize.otel helpers](https://docs.arize.com/ax/concepts/otel-openinference/arize-otel-helpers) for the full set of `arize.otel` functions, including routing traces to multiple projects from a single app."
    ]
   },
   {
@@ -148,18 +150,19 @@
    "source": [
     "[OpenInference](https://github.com/Arize-ai/openinference) is an open-source set of conventions and instrumentation libraries for tracing AI applications. It is maintained by Arize and is the standard that Arize AX uses to render LLM, tool, agent, chain, retriever, and other AI-specific spans in the trace view.\n",
     "\n",
-    "OpenInference is an **extension to [OpenTelemetry](https://opentelemetry.io/docs/)**, not a replacement for it. It uses the standard OpenTelemetry SDK and libraries under the hood — the same `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` you would use for any OTel-instrumented service. What OpenInference adds is:\n",
+    "OpenInference is an **extension to [OpenTelemetry](https://opentelemetry.io/docs/)**, not a replacement for it. It uses the standard OpenTelemetry SDK and libraries under the hood \u2014 the same `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` you would use for any OTel-instrumented service. What OpenInference adds is:\n",
     "\n",
     "- A set of **semantic conventions** that describe how to represent AI concepts (LLM calls, prompts, messages, tool invocations, retrieval, agent steps, sessions) as span attributes\n",
     "- A library of **auto-instrumentors** for popular LLM SDKs and orchestration frameworks (OpenAI, Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many more)\n",
     "\n",
-    "Because OpenInference is built on OpenTelemetry, any tool that speaks OTel can consume the spans — but a backend that understands the OpenInference conventions (like Arize AX) can render them as a rich, AI-aware trace view rather than a generic span list.\n",
+    "Because OpenInference is built on OpenTelemetry, any tool that speaks OTel can consume the spans \u2014 but a backend that understands the OpenInference conventions (like Arize AX) can render them as a rich, AI-aware trace view rather than a generic span list.\n",
     "\n",
     "**Read more:**\n",
     "\n",
-    "- [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) — the formal definitions for span kinds, attributes, and message structure.\n",
-    "- [OpenInference repository](https://github.com/Arize-ai/openinference) — auto-instrumentors, examples, and source for every supported language and framework.\n",
-    "- [OpenTelemetry documentation](https://opentelemetry.io/docs/) — the underlying observability framework that OpenInference builds on."
+    "- [OpenTelemetry and OpenInference concepts](https://docs.arize.com/ax/concepts/otel-openinference/overview) \u2014 the full reference companion to this cookbook.\n",
+    "- [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) \u2014 the formal definitions for span kinds, attributes, and message structure.\n",
+    "- [OpenInference repository](https://github.com/Arize-ai/openinference) \u2014 auto-instrumentors, examples, and source for every supported language and framework.\n",
+    "- [OpenTelemetry documentation](https://opentelemetry.io/docs/) \u2014 the underlying observability framework that OpenInference builds on."
    ]
   },
   {
@@ -241,33 +244,35 @@
    "source": [
     "Three concepts shape how OpenInference (and OpenTelemetry) organize tracing data, and they nest inside each other:\n",
     "\n",
-    "- **Span** — a single step in your application, such as an LLM call, a tool invocation, or a chain stage. Each span has a name, start and end timestamps, attributes, and a potentially a parent — spans nest to form a tree. The root of the tree is known as the root span, and has no parent.\n",
-    "- **Trace** — a collection of spans tied together by a shared `trace_id`. A trace represents one end-to-end request through your agent.\n",
-    "- **Session** — a collection of traces tied together by a shared `session.id`. A session is a logical grouping of traces based on a shared concept, such as multiple agent interactions to solve the same task, or to help with a continuous conversation.\n",
+    "- **Span** \u2014 a single step in your application, such as an LLM call, a tool invocation, or a chain stage. Each span has a name, start and end timestamps, attributes, and a potentially a parent \u2014 spans nest to form a tree. The root of the tree is known as the root span, and has no parent.\n",
+    "- **Trace** \u2014 a collection of spans tied together by a shared `trace_id`. A trace represents one end-to-end request through your agent.\n",
+    "- **Session** \u2014 a collection of traces tied together by a shared `session.id`. A session is a logical grouping of traces based on a shared concept, such as multiple agent interactions to solve the same task, or to help with a continuous conversation.\n",
     "\n",
-    "Picture a customer-support chatbot. The user has a multi-turn conversation, and that whole conversation is one **session**. Each turn — one user message and the app's response — is one **trace**. Inside each trace, the app does several things to produce the response (classify intent, call a tool, format a reply), and each of those steps is a **span**.\n",
+    "Picture a customer-support chatbot. The user has a multi-turn conversation, and that whole conversation is one **session**. Each turn \u2014 one user message and the app's response \u2014 is one **trace**. Inside each trace, the app does several things to produce the response (classify intent, call a tool, format a reply), and each of those steps is a **span**.\n",
     "\n",
     "```\n",
     "Session: support-chat-7a3f\n",
-    "│\n",
-    "├── Trace 1: \"Where is my order?\"\n",
-    "│   └── Chain span: handle_message\n",
-    "│       ├── LLM span:  classify_intent\n",
-    "│       ├── Tool span: lookup_order(order_id=\"A123\")\n",
-    "│       └── LLM span:  format_response\n",
-    "│\n",
-    "├── Trace 2: \"When will it arrive?\"\n",
-    "│   └── Chain span: handle_message\n",
-    "│       ├── LLM span:  classify_intent\n",
-    "│       ├── Tool span: get_shipping_status(order_id=\"A123\")\n",
-    "│       └── LLM span:  format_response\n",
-    "│\n",
-    "└── Trace 3: \"Thanks!\"\n",
-    "    └── Chain span: handle_message\n",
-    "        └── LLM span: generate_acknowledgement\n",
+    "\u2502\n",
+    "\u251c\u2500\u2500 Trace 1: \"Where is my order?\"\n",
+    "\u2502   \u2514\u2500\u2500 Chain span: handle_message\n",
+    "\u2502       \u251c\u2500\u2500 LLM span:  classify_intent\n",
+    "\u2502       \u251c\u2500\u2500 Tool span: lookup_order(order_id=\"A123\")\n",
+    "\u2502       \u2514\u2500\u2500 LLM span:  format_response\n",
+    "\u2502\n",
+    "\u251c\u2500\u2500 Trace 2: \"When will it arrive?\"\n",
+    "\u2502   \u2514\u2500\u2500 Chain span: handle_message\n",
+    "\u2502       \u251c\u2500\u2500 LLM span:  classify_intent\n",
+    "\u2502       \u251c\u2500\u2500 Tool span: get_shipping_status(order_id=\"A123\")\n",
+    "\u2502       \u2514\u2500\u2500 LLM span:  format_response\n",
+    "\u2502\n",
+    "\u2514\u2500\u2500 Trace 3: \"Thanks!\"\n",
+    "    \u2514\u2500\u2500 Chain span: handle_message\n",
+    "        \u2514\u2500\u2500 LLM span: generate_acknowledgement\n",
     "```\n",
     "\n",
-    "Three traces, one session. In Arize AX you can open a single trace to debug what happened in one turn, or use the session view to see all the turns together."
+    "Three traces, one session. In Arize AX you can open a single trace to debug what happened in one turn, or use the session view to see all the turns together.\n",
+    "\n",
+    "For the full breakdown of how signals, spans, traces, and sessions fit together, see [Signals, spans, traces, and sessions](https://docs.arize.com/ax/concepts/otel-openinference/signals)."
    ]
   },
   {
@@ -313,7 +318,7 @@
    "source": [
     "#### Spans\n",
     "\n",
-    "In the trace view you will see a tree of the spans that make up the trace. Spans are grouped into traces by having the same `trace_id` set on them. A trace is a tree of spans, so one span will be the root span at the top of the tree, and the rest of the spans will be under that tree. The hierarchy is defined using the `parent_id` on the span — each child span has its `parent_id` set to the id of the parent span.\n",
+    "In the trace view you will see a tree of the spans that make up the trace. Spans are grouped into traces by having the same `trace_id` set on them. A trace is a tree of spans, so one span will be the root span at the top of the tree, and the rest of the spans will be under that tree. The hierarchy is defined using the `parent_id` on the span \u2014 each child span has its `parent_id` set to the id of the parent span.\n",
     "\n",
     "In the trace we have 2 spans:\n",
     "\n",
@@ -341,7 +346,7 @@
     "| --- | --- |\n",
     "| `LLM` | A call to a large language model. Captures the model, input messages, output messages, token counts, and cost. |\n",
     "| `CHAIN` | A starting point or link between application steps. Commonly used as a parent span to group related work into a logical block. |\n",
-    "| `AGENT` | A span representing an agent's work — typically wraps LLM and tool spans together |\n",
+    "| `AGENT` | A span representing an agent's work \u2014 typically wraps LLM and tool spans together |\n",
     "| `TOOL` | A call to an external tool or function, often invoked in response to a tool-use request from an LLM |\n",
     "| `RETRIEVER` | A retrieval operation, such as fetching documents from a vector store or search index |\n",
     "| `EMBEDDING` | A call to an embedding model |\n",
@@ -351,7 +356,7 @@
     "| `PROMPT` | A prompt definition or templating step |\n",
     "| `UNKNOWN` | Used when no other kind applies |\n",
     "\n",
-    "In this tutorial, we will be looking at LLM, chain, agent, and tool spans."
+    "In this tutorial, we will be looking at LLM, chain, agent, and tool spans. For the complete reference covering every kind and the attributes each is expected to carry, see [OpenInference span kinds](https://docs.arize.com/ax/concepts/otel-openinference/span-kinds)."
    ]
   },
   {
@@ -371,7 +376,7 @@
     "\n",
     "Sessions are explicitly managed by the engineer building the agent; they are not created automatically when sending traces.\n",
     "\n",
-    "Sessions are set with the `using_session` function. This sets the session id for any spans created in any code run in this block.\n",
+    "Sessions are set with the `using_session` function. This sets the session id for any spans created in any code run in this block. `using_session` is one of a small family of OpenInference context managers \u2014 see [OpenInference context managers](https://docs.arize.com/ax/concepts/otel-openinference/context-managers) for the full list (`using_user`, `using_metadata`, `using_tags`, `using_prompt_template`, `using_attributes`).\n",
     "\n",
     "The following code contains a call to OpenAI inside a session. The session id is hardcoded here, so if you run this code multiple times, each run will be a new trace inside the same session."
    ]
@@ -446,7 +451,9 @@
     "- **Auto-instrumentors** wrap a specific library or framework (such as the OpenAI SDK, or LangChain) and emit a span for every call to that library automatically, along with spans for the different actions that the framework performs, such as tool calling. Each call to the library or framework is a separate trace.\n",
     "- **Manual instrumentation** lets you create your own traces and spans by calling the tracer directly in your application code\n",
     "\n",
-    "Most real-world applications use both. The auto-instrumentor handles the standard SDK calls; manual instrumentation captures your application's own logic that wraps around those calls."
+    "Most real-world applications use both. The auto-instrumentor handles the standard SDK calls; manual instrumentation captures your application's own logic that wraps around those calls.\n",
+    "\n",
+    "See [Instrumentation approaches](https://docs.arize.com/ax/concepts/otel-openinference/instrumentation-approaches) for a deeper comparison of auto-instrumentation, manual instrumentation, and the hybrid pattern."
    ]
   },
   {
@@ -519,9 +526,9 @@
     "    span.set_attribute(SpanAttributes.OUTPUT_VALUE, \"result\")\n",
     "```\n",
     "\n",
-    "You can manually create spans of any OpenInference kind, such as chain, LLM, or tool — by setting the `openinference.span.kind` attribute on the span. The kind controls how Arize AX renders the span (the icon and the detail view) and which set of OpenInference attributes the span is expected to carry.\n",
+    "You can manually create spans of any OpenInference kind, such as chain, LLM, or tool \u2014 by setting the `openinference.span.kind` attribute on the span. The kind controls how Arize AX renders the span (the icon and the detail view) and which set of OpenInference attributes the span is expected to carry.\n",
     "\n",
-    "The following code creates a trace with three manually-created spans: a parent `data-pipeline` chain span with two child spans (`step-1-validate` and `step-2-format`) nested inside. There are no LLM or tool calls — every span is created by your code."
+    "The following code creates a trace with three manually-created spans: a parent `data-pipeline` chain span with two child spans (`step-1-validate` and `step-2-format`) nested inside. There are no LLM or tool calls \u2014 every span is created by your code."
    ]
   },
   {
@@ -580,13 +587,13 @@
    "id": "519f8c10",
    "metadata": {},
    "source": [
-    "The most powerful pattern is to use both approaches together. **Hybrid instrumentation** lets you wrap auto-instrumented calls in your own manually-created spans, so you can group SDK calls into logical units, add custom attributes, and build the trace tree that best represents your application — without losing any of the rich attributes that the auto-instrumentor captures.\n",
+    "The most powerful pattern is to use both approaches together. **Hybrid instrumentation** lets you wrap auto-instrumented calls in your own manually-created spans, so you can group SDK calls into logical units, add custom attributes, and build the trace tree that best represents your application \u2014 without losing any of the rich attributes that the auto-instrumentor captures.\n",
     "\n",
     "Auto-instrumented spans and manually-created spans nest together naturally because they share the same OpenTelemetry context. When you open a manual span with `tracer.start_as_current_span(...)`, it becomes the active span on the context. Any call to an auto-instrumented SDK inside that block will create its span as a child of your manual span.\n",
     "\n",
     "You have already seen hybrid instrumentation in the Introduction to OpenInference section. The `ask_llm` function wraps each OpenAI call in a manually-created chain span.\n",
     "\n",
-    "The manually-created chain span is the parent; the LLM span that the OpenAI auto-instrumentor produces around `client.responses.create()` automatically becomes its child. That is what gives you the tree structure you saw in Arize AX when you ran the introduction example — a chain span at the top, with an LLM span nested inside.\n",
+    "The manually-created chain span is the parent; the LLM span that the OpenAI auto-instrumentor produces around `client.responses.create()` automatically becomes its child. That is what gives you the tree structure you saw in Arize AX when you ran the introduction example \u2014 a chain span at the top, with an LLM span nested inside.\n",
     "\n",
     "This pattern is the typical shape of a real-world traced application: manual chain or agent spans give you the high-level structure of your business logic; auto-instrumented spans fill in the low-level detail of every SDK call you make inside them.\n",
     "\n",
@@ -644,7 +651,9 @@
     "| `user.id` | Identifies the user the trace belongs to. Set with `using_user(...)` or directly. |\n",
     "| `tag.tags` | A list of string tags for filtering. Set with `using_tags(...)`. |\n",
     "\n",
-    "Arize AX uses several of these directly in the UI: `openinference.span.kind` drives the span icon and the kind-specific detail view; `input.value` and `output.value` on the root span feed the trace-level input and output preview in the Traces and Sessions tabs; `session.id` groups traces into sessions; `metadata` and `tag.tags` are filterable across spans."
+    "Arize AX uses several of these directly in the UI: `openinference.span.kind` drives the span icon and the kind-specific detail view; `input.value` and `output.value` on the root span feed the trace-level input and output preview in the Traces and Sessions tabs; `session.id` groups traces into sessions; `metadata` and `tag.tags` are filterable across spans.\n",
+    "\n",
+    "The full attribute catalogue is described in [OpenInference semantic conventions](https://docs.arize.com/ax/concepts/otel-openinference/semantic-conventions) (the overall standard) and [OpenInference span kinds](https://docs.arize.com/ax/concepts/otel-openinference/span-kinds) (per-kind reference)."
    ]
   },
   {
@@ -660,11 +669,11 @@
    "id": "36369ffb",
    "metadata": {},
    "source": [
-    "OpenInference defines 11 span kinds, but most AI applications use just four: **LLM**, **chain**, **agent**, and **tool**. These show up in almost every real-world trace — an agent makes LLM calls, LLM calls trigger tool calls, and chain spans group the related work together.\n",
+    "OpenInference defines 11 span kinds, but most AI applications use just four: **LLM**, **chain**, **agent**, and **tool**. These show up in almost every real-world trace \u2014 an agent makes LLM calls, LLM calls trigger tool calls, and chain spans group the related work together. For the canonical reference of every span kind and the attributes each carries, see [OpenInference span kinds](https://docs.arize.com/ax/concepts/otel-openinference/span-kinds).\n",
     "\n",
-    "The following example uses the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) to produce a single trace containing all four kinds. The SDK has its own auto-instrumentor — `openinference-instrumentation-openai-agents` — which emits the full set of span kinds for every agent run.\n",
+    "The following example uses the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) to produce a single trace containing all four kinds. The SDK has its own auto-instrumentor \u2014 `openinference-instrumentation-openai-agents` \u2014 which emits the full set of span kinds for every agent run.\n",
     "\n",
-    "Attach the Agents SDK instrumentor to the existing tracer provider. You can leave the OpenAI auto-instrumentor active alongside it — the Agents SDK creates its own LLM spans, so the two cooperate without duplicating work."
+    "Attach the Agents SDK instrumentor to the existing tracer provider. You can leave the OpenAI auto-instrumentor active alongside it \u2014 the Agents SDK creates its own LLM spans, so the two cooperate without duplicating work."
    ]
   },
   {
@@ -700,7 +709,7 @@
     "@function_tool\n",
     "def get_weather(city: str) -> str:\n",
     "    \"\"\"Get the current weather for a city.\"\"\"\n",
-    "    return f\"The weather in {city} is sunny and 22°C.\"\n",
+    "    return f\"The weather in {city} is sunny and 22\u00b0C.\"\n",
     "\n",
     "\n",
     "@function_tool\n",
@@ -741,10 +750,10 @@
    "source": [
     "Open the trace in Arize AX under the `otel-best-practices` project. A single agent run produces a trace containing all four core span kinds:\n",
     "\n",
-    "- Two **agent** spans — an outer `Agent workflow` wrapper and an inner `TravelAssistant`\n",
-    "- Three **chain** spans — one wrapping the whole workflow plus one per agent turn\n",
+    "- Two **agent** spans \u2014 an outer `Agent workflow` wrapper and an inner `TravelAssistant`\n",
+    "- Three **chain** spans \u2014 one wrapping the whole workflow plus one per agent turn\n",
     "- Two **tool** spans, one for each call to `get_weather` and `get_time_zone`\n",
-    "- Four **LLM** spans — each agent turn produces a Responses API call from the SDK with the underlying OpenAI client call nested inside it\n",
+    "- Four **LLM** spans \u2014 each agent turn produces a Responses API call from the SDK with the underlying OpenAI client call nested inside it\n",
     "\n",
     "![Trace in Arize AX from the OpenAI Agents SDK example, showing agent, chain, tool, and LLM spans nested together](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/agent-trace.png)\n",
     "\n",
@@ -862,7 +871,7 @@
    "source": [
     "#### LLM-specific attributes\n",
     "\n",
-    "Beyond the common attributes that any span carries (covered in the Span attributes section above), the OpenAI auto-instrumentor adds an LLM-specific set on every LLM span — all under the `llm.*` namespace and following the OpenInference semantic conventions:\n",
+    "Beyond the common attributes that any span carries (covered in the Span attributes section above), the OpenAI auto-instrumentor adds an LLM-specific set on every LLM span \u2014 all under the `llm.*` namespace and following the OpenInference semantic conventions:\n",
     "\n",
     "| Attribute | Description |\n",
     "| --- | --- |\n",
@@ -871,7 +880,7 @@
     "| `llm.system` | The AI system identifier, also `openai` |\n",
     "| `llm.invocation_parameters` | A JSON string of the parameters passed to the API: `{\"model\": \"gpt-5.4-mini\"}` |\n",
     "| `llm.input_messages` | The messages sent to the API as a structured array. Each entry has `message.role` and `message.content`. |\n",
-    "| `llm.output_messages` | The messages returned by the API as a structured array. Each entry has `message.role` and a `message.contents` list of structured content items (with `message_content.text` and `message_content.type`). This shape is multimodal-aware — text, image, audio, and reasoning content all fit the same structure. |\n",
+    "| `llm.output_messages` | The messages returned by the API as a structured array. Each entry has `message.role` and a `message.contents` list of structured content items (with `message_content.text` and `message_content.type`). This shape is multimodal-aware \u2014 text, image, audio, and reasoning content all fit the same structure. |\n",
     "| `llm.token_count.prompt` / `.completion` / `.total` | Token counts for the call, with detail breakdowns under `llm.token_count.prompt_details.*` (`cache_read`, `input`) and `llm.token_count.completion_details.*` (`output`, `reasoning`) |\n",
     "| `llm.cost.prompt` / `.completion` / `.total` | Estimated cost in USD with the same `_details` breakdowns. Arize AX computes these from the token counts and the published pricing for the model. |\n",
     "\n",
@@ -891,9 +900,9 @@
    "id": "fc996b12",
    "metadata": {},
    "source": [
-    "**Tool spans** represent a call to an external tool or function — typically a function the LLM has decided to call. They capture the tool's name, the arguments the LLM passed in, and the value the tool returned.\n",
+    "**Tool spans** represent a call to an external tool or function \u2014 typically a function the LLM has decided to call. They capture the tool's name, the arguments the LLM passed in, and the value the tool returned.\n",
     "\n",
-    "In the agent trace above you have two tool spans: `get_weather` and `get_time_zone`, one for each tool the agent invoked. Select one of them in the trace tree to see the tool-specific attributes — the tool name, the arguments the LLM passed in (`{\"city\": \"Tokyo\"}`), and the value the tool returned.\n",
+    "In the agent trace above you have two tool spans: `get_weather` and `get_time_zone`, one for each tool the agent invoked. Select one of them in the trace tree to see the tool-specific attributes \u2014 the tool name, the arguments the LLM passed in (`{\"city\": \"Tokyo\"}`), and the value the tool returned.\n",
     "\n",
     "![The Attributes tab in Arize AX showing the get_weather tool span attributes, including the input city and the returned weather text](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/tool-span-attributes.png)\n",
     "\n",
@@ -952,7 +961,7 @@
    "id": "b2e53c6e",
    "metadata": {},
    "source": [
-    "**Agent spans** represent the work of an autonomous agent — the orchestration that decides when to call the LLM, when to call tools, when to call the LLM again, and when to stop. An agent span is typically the parent of the LLM, tool, and chain spans that make up the agent's loop.\n",
+    "**Agent spans** represent the work of an autonomous agent \u2014 the orchestration that decides when to call the LLM, when to call tools, when to call the LLM again, and when to stop. An agent span is typically the parent of the LLM, tool, and chain spans that make up the agent's loop.\n",
     "\n",
     "In the agent trace above, the `TravelAssistant` span is an agent span. Select it to see how it wraps both of the agent's turns, with all of the LLM and tool calls nested inside it.\n",
     "\n",
@@ -996,7 +1005,7 @@
     "| Attribute | Description |\n",
     "| --- | --- |\n",
     "| `agent.name` | The name of the agent. Agents that perform the same logical role should share a name so you can group their traces together. |\n",
-    "| `graph.node.id` | The id of this agent's node in an execution graph. Optional — set when you want to visualize a multi-agent system as a graph in Arize AX. |\n",
+    "| `graph.node.id` | The id of this agent's node in an execution graph. Optional \u2014 set when you want to visualize a multi-agent system as a graph in Arize AX. |\n",
     "| `graph.node.name` | A human-readable name for the graph node |\n",
     "| `graph.node.parent_id` | The id of the parent node. Leave unset for a root agent. |\n",
     "\n",
@@ -1016,7 +1025,7 @@
    "id": "6a5e91b5",
    "metadata": {},
    "source": [
-    "**Chain spans** are general-purpose grouping spans. Use a chain span when you want to group a set of related work under a single parent in the trace tree — a multi-step pipeline, one agent turn, an LLM call with pre- and post-processing, or just a logical block in your application code.\n",
+    "**Chain spans** are general-purpose grouping spans. Use a chain span when you want to group a set of related work under a single parent in the trace tree \u2014 a multi-step pipeline, one agent turn, an LLM call with pre- and post-processing, or just a logical block in your application code.\n",
     "\n",
     "In the agent trace above the outer `Agent workflow` is a chain span, and each agent turn is also wrapped in a chain span called `turn`. Select a `turn` span to see how it groups the LLM and tool calls for that turn together.\n",
     "\n",
@@ -1034,7 +1043,7 @@
     "}\n",
     "```\n",
     "\n",
-    "The chain span carries only the kind and the common attributes — its value is purely structural, giving you a named parent in the trace tree."
+    "The chain span carries only the kind and the common attributes \u2014 its value is purely structural, giving you a named parent in the trace tree."
    ]
   },
   {
@@ -1050,7 +1059,7 @@
    "id": "ea30b7b2",
    "metadata": {},
    "source": [
-    "Chain spans have no kind-specific attributes. They rely on the common attributes covered in the Span attributes section above — `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, and so on. The chain span's value is purely structural: it gives you a named parent in the trace tree, with whatever input and output you choose to attach to it."
+    "Chain spans have no kind-specific attributes. They rely on the common attributes covered in the Span attributes section above \u2014 `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, and so on. The chain span's value is purely structural: it gives you a named parent in the trace tree, with whatever input and output you choose to attach to it."
    ]
   },
   {
@@ -1068,11 +1077,11 @@
    "source": [
     "Auto-instrumentors capture the standard OpenInference attributes for every span they create, but you often want to add your own. Common reasons:\n",
     "\n",
-    "- **Tag the call for filtering** — for example `experiment=\"v2-prompt\"` or `tenant=\"acme\"`\n",
-    "- **Attach domain metadata** — user tier, request id, feature flag value\n",
-    "- **Record a prompt template** — the template string, version, and variables you used, separate from the final flattened prompt\n",
+    "- **Tag the call for filtering** \u2014 for example `experiment=\"v2-prompt\"` or `tenant=\"acme\"`\n",
+    "- **Attach domain metadata** \u2014 user tier, request id, feature flag value\n",
+    "- **Record a prompt template** \u2014 the template string, version, and variables you used, separate from the final flattened prompt\n",
     "\n",
-    "With manually-created spans you can call `span.set_attribute(...)` directly inside the `with` block, as you saw in the manual instrumentation example. With auto-instrumented spans you do not have direct access to the span object — but you can still enrich it by putting attributes into the OpenTelemetry context using the **OpenInference context managers**. The auto-instrumentor reads from that context when it creates the span. This means the attributes are applied to every span created inside the block, no matter who creates it.\n",
+    "With manually-created spans you can call `span.set_attribute(...)` directly inside the `with` block, as you saw in the manual instrumentation example. With auto-instrumented spans you do not have direct access to the span object \u2014 but you can still enrich it by putting attributes into the OpenTelemetry context using the **OpenInference context managers**. The auto-instrumentor reads from that context when it creates the span. This means the attributes are applied to every span created inside the block, no matter who creates it.\n",
     "\n",
     "The available context managers are:\n",
     "\n",
@@ -1085,7 +1094,9 @@
     "| `using_prompt_template(template=, variables=, version=)` | The `llm.prompt_template.*` attributes. Most useful on LLM spans. |\n",
     "| `using_attributes(...)` | A convenience wrapper that combines all of the above into a single call |\n",
     "\n",
-    "The following code uses `using_metadata` to attach a domain-specific metadata dictionary. The example here wraps an OpenAI call so the metadata ends up on an LLM span, but the same pattern works for any span — auto-instrumented or manual — created inside the block."
+    "See [OpenInference context managers](https://docs.arize.com/ax/concepts/otel-openinference/context-managers) for the full reference, including detailed usage patterns and gotchas.\n",
+    "\n",
+    "The following code uses `using_metadata` to attach a domain-specific metadata dictionary. The example here wraps an OpenAI call so the metadata ends up on an LLM span, but the same pattern works for any span \u2014 auto-instrumented or manual \u2014 created inside the block."
    ]
   },
   {
@@ -1113,7 +1124,7 @@
    "source": [
     "Open the new trace in Arize AX. The LLM span now has an additional attribute:\n",
     "\n",
-    "- `metadata` — a JSON string containing `{\"user_tier\": \"premium\", \"request_source\": \"cookbook\"}`\n",
+    "- `metadata` \u2014 a JSON string containing `{\"user_tier\": \"premium\", \"request_source\": \"cookbook\"}`\n",
     "\n",
     "It appears in the **Attributes** tab alongside the standard `llm.*` attributes.\n",
     "\n",
@@ -1137,7 +1148,7 @@
    "id": "c5991f49",
    "metadata": {},
    "source": [
-    "You can also override attributes that an auto-instrumentor has set, or add attributes that it left out. The OpenAI Agents SDK auto-instrumentor only sets `tool.name` on tool spans — it does not populate `tool.description`. The following code redefines `get_weather` to set a custom `tool.description` attribute on the active tool span, then recreates the agent and re-runs it.\n",
+    "You can also override attributes that an auto-instrumentor has set, or add attributes that it left out. The OpenAI Agents SDK auto-instrumentor only sets `tool.name` on tool spans \u2014 it does not populate `tool.description`. The following code redefines `get_weather` to set a custom `tool.description` attribute on the active tool span, then recreates the agent and re-runs it.\n",
     "\n",
     "The pattern works because the auto-instrumentor opens the tool span before calling your function, so the tool span is the active span when your function body runs. Calling `set_attribute(...)` on it inside the function body either overrides the attribute (if the instrumentor set it) or adds it (if the instrumentor did not)."
    ]
@@ -1159,7 +1170,7 @@
     "        \"Looks up the current weather conditions for a given city.\",\n",
     "    )\n",
     "\n",
-    "    return f\"The weather in {city} is sunny and 22°C.\"\n",
+    "    return f\"The weather in {city} is sunny and 22\u00b0C.\"\n",
     "\n",
     "\n",
     "travel_agent = Agent(\n",
@@ -1225,11 +1236,11 @@
    "source": [
     "You have now seen the building blocks for tracing AI applications with OpenInference and Arize AX:\n",
     "\n",
-    "- **OpenInference layers on top of OpenTelemetry** to add semantic conventions and auto-instrumentors for AI-specific concepts. The standard OpenTelemetry SDK still drives everything underneath — `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` are all unchanged.\n",
+    "- **OpenInference layers on top of OpenTelemetry** to add semantic conventions and auto-instrumentors for AI-specific concepts. The standard OpenTelemetry SDK still drives everything underneath \u2014 `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` are all unchanged.\n",
     "- **Spans, traces, and sessions form a hierarchy.** A span is one step. A trace is a tree of spans tied together by `trace_id`. A session is a group of traces tied together by `session.id`. Sessions are how you stitch a multi-turn conversation together in Arize AX.\n",
-    "- **There are three ways to capture spans.** Auto-instrumentors wrap SDKs and emit spans for every call automatically. Manual instrumentation lets you create spans yourself with `tracer.start_as_current_span(...)`. Hybrid instrumentation combines the two — your manual spans wrap auto-instrumented calls and become their parents in the trace tree.\n",
-    "- **Every span carries a small set of common attributes** — `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, `user.id`, and `tag.tags` — regardless of the kind. The `openinference.span.kind` attribute drives how Arize AX renders the span.\n",
-    "- **Four span kinds cover most AI applications:** LLM, chain, agent, and tool. Each adds a kind-specific set of attributes — `llm.*` for model name, token counts, and costs; `tool.*` for tool name and description; `agent.name` (or `graph.node.id` for multi-agent graphs); chain spans rely on the common attributes alone.\n",
+    "- **There are three ways to capture spans.** Auto-instrumentors wrap SDKs and emit spans for every call automatically. Manual instrumentation lets you create spans yourself with `tracer.start_as_current_span(...)`. Hybrid instrumentation combines the two \u2014 your manual spans wrap auto-instrumented calls and become their parents in the trace tree.\n",
+    "- **Every span carries a small set of common attributes** \u2014 `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, `user.id`, and `tag.tags` \u2014 regardless of the kind. The `openinference.span.kind` attribute drives how Arize AX renders the span.\n",
+    "- **Four span kinds cover most AI applications:** LLM, chain, agent, and tool. Each adds a kind-specific set of attributes \u2014 `llm.*` for model name, token counts, and costs; `tool.*` for tool name and description; `agent.name` (or `graph.node.id` for multi-agent graphs); chain spans rely on the common attributes alone.\n",
     "- **You can enrich auto-instrumented spans.** Use OpenInference context managers like `using_session`, `using_metadata`, `using_tags`, and `using_prompt_template` to attach attributes that the auto-instrumentor picks up via the OpenTelemetry context. You can also override or add specific attributes by grabbing the active span inside a tool function and calling `set_attribute(...)` directly."
    ]
   },
@@ -1246,8 +1257,13 @@
    "id": "7f39bd16",
    "metadata": {},
    "source": [
+    "- Read the [OpenTelemetry and OpenInference concepts](https://docs.arize.com/ax/concepts/otel-openinference/overview) section of the Arize docs for the full reference companion to this cookbook\n",
+    "- Dive into the [OpenInference span kinds](https://docs.arize.com/ax/concepts/otel-openinference/span-kinds) reference for every span kind and the attributes each carries\n",
+    "- Read [Instrumentation approaches](https://docs.arize.com/ax/concepts/otel-openinference/instrumentation-approaches) for a deeper comparison of auto, manual, and hybrid instrumentation\n",
+    "- Learn how to [propagate context across services or async boundaries](https://docs.arize.com/ax/concepts/otel-openinference/context-propagation) when your app spans multiple processes\n",
+    "- Reduce trace volume in production with [sampling](https://docs.arize.com/ax/concepts/otel-openinference/sampling)\n",
     "- Browse the [OpenInference repository](https://github.com/Arize-ai/openinference) for auto-instrumentors covering Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many others\n",
-    "- Read the [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) for the full list of attributes by span kind"
+    "- Read the [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) for the source-of-truth attribute definitions"
    ]
   }
  ],

--- a/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
+++ b/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
@@ -493,11 +493,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = client.responses.create(\n",
-    "    model=\"gpt-5.4-mini\",\n",
-    "    input=\"What are sessions in OpenInference? Be concise.\",\n",
-    ")\n",
-    "display(Markdown(response.output_text))"
+    "with using_session(session_id=\"Capturing Spans Example\"):\n",
+    "    response = client.responses.create(\n",
+    "        model=\"gpt-5.4-mini\",\n",
+    "        input=\"What are sessions in OpenInference? Be concise.\",\n",
+    "    )\n",
+    "    display(Markdown(response.output_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b920c16",
+   "metadata": {},
+   "source": [
+    "Open the new trace in Arize AX under the `Capturing Spans Example` session. You will see a single LLM span — the auto-instrumentor created it automatically for the `client.responses.create()` call, without you writing any tracing code."
    ]
   },
   {
@@ -538,30 +547,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with tracer.start_as_current_span(\"data-pipeline\") as pipeline:\n",
-    "    pipeline.set_attribute(\n",
-    "        SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
-    "        OpenInferenceSpanKindValues.CHAIN.value,\n",
-    "    )\n",
-    "    pipeline.set_attribute(SpanAttributes.INPUT_VALUE, \"raw request\")\n",
-    "\n",
-    "    with tracer.start_as_current_span(\"step-1-validate\") as step:\n",
-    "        step.set_attribute(\n",
+    "with using_session(session_id=\"Capturing Spans Example\"):\n",
+    "    with tracer.start_as_current_span(\"data-pipeline\") as pipeline:\n",
+    "        pipeline.set_attribute(\n",
     "            SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
     "            OpenInferenceSpanKindValues.CHAIN.value,\n",
     "        )\n",
-    "        step.set_attribute(SpanAttributes.INPUT_VALUE, \"raw request\")\n",
-    "        step.set_attribute(SpanAttributes.OUTPUT_VALUE, \"validated request\")\n",
+    "        pipeline.set_attribute(SpanAttributes.INPUT_VALUE, \"raw request\")\n",
     "\n",
-    "    with tracer.start_as_current_span(\"step-2-format\") as step:\n",
-    "        step.set_attribute(\n",
-    "            SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
-    "            OpenInferenceSpanKindValues.CHAIN.value,\n",
-    "        )\n",
-    "        step.set_attribute(SpanAttributes.INPUT_VALUE, \"validated request\")\n",
-    "        step.set_attribute(SpanAttributes.OUTPUT_VALUE, \"formatted output\")\n",
+    "        with tracer.start_as_current_span(\"step-1-validate\") as step:\n",
+    "            step.set_attribute(\n",
+    "                SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "                OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "            )\n",
+    "            step.set_attribute(SpanAttributes.INPUT_VALUE, \"raw request\")\n",
+    "            step.set_attribute(SpanAttributes.OUTPUT_VALUE, \"validated request\")\n",
     "\n",
-    "    pipeline.set_attribute(SpanAttributes.OUTPUT_VALUE, \"formatted output\")"
+    "        with tracer.start_as_current_span(\"step-2-format\") as step:\n",
+    "            step.set_attribute(\n",
+    "                SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "                OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "            )\n",
+    "            step.set_attribute(SpanAttributes.INPUT_VALUE, \"validated request\")\n",
+    "            step.set_attribute(SpanAttributes.OUTPUT_VALUE, \"formatted output\")\n",
+    "\n",
+    "        pipeline.set_attribute(SpanAttributes.OUTPUT_VALUE, \"formatted output\")"
    ]
   },
   {
@@ -569,7 +579,7 @@
    "id": "d3c876d2",
    "metadata": {},
    "source": [
-    "Open the new trace in Arize AX. You will see a single chain span called `data-pipeline` with two child chain spans (`step-1-validate` and `step-2-format`) nested underneath.\n",
+    "Open the new trace in Arize AX under the `Capturing Spans Example` session. You will see a single chain span called `data-pipeline` with two child chain spans (`step-1-validate` and `step-2-format`) nested underneath.\n",
     "\n",
     "![Trace tree in Arize AX showing the data-pipeline chain span with step-1-validate and step-2-format child chain spans nested inside](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/data-pipeline.png)"
    ]
@@ -607,19 +617,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with tracer.start_as_current_span(\"manual-chain\") as chain_span:\n",
-    "    chain_span.set_attribute(\n",
-    "        SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
-    "        OpenInferenceSpanKindValues.CHAIN.value,\n",
-    "    )\n",
-    "    chain_span.set_attribute(SpanAttributes.INPUT_VALUE, \"What are sessions in OpenInference? Be concise.\")\n",
+    "with using_session(session_id=\"Capturing Spans Example\"):\n",
+    "    with tracer.start_as_current_span(\"manual-chain\") as chain_span:\n",
+    "        chain_span.set_attribute(\n",
+    "            SpanAttributes.OPENINFERENCE_SPAN_KIND,\n",
+    "            OpenInferenceSpanKindValues.CHAIN.value,\n",
+    "        )\n",
+    "        chain_span.set_attribute(SpanAttributes.INPUT_VALUE, \"What are sessions in OpenInference? Be concise.\")\n",
     "\n",
-    "    response = client.responses.create(\n",
-    "        model=\"gpt-5.4-mini\",\n",
-    "        input=\"What are sessions in OpenInference? Be concise.\",\n",
-    "    )\n",
+    "        response = client.responses.create(\n",
+    "            model=\"gpt-5.4-mini\",\n",
+    "            input=\"What are sessions in OpenInference? Be concise.\",\n",
+    "        )\n",
     "\n",
-    "    chain_span.set_attribute(SpanAttributes.OUTPUT_VALUE, response.output_text)"
+    "        chain_span.set_attribute(SpanAttributes.OUTPUT_VALUE, response.output_text)\n",
+    "        display(Markdown(response.output_text))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026931b8",
+   "metadata": {},
+   "source": [
+    "Open the new trace in Arize AX under the `Capturing Spans Example` session. You will see a chain span called `manual-chain` with an LLM span nested inside it — the manual span is the parent, and the auto-instrumented LLM span automatically became its child because they share the same OpenTelemetry context."
    ]
   },
   {

--- a/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
+++ b/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
@@ -80,12 +80,12 @@
     "\n",
     "Copy the Arize `API_KEY` and `SPACE_ID` from your Space Settings page (shown below) to the variables in the cell below.\n",
     "\n",
-    "![](apikey.png)"
+    "![Arize AX Space Settings page showing the Space ID and API Key fields](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/apikey.png)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "94a0ad81",
    "metadata": {},
    "outputs": [],
@@ -115,29 +115,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "cba74baa",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🔭 OpenTelemetry Tracing Details 🔭\n",
-      "|  Arize Project: otel-best-practices\n",
-      "|  Span Processor: SimpleSpanProcessor\n",
-      "|  Collector Endpoint: otlp.arize.com\n",
-      "|  Transport: gRPC\n",
-      "|  Transport Headers: {'authorization': '****', 'api_key': '****', 'arize-space-id': '****', 'space_id': '****', 'arize-interface': '****'}\n",
-      "|  \n",
-      "|  Using a default SpanProcessor. `add_span_processor` will overwrite this default.\n",
-      "|  \n",
-      "|  `register` has set this TracerProvider as the global OpenTelemetry default.\n",
-      "|  To disable this behavior, call `register` with `set_global_tracer_provider=False`.\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from arize.otel import register\n",
     "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
@@ -193,64 +174,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "e2952ced",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "OpenInference is an open standard for **instrumenting and tracing AI applications**, especially LLM apps and agent workflows.\n",
-       "\n",
-       "It helps you:\n",
-       "- **Capture spans, prompts, tool calls, outputs, and metadata**\n",
-       "- **Trace** how an app or agent made decisions\n",
-       "- **Debug** failures and weird model behavior\n",
-       "- **Analyze** performance, latency, cost, and quality\n",
-       "- **Export** data to observability tools like OpenTelemetry-compatible backends\n",
-       "\n",
-       "In short: **OpenInference gives you a common way to observe and understand AI systems end to end**.\n",
-       "\n",
-       "If you want, I can also explain how it compares to OpenTelemetry or show a simple example."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "OpenInference is built on top of **OpenTelemetry (OTel)**.\n",
-       "\n",
-       "Relationship:\n",
-       "- **OpenTelemetry** provides the general-purpose standard for tracing, metrics, and logs.\n",
-       "- **OpenInference** defines **AI/LLM-specific conventions** for those traces, like:\n",
-       "  - prompts\n",
-       "  - completions\n",
-       "  - tool calls\n",
-       "  - embeddings\n",
-       "  - token counts\n",
-       "  - model/provider metadata\n",
-       "\n",
-       "So:\n",
-       "- OTel = the **observability framework**\n",
-       "- OpenInference = the **AI semantic conventions / instrumentation layer** for OTel\n",
-       "\n",
-       "This means OpenInference traces can usually be sent to any **OpenTelemetry-compatible backend**.\n",
-       "\n",
-       "If you want, I can give a concrete example of an OpenInference trace in OTel terms."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import uuid\n",
     "from IPython.display import Markdown, display\n",
@@ -352,11 +279,11 @@
     "\n",
     "In Arize AX, start with the **Sessions** tab. You should see a single session that represents the entire two step conversation.\n",
     "\n",
-    "![The sessions tab](sessions.png)\n",
+    "![The Sessions tab in Arize AX showing one session for the chatbot conversation](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/sessions.png)\n",
     "\n",
     "If you select the session, a pane will appear with details of the session, including both steps in the conversation, showing the input to and the output from the agent. It will also show the latency, so the time the agent took to run, as well as the total number of tokens used and the estimated cost based off published token pricing from the LLM provider if available.\n",
     "\n",
-    "![A single session in Arize AX](session.png)"
+    "![Details pane in Arize AX for the chatbot session, showing both conversation turns with input, output, latency, tokens, and cost](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/session.png)"
    ]
   },
   {
@@ -370,11 +297,11 @@
     "\n",
     "The code you ran just makes a single LLM call, so the trace has the input set to what was sent to the LLM, and the output set to the response from the LLM. In a more complicated trace, the input is what was sent to the agent, and the output is the final response sent by the agent after it has completed its entire processing, including calling LLMs or tools.\n",
     "\n",
-    "![](traces.png)\n",
+    "![The Traces tab in Arize AX showing two traces from the chatbot conversation](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/traces.png)\n",
     "\n",
     "If you select a trace, a pane will appear with details of the trace. It will show a tree of spans, along with latency, token counts, and estimated cost.\n",
     "\n",
-    "![](trace.png)\n",
+    "![Details pane in Arize AX for a single trace, showing the span tree with latency, token counts, and cost](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/trace.png)\n",
     "\n",
     "> You can also navigate to the individual traces directly from the session view."
    ]
@@ -390,17 +317,17 @@
     "\n",
     "In the trace we have 2 spans:\n",
     "\n",
-    "![](trace.png)\n",
+    "![Details pane in Arize AX for a single trace, showing the span tree with latency, token counts, and cost](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/trace.png)\n",
     "\n",
     "The root span is a **Chain** span. Chain spans are starting points for a set of related spans, you can think of them as a folder that groups spans together. In this example, the chain span isn't really necessary, it's just here to help show a tree.\n",
     "\n",
     "Under the root span is an **LLM** span called `ChatCompletion`. This span represents a call to an LLM, in our case OpenAI.\n",
     "\n",
-    "![](llm-span.png)\n",
+    "![An LLM span named ChatCompletion selected in the Arize AX trace tree](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/llm-span.png)\n",
     "\n",
     "Against each span is an **Attributes** tab that has JSON containing all the attributes associated with the span, such as the input and output, number of tokens used for an LLM span, and so on. We will cover these attributes in the rest of this tutorial.\n",
     "\n",
-    "![](span-attributes.png)"
+    "![The Attributes tab in Arize AX showing the JSON attributes for a selected span](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/span-attributes.png)"
    ]
   },
   {
@@ -451,35 +378,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "7801593f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "In OpenInference, **sessions** are a way to **group related traces and spans** that belong to the same user interaction, workflow, or conversation.\n",
-       "\n",
-       "They help you:\n",
-       "- **organize observability data** across multiple requests\n",
-       "- **track stateful experiences** like chats or agent runs\n",
-       "- **analyze behavior over time** within one logical session\n",
-       "\n",
-       "Typically, a session represents something like:\n",
-       "- a chat conversation\n",
-       "- a user visit\n",
-       "- a single end-to-end task or workflow\n",
-       "\n",
-       "If you want, I can also explain how sessions relate to **traces** and **spans**."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "with using_session(session_id=\"My Session\"):\n",
     "    response = client.responses.create(\n",
@@ -496,42 +398,17 @@
    "source": [
     "Look up this session in Arize AX. You will see a single session with multiple traces depending on how many times you ran the code.\n",
     "\n",
-    "![](sessions-1-session.png)\n",
+    "![The Sessions tab in Arize AX showing a single session with multiple traces](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/sessions-1-session.png)\n",
     "\n",
     "Now run the following code. This has a different session Id, so will create a new session."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "27614472",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "In OpenInference, a **session** is a way to **group related traces/runs from the same user interaction or workflow** into a single logical unit.\n",
-       "\n",
-       "Commonly, a session represents things like:\n",
-       "- one chat conversation,\n",
-       "- one experiment,\n",
-       "- one end-to-end task or workflow.\n",
-       "\n",
-       "It helps you:\n",
-       "- **associate multiple spans/traces together**,\n",
-       "- **analyze behavior over time** within that interaction,\n",
-       "- **filter and inspect** all activity tied to the same session.\n",
-       "\n",
-       "Typically, a session is identified by a **session ID** attached as trace/span metadata."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "with using_session(session_id=\"My Session 2\"):\n",
     "    response = client.responses.create(\n",
@@ -548,7 +425,7 @@
    "source": [
     "You will now see a new session in the sessions list.\n",
     "\n",
-    "![](sessions-2-sessions.png)"
+    "![The Sessions tab in Arize AX showing two distinct sessions in the list](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/sessions-2-sessions.png)"
    ]
   },
   {
@@ -604,29 +481,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "4707bbda",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "In OpenInference, **sessions** are **groupings of related traces/spans** that represent a single user interaction or workflow over time.\n",
-       "\n",
-       "- They help tie together multiple requests, tool calls, or agent actions.\n",
-       "- Usually identified by a **session ID**.\n",
-       "- Useful for **tracking conversation history, debugging, and analytics** across a user’s whole experience, not just one span.\n",
-       "\n",
-       "In short: **a session is the higher-level context that contains multiple traces/spans from the same user or task.**"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "response = client.responses.create(\n",
     "    model=\"gpt-5.4-mini\",\n",
@@ -668,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "397c1102",
    "metadata": {},
    "outputs": [],
@@ -706,7 +564,7 @@
    "source": [
     "Open the new trace in Arize AX. You will see a single chain span called `data-pipeline` with two child chain spans (`step-1-validate` and `step-2-format`) nested underneath.\n",
     "\n",
-    "![](data-pipeline.png)"
+    "![Trace tree in Arize AX showing the data-pipeline chain span with step-1-validate and step-2-format child chain spans nested inside](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/data-pipeline.png)"
    ]
   },
   {
@@ -737,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "2da697be",
    "metadata": {},
    "outputs": [],
@@ -811,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "e92eae93",
    "metadata": {},
    "outputs": [],
@@ -888,7 +746,7 @@
     "- Two **tool** spans, one for each call to `get_weather` and `get_time_zone`\n",
     "- Four **LLM** spans — each agent turn produces a Responses API call from the SDK with the underlying OpenAI client call nested inside it\n",
     "\n",
-    "![](agent-trace.png)\n",
+    "![Trace in Arize AX from the OpenAI Agents SDK example, showing agent, chain, tool, and LLM spans nested together](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/agent-trace.png)\n",
     "\n",
     "This is the trace shape you will see from most non-trivial agents: an outer agent/chain workflow, tool spans for each external call, and LLM spans for every model call inside."
    ]
@@ -910,7 +768,7 @@
     "\n",
     "In the agent trace are several LLM spans. Select one of these, and you will see the input and output from that LLM call. Against the span in the tree you will also see the number of tokens used, the latency, and the cost. In the **Attributes** tab, you can see the full attributes for the span.\n",
     "\n",
-    "![](llm-span-attributes.png)\n",
+    "![The Attributes tab in Arize AX showing the full attribute set for an LLM span](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/llm-span-attributes.png)\n",
     "\n",
     "The relevant attributes for this example are:\n",
     "\n",
@@ -1037,7 +895,7 @@
     "\n",
     "In the agent trace above you have two tool spans: `get_weather` and `get_time_zone`, one for each tool the agent invoked. Select one of them in the trace tree to see the tool-specific attributes — the tool name, the arguments the LLM passed in (`{\"city\": \"Tokyo\"}`), and the value the tool returned.\n",
     "\n",
-    "![](tool-span-attributes.png)\n",
+    "![The Attributes tab in Arize AX showing the get_weather tool span attributes, including the input city and the returned weather text](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/tool-span-attributes.png)\n",
     "\n",
     "The relevant attributes for this example are:\n",
     "\n",
@@ -1098,7 +956,7 @@
     "\n",
     "In the agent trace above, the `TravelAssistant` span is an agent span. Select it to see how it wraps both of the agent's turns, with all of the LLM and tool calls nested inside it.\n",
     "\n",
-    "![](agent-span-attributes.png)\n",
+    "![The Attributes tab in Arize AX showing the TravelAssistant agent span attributes](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/agent-span-attributes.png)\n",
     "\n",
     "The relevant attributes for this example are:\n",
     "\n",
@@ -1162,7 +1020,7 @@
     "\n",
     "In the agent trace above the outer `Agent workflow` is a chain span, and each agent turn is also wrapped in a chain span called `turn`. Select a `turn` span to see how it groups the LLM and tool calls for that turn together.\n",
     "\n",
-    "![](chain-span-attributes.png)\n",
+    "![The Attributes tab in Arize AX showing a turn chain span grouping the LLM and tool calls for one agent turn](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/chain-span-attributes.png)\n",
     "\n",
     "The relevant attributes for this example are:\n",
     "\n",
@@ -1232,32 +1090,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "d6bd68c4",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "In OpenInference, **LLM spans** are **trace spans that represent a single interaction with a large language model**—for example, a prompt/completion, chat turn, or model call.\n",
-       "\n",
-       "They typically capture things like:\n",
-       "- **Input**: prompts, messages, parameters\n",
-       "- **Output**: completions or responses\n",
-       "- **Model metadata**: model name, provider, temperature, etc.\n",
-       "- **Usage**: token counts, latency, cost-related info\n",
-       "- **Trace context**: parent/child relationships with other spans\n",
-       "\n",
-       "They’re used to **observe, debug, and evaluate LLM apps** across frameworks and providers."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from openinference.instrumentation import using_metadata\n",
     "\n",
@@ -1281,11 +1117,11 @@
     "\n",
     "It appears in the **Attributes** tab alongside the standard `llm.*` attributes.\n",
     "\n",
-    "![](llm-span-metadata.png)\n",
+    "![The Attributes tab in Arize AX showing an LLM span with the custom metadata attribute alongside the standard llm.* attributes](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/llm-span-metadata.png)\n",
     "\n",
     "You can also filter spans by `metadata` values in the Arize AX trace view, which makes it easy to slice traces by tenant, feature flag, or any other domain dimension. In the **Spans** tab, set the filter to `attributes.metadata.request_source = \"cookbook\"` to only see spans created with the `request_source` metadata set to `cookbook`.\n",
     "\n",
-    "![](metadata-filter.png)"
+    "![The Spans tab in Arize AX filtered by attributes.metadata.request_source equal to cookbook](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/metadata-filter.png)"
    ]
   },
   {
@@ -1308,23 +1144,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "48396d17",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "Tokyo: sunny, 22°C. Time zone: JST (UTC+9)."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "@function_tool\n",
     "def get_weather(city: str) -> str:\n",
@@ -1366,7 +1189,7 @@
    "source": [
     "Open the new trace in Arize AX under the `otel-best-practices` project (find it via the `Tool Override Example` session). Select the `get_weather` tool span and open its **Attributes** tab. You will now see `tool.description` populated with the string you set inside the function body, alongside the standard `tool.name` the auto-instrumentor produced.\n",
     "\n",
-    "![](tool-override-attributes.png)\n",
+    "![The Attributes tab in Arize AX showing the get_weather tool span with the manually-set tool.description alongside tool.name](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/tool-span-attributes-override.png)\n",
     "\n",
     "The relevant attributes for this example are:\n",
     "\n",
@@ -1385,6 +1208,46 @@
     "```\n",
     "\n",
     "The `get_time_zone` tool span in the same trace still has only `tool.name`, which is a good visual confirmation that the override applies only to the span you set attributes on."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42656493",
+   "metadata": {},
+   "source": [
+    "## Summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe1e0e14",
+   "metadata": {},
+   "source": [
+    "You have now seen the building blocks for tracing AI applications with OpenInference and Arize AX:\n",
+    "\n",
+    "- **OpenInference layers on top of OpenTelemetry** to add semantic conventions and auto-instrumentors for AI-specific concepts. The standard OpenTelemetry SDK still drives everything underneath — `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` are all unchanged.\n",
+    "- **Spans, traces, and sessions form a hierarchy.** A span is one step. A trace is a tree of spans tied together by `trace_id`. A session is a group of traces tied together by `session.id`. Sessions are how you stitch a multi-turn conversation together in Arize AX.\n",
+    "- **There are three ways to capture spans.** Auto-instrumentors wrap SDKs and emit spans for every call automatically. Manual instrumentation lets you create spans yourself with `tracer.start_as_current_span(...)`. Hybrid instrumentation combines the two — your manual spans wrap auto-instrumented calls and become their parents in the trace tree.\n",
+    "- **Every span carries a small set of common attributes** — `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, `user.id`, and `tag.tags` — regardless of the kind. The `openinference.span.kind` attribute drives how Arize AX renders the span.\n",
+    "- **Four span kinds cover most AI applications:** LLM, chain, agent, and tool. Each adds a kind-specific set of attributes — `llm.*` for model name, token counts, and costs; `tool.*` for tool name and description; `agent.name` (or `graph.node.id` for multi-agent graphs); chain spans rely on the common attributes alone.\n",
+    "- **You can enrich auto-instrumented spans.** Use OpenInference context managers like `using_session`, `using_metadata`, `using_tags`, and `using_prompt_template` to attach attributes that the auto-instrumentor picks up via the OpenTelemetry context. You can also override or add specific attributes by grabbing the active span inside a tool function and calling `set_attribute(...)` directly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "daf3acfb",
+   "metadata": {},
+   "source": [
+    "### Where to go next"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f39bd16",
+   "metadata": {},
+   "source": [
+    "- Browse the [OpenInference repository](https://github.com/Arize-ai/openinference) for auto-instrumentors covering Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many others\n",
+    "- Read the [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) for the full list of attributes by span kind"
    ]
   }
  ],

--- a/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
+++ b/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "- How OpenInference layers on top of OpenTelemetry to add AI-aware semantics\n",
     "- The hierarchy of sessions, traces, and spans that organizes your telemetry\n",
-    "- Three ways to capture spans \u2014 auto-instrumentation, manual instrumentation, and the hybrid approach that combines them\n",
+    "- Three ways to capture spans — auto-instrumentation, manual instrumentation, and the hybrid approach that combines them\n",
     "- The common attributes every span carries, and the kind-specific attributes for the four core span kinds (LLM, chain, agent, and tool)\n",
     "- How to add or override attributes on spans, including auto-instrumented spans you cannot access directly\n",
     "\n",
@@ -67,8 +67,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq openai openai-agents\n",
-    "!pip install -qq arize-otel openinference-instrumentation-openai openinference-instrumentation-openai-agents opentelemetry-sdk opentelemetry-exporter-otlp"
+    "%pip install -qq openai openai-agents\n",
+    "%pip install -qq arize-otel openinference-instrumentation-openai openinference-instrumentation-openai-agents opentelemetry-sdk opentelemetry-exporter-otlp"
    ]
   },
   {
@@ -94,11 +94,11 @@
     "from getpass import getpass\n",
     "\n",
     "ARIZE_SPACE_ID = globals().get(\"ARIZE_SPACE_ID\") or getpass(\n",
-    "    \"\ud83d\udd11 Enter your Arize Space ID: \"\n",
+    "    \"🔑 Enter your Arize Space ID: \"\n",
     ")\n",
-    "ARIZE_API_KEY = globals().get(\"ARIZE_API_KEY\") or getpass(\"\ud83d\udd11 Enter your Arize API Key: \")\n",
+    "ARIZE_API_KEY = globals().get(\"ARIZE_API_KEY\") or getpass(\"🔑 Enter your Arize API Key: \")\n",
     "OPENAI_API_KEY = globals().get(\"OPENAI_API_KEY\") or getpass(\n",
-    "    \"\ud83d\udd11 Enter your OpenAI API key: \"\n",
+    "    \"🔑 Enter your OpenAI API key: \"\n",
     ")\n",
     "os.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY"
    ]
@@ -150,19 +150,19 @@
    "source": [
     "[OpenInference](https://github.com/Arize-ai/openinference) is an open-source set of conventions and instrumentation libraries for tracing AI applications. It is maintained by Arize and is the standard that Arize AX uses to render LLM, tool, agent, chain, retriever, and other AI-specific spans in the trace view.\n",
     "\n",
-    "OpenInference is an **extension to [OpenTelemetry](https://opentelemetry.io/docs/)**, not a replacement for it. It uses the standard OpenTelemetry SDK and libraries under the hood \u2014 the same `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` you would use for any OTel-instrumented service. What OpenInference adds is:\n",
+    "OpenInference is an **extension to [OpenTelemetry](https://opentelemetry.io/docs/)**, not a replacement for it. It uses the standard OpenTelemetry SDK and libraries under the hood — the same `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` you would use for any OTel-instrumented service. What OpenInference adds is:\n",
     "\n",
     "- A set of **semantic conventions** that describe how to represent AI concepts (LLM calls, prompts, messages, tool invocations, retrieval, agent steps, sessions) as span attributes\n",
     "- A library of **auto-instrumentors** for popular LLM SDKs and orchestration frameworks (OpenAI, Anthropic, Bedrock, LangChain, LlamaIndex, CrewAI, AutoGen, and many more)\n",
     "\n",
-    "Because OpenInference is built on OpenTelemetry, any tool that speaks OTel can consume the spans \u2014 but a backend that understands the OpenInference conventions (like Arize AX) can render them as a rich, AI-aware trace view rather than a generic span list.\n",
+    "Because OpenInference is built on OpenTelemetry, any tool that speaks OTel can consume the spans — but a backend that understands the OpenInference conventions (like Arize AX) can render them as a rich, AI-aware trace view rather than a generic span list.\n",
     "\n",
     "**Read more:**\n",
     "\n",
-    "- [OpenTelemetry and OpenInference concepts](https://docs.arize.com/ax/concepts/otel-openinference/overview) \u2014 the full reference companion to this cookbook.\n",
-    "- [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) \u2014 the formal definitions for span kinds, attributes, and message structure.\n",
-    "- [OpenInference repository](https://github.com/Arize-ai/openinference) \u2014 auto-instrumentors, examples, and source for every supported language and framework.\n",
-    "- [OpenTelemetry documentation](https://opentelemetry.io/docs/) \u2014 the underlying observability framework that OpenInference builds on."
+    "- [OpenTelemetry and OpenInference concepts](https://docs.arize.com/ax/concepts/otel-openinference/overview) — the full reference companion to this cookbook.\n",
+    "- [OpenInference semantic conventions spec](https://github.com/Arize-ai/openinference/tree/main/spec) — the formal definitions for span kinds, attributes, and message structure.\n",
+    "- [OpenInference repository](https://github.com/Arize-ai/openinference) — auto-instrumentors, examples, and source for every supported language and framework.\n",
+    "- [OpenTelemetry documentation](https://opentelemetry.io/docs/) — the underlying observability framework that OpenInference builds on."
    ]
   },
   {
@@ -244,30 +244,30 @@
    "source": [
     "Three concepts shape how OpenInference (and OpenTelemetry) organize tracing data, and they nest inside each other:\n",
     "\n",
-    "- **Span** \u2014 a single step in your application, such as an LLM call, a tool invocation, or a chain stage. Each span has a name, start and end timestamps, attributes, and a potentially a parent \u2014 spans nest to form a tree. The root of the tree is known as the root span, and has no parent.\n",
-    "- **Trace** \u2014 a collection of spans tied together by a shared `trace_id`. A trace represents one end-to-end request through your agent.\n",
-    "- **Session** \u2014 a collection of traces tied together by a shared `session.id`. A session is a logical grouping of traces based on a shared concept, such as multiple agent interactions to solve the same task, or to help with a continuous conversation.\n",
+    "- **Span** — a single step in your application, such as an LLM call, a tool invocation, or a chain stage. Each span has a name, start and end timestamps, attributes, and a potentially a parent — spans nest to form a tree. The root of the tree is known as the root span, and has no parent.\n",
+    "- **Trace** — a collection of spans tied together by a shared `trace_id`. A trace represents one end-to-end request through your agent.\n",
+    "- **Session** — a collection of traces tied together by a shared `session.id`. A session is a logical grouping of traces based on a shared concept, such as multiple agent interactions to solve the same task, or to help with a continuous conversation.\n",
     "\n",
-    "Picture a customer-support chatbot. The user has a multi-turn conversation, and that whole conversation is one **session**. Each turn \u2014 one user message and the app's response \u2014 is one **trace**. Inside each trace, the app does several things to produce the response (classify intent, call a tool, format a reply), and each of those steps is a **span**.\n",
+    "Picture a customer-support chatbot. The user has a multi-turn conversation, and that whole conversation is one **session**. Each turn — one user message and the app's response — is one **trace**. Inside each trace, the app does several things to produce the response (classify intent, call a tool, format a reply), and each of those steps is a **span**.\n",
     "\n",
     "```\n",
     "Session: support-chat-7a3f\n",
-    "\u2502\n",
-    "\u251c\u2500\u2500 Trace 1: \"Where is my order?\"\n",
-    "\u2502   \u2514\u2500\u2500 Chain span: handle_message\n",
-    "\u2502       \u251c\u2500\u2500 LLM span:  classify_intent\n",
-    "\u2502       \u251c\u2500\u2500 Tool span: lookup_order(order_id=\"A123\")\n",
-    "\u2502       \u2514\u2500\u2500 LLM span:  format_response\n",
-    "\u2502\n",
-    "\u251c\u2500\u2500 Trace 2: \"When will it arrive?\"\n",
-    "\u2502   \u2514\u2500\u2500 Chain span: handle_message\n",
-    "\u2502       \u251c\u2500\u2500 LLM span:  classify_intent\n",
-    "\u2502       \u251c\u2500\u2500 Tool span: get_shipping_status(order_id=\"A123\")\n",
-    "\u2502       \u2514\u2500\u2500 LLM span:  format_response\n",
-    "\u2502\n",
-    "\u2514\u2500\u2500 Trace 3: \"Thanks!\"\n",
-    "    \u2514\u2500\u2500 Chain span: handle_message\n",
-    "        \u2514\u2500\u2500 LLM span: generate_acknowledgement\n",
+    "│\n",
+    "├── Trace 1: \"Where is my order?\"\n",
+    "│   └── Chain span: handle_message\n",
+    "│       ├── LLM span:  classify_intent\n",
+    "│       ├── Tool span: lookup_order(order_id=\"A123\")\n",
+    "│       └── LLM span:  format_response\n",
+    "│\n",
+    "├── Trace 2: \"When will it arrive?\"\n",
+    "│   └── Chain span: handle_message\n",
+    "│       ├── LLM span:  classify_intent\n",
+    "│       ├── Tool span: get_shipping_status(order_id=\"A123\")\n",
+    "│       └── LLM span:  format_response\n",
+    "│\n",
+    "└── Trace 3: \"Thanks!\"\n",
+    "    └── Chain span: handle_message\n",
+    "        └── LLM span: generate_acknowledgement\n",
     "```\n",
     "\n",
     "Three traces, one session. In Arize AX you can open a single trace to debug what happened in one turn, or use the session view to see all the turns together.\n",
@@ -318,7 +318,7 @@
    "source": [
     "#### Spans\n",
     "\n",
-    "In the trace view you will see a tree of the spans that make up the trace. Spans are grouped into traces by having the same `trace_id` set on them. A trace is a tree of spans, so one span will be the root span at the top of the tree, and the rest of the spans will be under that tree. The hierarchy is defined using the `parent_id` on the span \u2014 each child span has its `parent_id` set to the id of the parent span.\n",
+    "In the trace view you will see a tree of the spans that make up the trace. Spans are grouped into traces by having the same `trace_id` set on them. A trace is a tree of spans, so one span will be the root span at the top of the tree, and the rest of the spans will be under that tree. The hierarchy is defined using the `parent_id` on the span — each child span has its `parent_id` set to the id of the parent span.\n",
     "\n",
     "In the trace we have 2 spans:\n",
     "\n",
@@ -346,7 +346,7 @@
     "| --- | --- |\n",
     "| `LLM` | A call to a large language model. Captures the model, input messages, output messages, token counts, and cost. |\n",
     "| `CHAIN` | A starting point or link between application steps. Commonly used as a parent span to group related work into a logical block. |\n",
-    "| `AGENT` | A span representing an agent's work \u2014 typically wraps LLM and tool spans together |\n",
+    "| `AGENT` | A span representing an agent's work — typically wraps LLM and tool spans together |\n",
     "| `TOOL` | A call to an external tool or function, often invoked in response to a tool-use request from an LLM |\n",
     "| `RETRIEVER` | A retrieval operation, such as fetching documents from a vector store or search index |\n",
     "| `EMBEDDING` | A call to an embedding model |\n",
@@ -376,7 +376,7 @@
     "\n",
     "Sessions are explicitly managed by the engineer building the agent; they are not created automatically when sending traces.\n",
     "\n",
-    "Sessions are set with the `using_session` function. This sets the session id for any spans created in any code run in this block. `using_session` is one of a small family of OpenInference context managers \u2014 see [OpenInference context managers](https://docs.arize.com/ax/concepts/otel-openinference/context-managers) for the full list (`using_user`, `using_metadata`, `using_tags`, `using_prompt_template`, `using_attributes`).\n",
+    "Sessions are set with the `using_session` function. This sets the session id for any spans created in any code run in this block. `using_session` is one of a small family of OpenInference context managers — see [OpenInference context managers](https://docs.arize.com/ax/concepts/otel-openinference/context-managers) for the full list (`using_user`, `using_metadata`, `using_tags`, `using_prompt_template`, `using_attributes`).\n",
     "\n",
     "The following code contains a call to OpenAI inside a session. The session id is hardcoded here, so if you run this code multiple times, each run will be a new trace inside the same session."
    ]
@@ -526,9 +526,9 @@
     "    span.set_attribute(SpanAttributes.OUTPUT_VALUE, \"result\")\n",
     "```\n",
     "\n",
-    "You can manually create spans of any OpenInference kind, such as chain, LLM, or tool \u2014 by setting the `openinference.span.kind` attribute on the span. The kind controls how Arize AX renders the span (the icon and the detail view) and which set of OpenInference attributes the span is expected to carry.\n",
+    "You can manually create spans of any OpenInference kind, such as chain, LLM, or tool — by setting the `openinference.span.kind` attribute on the span. The kind controls how Arize AX renders the span (the icon and the detail view) and which set of OpenInference attributes the span is expected to carry.\n",
     "\n",
-    "The following code creates a trace with three manually-created spans: a parent `data-pipeline` chain span with two child spans (`step-1-validate` and `step-2-format`) nested inside. There are no LLM or tool calls \u2014 every span is created by your code."
+    "The following code creates a trace with three manually-created spans: a parent `data-pipeline` chain span with two child spans (`step-1-validate` and `step-2-format`) nested inside. There are no LLM or tool calls — every span is created by your code."
    ]
   },
   {
@@ -587,13 +587,13 @@
    "id": "519f8c10",
    "metadata": {},
    "source": [
-    "The most powerful pattern is to use both approaches together. **Hybrid instrumentation** lets you wrap auto-instrumented calls in your own manually-created spans, so you can group SDK calls into logical units, add custom attributes, and build the trace tree that best represents your application \u2014 without losing any of the rich attributes that the auto-instrumentor captures.\n",
+    "The most powerful pattern is to use both approaches together. **Hybrid instrumentation** lets you wrap auto-instrumented calls in your own manually-created spans, so you can group SDK calls into logical units, add custom attributes, and build the trace tree that best represents your application — without losing any of the rich attributes that the auto-instrumentor captures.\n",
     "\n",
     "Auto-instrumented spans and manually-created spans nest together naturally because they share the same OpenTelemetry context. When you open a manual span with `tracer.start_as_current_span(...)`, it becomes the active span on the context. Any call to an auto-instrumented SDK inside that block will create its span as a child of your manual span.\n",
     "\n",
     "You have already seen hybrid instrumentation in the Introduction to OpenInference section. The `ask_llm` function wraps each OpenAI call in a manually-created chain span.\n",
     "\n",
-    "The manually-created chain span is the parent; the LLM span that the OpenAI auto-instrumentor produces around `client.responses.create()` automatically becomes its child. That is what gives you the tree structure you saw in Arize AX when you ran the introduction example \u2014 a chain span at the top, with an LLM span nested inside.\n",
+    "The manually-created chain span is the parent; the LLM span that the OpenAI auto-instrumentor produces around `client.responses.create()` automatically becomes its child. That is what gives you the tree structure you saw in Arize AX when you ran the introduction example — a chain span at the top, with an LLM span nested inside.\n",
     "\n",
     "This pattern is the typical shape of a real-world traced application: manual chain or agent spans give you the high-level structure of your business logic; auto-instrumented spans fill in the low-level detail of every SDK call you make inside them.\n",
     "\n",
@@ -669,11 +669,11 @@
    "id": "36369ffb",
    "metadata": {},
    "source": [
-    "OpenInference defines 11 span kinds, but most AI applications use just four: **LLM**, **chain**, **agent**, and **tool**. These show up in almost every real-world trace \u2014 an agent makes LLM calls, LLM calls trigger tool calls, and chain spans group the related work together. For the canonical reference of every span kind and the attributes each carries, see [OpenInference span kinds](https://docs.arize.com/ax/concepts/otel-openinference/span-kinds).\n",
+    "OpenInference defines 11 span kinds, but most AI applications use just four: **LLM**, **chain**, **agent**, and **tool**. These show up in almost every real-world trace — an agent makes LLM calls, LLM calls trigger tool calls, and chain spans group the related work together. For the canonical reference of every span kind and the attributes each carries, see [OpenInference span kinds](https://docs.arize.com/ax/concepts/otel-openinference/span-kinds).\n",
     "\n",
-    "The following example uses the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) to produce a single trace containing all four kinds. The SDK has its own auto-instrumentor \u2014 `openinference-instrumentation-openai-agents` \u2014 which emits the full set of span kinds for every agent run.\n",
+    "The following example uses the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) to produce a single trace containing all four kinds. The SDK has its own auto-instrumentor — `openinference-instrumentation-openai-agents` — which emits the full set of span kinds for every agent run.\n",
     "\n",
-    "Attach the Agents SDK instrumentor to the existing tracer provider. You can leave the OpenAI auto-instrumentor active alongside it \u2014 the Agents SDK creates its own LLM spans, so the two cooperate without duplicating work."
+    "Attach the Agents SDK instrumentor to the existing tracer provider. You can leave the OpenAI auto-instrumentor active alongside it — the Agents SDK creates its own LLM spans, so the two cooperate without duplicating work."
    ]
   },
   {
@@ -709,7 +709,7 @@
     "@function_tool\n",
     "def get_weather(city: str) -> str:\n",
     "    \"\"\"Get the current weather for a city.\"\"\"\n",
-    "    return f\"The weather in {city} is sunny and 22\u00b0C.\"\n",
+    "    return f\"The weather in {city} is sunny and 22°C.\"\n",
     "\n",
     "\n",
     "@function_tool\n",
@@ -750,10 +750,10 @@
    "source": [
     "Open the trace in Arize AX under the `otel-best-practices` project. A single agent run produces a trace containing all four core span kinds:\n",
     "\n",
-    "- Two **agent** spans \u2014 an outer `Agent workflow` wrapper and an inner `TravelAssistant`\n",
-    "- Three **chain** spans \u2014 one wrapping the whole workflow plus one per agent turn\n",
+    "- Two **agent** spans — an outer `Agent workflow` wrapper and an inner `TravelAssistant`\n",
+    "- Three **chain** spans — one wrapping the whole workflow plus one per agent turn\n",
     "- Two **tool** spans, one for each call to `get_weather` and `get_time_zone`\n",
-    "- Four **LLM** spans \u2014 each agent turn produces a Responses API call from the SDK with the underlying OpenAI client call nested inside it\n",
+    "- Four **LLM** spans — each agent turn produces a Responses API call from the SDK with the underlying OpenAI client call nested inside it\n",
     "\n",
     "![Trace in Arize AX from the OpenAI Agents SDK example, showing agent, chain, tool, and LLM spans nested together](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/agent-trace.png)\n",
     "\n",
@@ -871,7 +871,7 @@
    "source": [
     "#### LLM-specific attributes\n",
     "\n",
-    "Beyond the common attributes that any span carries (covered in the Span attributes section above), the OpenAI auto-instrumentor adds an LLM-specific set on every LLM span \u2014 all under the `llm.*` namespace and following the OpenInference semantic conventions:\n",
+    "Beyond the common attributes that any span carries (covered in the Span attributes section above), the OpenAI auto-instrumentor adds an LLM-specific set on every LLM span — all under the `llm.*` namespace and following the OpenInference semantic conventions:\n",
     "\n",
     "| Attribute | Description |\n",
     "| --- | --- |\n",
@@ -880,7 +880,7 @@
     "| `llm.system` | The AI system identifier, also `openai` |\n",
     "| `llm.invocation_parameters` | A JSON string of the parameters passed to the API: `{\"model\": \"gpt-5.4-mini\"}` |\n",
     "| `llm.input_messages` | The messages sent to the API as a structured array. Each entry has `message.role` and `message.content`. |\n",
-    "| `llm.output_messages` | The messages returned by the API as a structured array. Each entry has `message.role` and a `message.contents` list of structured content items (with `message_content.text` and `message_content.type`). This shape is multimodal-aware \u2014 text, image, audio, and reasoning content all fit the same structure. |\n",
+    "| `llm.output_messages` | The messages returned by the API as a structured array. Each entry has `message.role` and a `message.contents` list of structured content items (with `message_content.text` and `message_content.type`). This shape is multimodal-aware — text, image, audio, and reasoning content all fit the same structure. |\n",
     "| `llm.token_count.prompt` / `.completion` / `.total` | Token counts for the call, with detail breakdowns under `llm.token_count.prompt_details.*` (`cache_read`, `input`) and `llm.token_count.completion_details.*` (`output`, `reasoning`) |\n",
     "| `llm.cost.prompt` / `.completion` / `.total` | Estimated cost in USD with the same `_details` breakdowns. Arize AX computes these from the token counts and the published pricing for the model. |\n",
     "\n",
@@ -900,9 +900,9 @@
    "id": "fc996b12",
    "metadata": {},
    "source": [
-    "**Tool spans** represent a call to an external tool or function \u2014 typically a function the LLM has decided to call. They capture the tool's name, the arguments the LLM passed in, and the value the tool returned.\n",
+    "**Tool spans** represent a call to an external tool or function — typically a function the LLM has decided to call. They capture the tool's name, the arguments the LLM passed in, and the value the tool returned.\n",
     "\n",
-    "In the agent trace above you have two tool spans: `get_weather` and `get_time_zone`, one for each tool the agent invoked. Select one of them in the trace tree to see the tool-specific attributes \u2014 the tool name, the arguments the LLM passed in (`{\"city\": \"Tokyo\"}`), and the value the tool returned.\n",
+    "In the agent trace above you have two tool spans: `get_weather` and `get_time_zone`, one for each tool the agent invoked. Select one of them in the trace tree to see the tool-specific attributes — the tool name, the arguments the LLM passed in (`{\"city\": \"Tokyo\"}`), and the value the tool returned.\n",
     "\n",
     "![The Attributes tab in Arize AX showing the get_weather tool span attributes, including the input city and the returned weather text](https://storage.googleapis.com/arize-phoenix-assets/assets/images/arize-docs-images/cookbooks/otel-cookbook/tool-span-attributes.png)\n",
     "\n",
@@ -961,7 +961,7 @@
    "id": "b2e53c6e",
    "metadata": {},
    "source": [
-    "**Agent spans** represent the work of an autonomous agent \u2014 the orchestration that decides when to call the LLM, when to call tools, when to call the LLM again, and when to stop. An agent span is typically the parent of the LLM, tool, and chain spans that make up the agent's loop.\n",
+    "**Agent spans** represent the work of an autonomous agent — the orchestration that decides when to call the LLM, when to call tools, when to call the LLM again, and when to stop. An agent span is typically the parent of the LLM, tool, and chain spans that make up the agent's loop.\n",
     "\n",
     "In the agent trace above, the `TravelAssistant` span is an agent span. Select it to see how it wraps both of the agent's turns, with all of the LLM and tool calls nested inside it.\n",
     "\n",
@@ -1005,7 +1005,7 @@
     "| Attribute | Description |\n",
     "| --- | --- |\n",
     "| `agent.name` | The name of the agent. Agents that perform the same logical role should share a name so you can group their traces together. |\n",
-    "| `graph.node.id` | The id of this agent's node in an execution graph. Optional \u2014 set when you want to visualize a multi-agent system as a graph in Arize AX. |\n",
+    "| `graph.node.id` | The id of this agent's node in an execution graph. Optional — set when you want to visualize a multi-agent system as a graph in Arize AX. |\n",
     "| `graph.node.name` | A human-readable name for the graph node |\n",
     "| `graph.node.parent_id` | The id of the parent node. Leave unset for a root agent. |\n",
     "\n",
@@ -1025,7 +1025,7 @@
    "id": "6a5e91b5",
    "metadata": {},
    "source": [
-    "**Chain spans** are general-purpose grouping spans. Use a chain span when you want to group a set of related work under a single parent in the trace tree \u2014 a multi-step pipeline, one agent turn, an LLM call with pre- and post-processing, or just a logical block in your application code.\n",
+    "**Chain spans** are general-purpose grouping spans. Use a chain span when you want to group a set of related work under a single parent in the trace tree — a multi-step pipeline, one agent turn, an LLM call with pre- and post-processing, or just a logical block in your application code.\n",
     "\n",
     "In the agent trace above the outer `Agent workflow` is a chain span, and each agent turn is also wrapped in a chain span called `turn`. Select a `turn` span to see how it groups the LLM and tool calls for that turn together.\n",
     "\n",
@@ -1043,7 +1043,7 @@
     "}\n",
     "```\n",
     "\n",
-    "The chain span carries only the kind and the common attributes \u2014 its value is purely structural, giving you a named parent in the trace tree."
+    "The chain span carries only the kind and the common attributes — its value is purely structural, giving you a named parent in the trace tree."
    ]
   },
   {
@@ -1059,7 +1059,7 @@
    "id": "ea30b7b2",
    "metadata": {},
    "source": [
-    "Chain spans have no kind-specific attributes. They rely on the common attributes covered in the Span attributes section above \u2014 `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, and so on. The chain span's value is purely structural: it gives you a named parent in the trace tree, with whatever input and output you choose to attach to it."
+    "Chain spans have no kind-specific attributes. They rely on the common attributes covered in the Span attributes section above — `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, and so on. The chain span's value is purely structural: it gives you a named parent in the trace tree, with whatever input and output you choose to attach to it."
    ]
   },
   {
@@ -1077,11 +1077,11 @@
    "source": [
     "Auto-instrumentors capture the standard OpenInference attributes for every span they create, but you often want to add your own. Common reasons:\n",
     "\n",
-    "- **Tag the call for filtering** \u2014 for example `experiment=\"v2-prompt\"` or `tenant=\"acme\"`\n",
-    "- **Attach domain metadata** \u2014 user tier, request id, feature flag value\n",
-    "- **Record a prompt template** \u2014 the template string, version, and variables you used, separate from the final flattened prompt\n",
+    "- **Tag the call for filtering** — for example `experiment=\"v2-prompt\"` or `tenant=\"acme\"`\n",
+    "- **Attach domain metadata** — user tier, request id, feature flag value\n",
+    "- **Record a prompt template** — the template string, version, and variables you used, separate from the final flattened prompt\n",
     "\n",
-    "With manually-created spans you can call `span.set_attribute(...)` directly inside the `with` block, as you saw in the manual instrumentation example. With auto-instrumented spans you do not have direct access to the span object \u2014 but you can still enrich it by putting attributes into the OpenTelemetry context using the **OpenInference context managers**. The auto-instrumentor reads from that context when it creates the span. This means the attributes are applied to every span created inside the block, no matter who creates it.\n",
+    "With manually-created spans you can call `span.set_attribute(...)` directly inside the `with` block, as you saw in the manual instrumentation example. With auto-instrumented spans you do not have direct access to the span object — but you can still enrich it by putting attributes into the OpenTelemetry context using the **OpenInference context managers**. The auto-instrumentor reads from that context when it creates the span. This means the attributes are applied to every span created inside the block, no matter who creates it.\n",
     "\n",
     "The available context managers are:\n",
     "\n",
@@ -1096,7 +1096,7 @@
     "\n",
     "See [OpenInference context managers](https://docs.arize.com/ax/concepts/otel-openinference/context-managers) for the full reference, including detailed usage patterns and gotchas.\n",
     "\n",
-    "The following code uses `using_metadata` to attach a domain-specific metadata dictionary. The example here wraps an OpenAI call so the metadata ends up on an LLM span, but the same pattern works for any span \u2014 auto-instrumented or manual \u2014 created inside the block."
+    "The following code uses `using_metadata` to attach a domain-specific metadata dictionary. The example here wraps an OpenAI call so the metadata ends up on an LLM span, but the same pattern works for any span — auto-instrumented or manual — created inside the block."
    ]
   },
   {
@@ -1124,7 +1124,7 @@
    "source": [
     "Open the new trace in Arize AX. The LLM span now has an additional attribute:\n",
     "\n",
-    "- `metadata` \u2014 a JSON string containing `{\"user_tier\": \"premium\", \"request_source\": \"cookbook\"}`\n",
+    "- `metadata` — a JSON string containing `{\"user_tier\": \"premium\", \"request_source\": \"cookbook\"}`\n",
     "\n",
     "It appears in the **Attributes** tab alongside the standard `llm.*` attributes.\n",
     "\n",
@@ -1148,7 +1148,7 @@
    "id": "c5991f49",
    "metadata": {},
    "source": [
-    "You can also override attributes that an auto-instrumentor has set, or add attributes that it left out. The OpenAI Agents SDK auto-instrumentor only sets `tool.name` on tool spans \u2014 it does not populate `tool.description`. The following code redefines `get_weather` to set a custom `tool.description` attribute on the active tool span, then recreates the agent and re-runs it.\n",
+    "You can also override attributes that an auto-instrumentor has set, or add attributes that it left out. The OpenAI Agents SDK auto-instrumentor only sets `tool.name` on tool spans — it does not populate `tool.description`. The following code redefines `get_weather` to set a custom `tool.description` attribute on the active tool span, then recreates the agent and re-runs it.\n",
     "\n",
     "The pattern works because the auto-instrumentor opens the tool span before calling your function, so the tool span is the active span when your function body runs. Calling `set_attribute(...)` on it inside the function body either overrides the attribute (if the instrumentor set it) or adds it (if the instrumentor did not)."
    ]
@@ -1170,7 +1170,7 @@
     "        \"Looks up the current weather conditions for a given city.\",\n",
     "    )\n",
     "\n",
-    "    return f\"The weather in {city} is sunny and 22\u00b0C.\"\n",
+    "    return f\"The weather in {city} is sunny and 22°C.\"\n",
     "\n",
     "\n",
     "travel_agent = Agent(\n",
@@ -1236,11 +1236,11 @@
    "source": [
     "You have now seen the building blocks for tracing AI applications with OpenInference and Arize AX:\n",
     "\n",
-    "- **OpenInference layers on top of OpenTelemetry** to add semantic conventions and auto-instrumentors for AI-specific concepts. The standard OpenTelemetry SDK still drives everything underneath \u2014 `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` are all unchanged.\n",
+    "- **OpenInference layers on top of OpenTelemetry** to add semantic conventions and auto-instrumentors for AI-specific concepts. The standard OpenTelemetry SDK still drives everything underneath — `TracerProvider`, `Tracer`, `Span`, `SpanProcessor`, and `Exporter` are all unchanged.\n",
     "- **Spans, traces, and sessions form a hierarchy.** A span is one step. A trace is a tree of spans tied together by `trace_id`. A session is a group of traces tied together by `session.id`. Sessions are how you stitch a multi-turn conversation together in Arize AX.\n",
-    "- **There are three ways to capture spans.** Auto-instrumentors wrap SDKs and emit spans for every call automatically. Manual instrumentation lets you create spans yourself with `tracer.start_as_current_span(...)`. Hybrid instrumentation combines the two \u2014 your manual spans wrap auto-instrumented calls and become their parents in the trace tree.\n",
-    "- **Every span carries a small set of common attributes** \u2014 `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, `user.id`, and `tag.tags` \u2014 regardless of the kind. The `openinference.span.kind` attribute drives how Arize AX renders the span.\n",
-    "- **Four span kinds cover most AI applications:** LLM, chain, agent, and tool. Each adds a kind-specific set of attributes \u2014 `llm.*` for model name, token counts, and costs; `tool.*` for tool name and description; `agent.name` (or `graph.node.id` for multi-agent graphs); chain spans rely on the common attributes alone.\n",
+    "- **There are three ways to capture spans.** Auto-instrumentors wrap SDKs and emit spans for every call automatically. Manual instrumentation lets you create spans yourself with `tracer.start_as_current_span(...)`. Hybrid instrumentation combines the two — your manual spans wrap auto-instrumented calls and become their parents in the trace tree.\n",
+    "- **Every span carries a small set of common attributes** — `openinference.span.kind`, `input.value`, `output.value`, `metadata`, `session.id`, `user.id`, and `tag.tags` — regardless of the kind. The `openinference.span.kind` attribute drives how Arize AX renders the span.\n",
+    "- **Four span kinds cover most AI applications:** LLM, chain, agent, and tool. Each adds a kind-specific set of attributes — `llm.*` for model name, token counts, and costs; `tool.*` for tool name and description; `agent.name` (or `graph.node.id` for multi-agent graphs); chain spans rely on the common attributes alone.\n",
     "- **You can enrich auto-instrumented spans.** Use OpenInference context managers like `using_session`, `using_metadata`, `using_tags`, and `using_prompt_template` to attach attributes that the auto-instrumentor picks up via the OpenTelemetry context. You can also override or add specific attributes by grabbing the active span inside a tool function and calling `set_attribute(...)` directly."
    ]
   },


### PR DESCRIPTION
## Summary

Adds a new hands-on cookbook teaching OpenInference best practices for tracing AI applications with Arize AX. Lives at `python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb`.

## What's covered

- How OpenInference layers on top of OpenTelemetry to add AI-aware semantics
- The hierarchy of sessions, traces, and spans
- Three ways to capture spans: auto-instrumentation, manual instrumentation, and the hybrid approach
- The common attributes every OpenInference span carries
- The four core span kinds (LLM, chain, agent, tool) and the attributes specific to each
- How to add or override attributes on auto-instrumented spans (OpenInference context managers like `using_metadata`, plus setting attributes on the active span from inside a tool function)

The walkthrough centers on a multi-tool agent built with the OpenAI Agents SDK that produces all four core span kinds in a single trace.

## Status

**Draft** — the notebook references screenshots that still need to be captured and dropped into `python/llm/tracing/otel-best-practices/`:

- `apikey.png`
- `sessions.png`, `session.png`, `sessions-1-session.png`, `sessions-2-sessions.png`
- `traces.png`, `trace.png`
- `llm-span.png`, `span-attributes.png`
- `data-pipeline.png`
- `agent-trace.png`
- `llm-span-attributes.png`, `tool-span-attributes.png`, `agent-span-attributes.png`, `chain-span-attributes.png`
- `llm-span-metadata.png`, `metadata-filter.png`
- `tool-override-attributes.png`

A mirroring cookbook MDX page in `Arize-ai/docs` will be opened as a separate PR once this notebook is ready to merge.

## Test plan

- [ ] Open the notebook in Colab and run all cells with valid Arize Space ID, API Key, and OpenAI API key
- [ ] Verify traces appear in the `otel-best-practices` Arize AX project
- [ ] Verify the multi-tool agent trace contains all four core span kinds (LLM, chain, agent, tool)
- [ ] Verify `using_metadata` adds the metadata attribute to LLM spans
- [ ] Verify the manual `tool.description` override appears on the `get_weather` span in the Tool Override Example session
- [ ] Capture and add all screenshots listed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)