### PR TITLE
Fix GitHub render: add missing cell id to header cell

### DIFF
--- a/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
+++ b/python/llm/tracing/otel-best-practices/openinference-span-kinds.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "8be56ed0",
    "metadata": {},
    "source": [
     "\n",


### PR DESCRIPTION
Cell 0 (the logo + title header) was missing its `id` field. nbformat 4.5+ requires every cell to have a unique id, and GitHub's notebook viewer rejects the file with "An error occurred" when one is missing. Local nbformat.validate() only warns, which is why this slipped through.

Fix applied via nbformat.validator.normalize().