### PR TITLE
new databricks integration notebook

### DIFF
--- a/python/cookbooks/databricks/databricks_dual_ingest_otel.ipynb
+++ b/python/cookbooks/databricks/databricks_dual_ingest_otel.ipynb
@@ -1,0 +1,912 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "d001cb5d-4849-413d-bae0-e8f833ddb7e7",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "<center>\n",
+        "    <p style=\"text-align:center\">\n",
+        "    <img alt=\"arize logo\" src=\"https://storage.googleapis.com/arize-assets/arize-logo-white.jpg\" width=\"300\"/>\n",
+        "        <br>\n",
+        "        <a href=\"https://docs.arize.com/arize/\">Docs</a>\n",
+        "        |\n",
+        "        <a href=\"https://github.com/Arize-ai/client_python\">GitHub</a>\n",
+        "        |\n",
+        "        <a href=\"https://arize-ai.slack.com/join/shared_invite/zt-11t1vbu4x-xkBIHmOREQnYnYDH1GDfCg\">Slack Community</a>\n",
+        "    </p>\n",
+        "</center>\n",
+        "\n",
+        "\n",
+        "\n",
+        "# Databricks Dual OTel ingest (Arize AX + Unity Catalog)\n",
+        "\n",
+        "This notebook demonstrates **split-stream tracing** for agents running outside Databricks-native auto-persist:\n",
+        "\n",
+        "1. **Arize AX** — sub-second OTLP ingest for trace exploration, evaluation, and monitoring.\n",
+        "2. **Databricks governed storage** — the same spans exported via OTLP to Unity Catalog Delta tables for retention, governance, and SQL analytics.\n",
+        "\n",
+        "**Demo workload:** OpenAI + LangChain tool-calling agent with OpenInference auto-instrumentation.\n",
+        "\n",
+        "**Prerequisites:** Unity Catalog workspace, [OpenTelemetry on Databricks](https://docs.databricks.com/aws/en/mlflow3/genai/tracing/trace-unity-catalog) preview enabled, Arize space API key, OpenAI API key.\n",
+        "\n",
+        "This notebook is **self-contained** — dependencies and dual-export helpers are defined inline (no separate `requirements.txt` or helper modules)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "f2b1f2ba-5ee7-4254-8e2c-d653e80452d8",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "## 1. Install dependencies"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "f83f0c54-e65b-4cdd-b5c8-0402adc0c5cf",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "outputs": [],
+      "source": [
+        "%pip install \\\n",
+        "  \"mlflow[databricks]>=3.11.0\" \\\n",
+        "  \"arize-otel>=0.8.0\" \\\n",
+        "  \"openinference-instrumentation-langchain>=0.1.30\" \\\n",
+        "  \"langchain>=1.0.0\" \\\n",
+        "  \"langchain-core>=0.3.0\" \\\n",
+        "  \"langchain-openai>=0.2.0\" \\\n",
+        "  \"opentelemetry-exporter-otlp-proto-http>=1.27.0\" \\\n",
+        "  \"openinference-semantic-conventions>=0.1.12\" \\\n",
+        "  --quiet\n",
+        "dbutils.library.restartPython()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "84c8e956-e2d2-4865-96b0-e900496dfe7b",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "## 2. Configuration\n",
+        "\n",
+        "Run this section **after** the install cell restarts Python.\n",
+        "\n",
+        "Set widgets below or map secrets to environment variables in your cluster policy.\n",
+        "\n",
+        "| Variable | Description |\n",
+        "|----------|-------------|\n",
+        "| `catalog_name` / `schema_name` / `table_prefix` | UC trace location |\n",
+        "| `experiment_name` | MLflow experiment (optional UI for traces) |\n",
+        "| `sql_warehouse_id` | Warehouse for trace search / SQL |\n",
+        "| `arize_project_name` | Arize project for spans |\n",
+        "| Secrets: `ARIZE_SPACE_ID`, `ARIZE_API_KEY`, `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, `OPENAI_API_KEY` | |\n",
+        "\n",
+        "Access Secrets from Databricks Secrets and set them as Environment Variables\n",
+        "- Create a [Arize API key and Space ID](https://docs.arize.com/arize/reference/authentication-and-security/api-keys) for the items below.\n",
+        "- Use [Databricks Secrets](https://docs.databricks.com/aws/en/security/secrets/) for secure access of keys."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "b383c6e3-d349-4935-a3b4-6b1632f26e88",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "dbutils.widgets.text(\"catalog_name\", \"main\", \"UC catalog\")\n",
+        "dbutils.widgets.text(\"schema_name\", \"otel_traces\", \"UC schema\")\n",
+        "dbutils.widgets.text(\"table_prefix\", \"partner_demo\", \"UC table prefix\")\n",
+        "dbutils.widgets.text(\n",
+        "    \"experiment_name\",\n",
+        "    \"/Shared/partner-dual-ingest-demo\",\n",
+        "    \"MLflow experiment\",\n",
+        ")\n",
+        "dbutils.widgets.text(\"sql_warehouse_id\", \"default-warehouse-id\", \"SQL warehouse ID\")\n",
+        "dbutils.widgets.text(\"arize_project_name\", \"databricks-dual-ingest-demo\", \"Arize project\")\n",
+        "dbutils.widgets.text(\"openai_model\", \"gpt-4o-mini\", \"OpenAI model\")\n",
+        "dbutils.widgets.text(\"demo_user_message\", \"What does our travel policy say about demo expenses?\", \"Demo prompt\")\n",
+        "\n",
+        "# Optional: load from a secret scope (uncomment and set scope name)\n",
+        "scope = \"arize-databricks-partner\"\n",
+        "os.environ[\"ARIZE_SPACE_ID\"] = dbutils.secrets.get(scope=scope, key=\"arize-space-id\")\n",
+        "os.environ[\"ARIZE_API_KEY\"] = dbutils.secrets.get(scope=scope, key=\"arize-api-key\")\n",
+        "os.environ[\"DATABRICKS_HOST\"] = dbutils.secrets.get(scope=scope, key=\"databricks-host\")\n",
+        "os.environ[\"DATABRICKS_TOKEN\"] = dbutils.secrets.get(scope=scope, key=\"databricks-token\")\n",
+        "os.environ[\"OPENAI_API_KEY\"] = dbutils.secrets.get(scope=scope, key=\"openai-api-key\")\n",
+        "\n",
+        "catalog_name = dbutils.widgets.get(\"catalog_name\").strip()\n",
+        "schema_name = dbutils.widgets.get(\"schema_name\").strip()\n",
+        "table_prefix = dbutils.widgets.get(\"table_prefix\").strip()\n",
+        "experiment_name = dbutils.widgets.get(\"experiment_name\").strip()\n",
+        "sql_warehouse_id = dbutils.widgets.get(\"sql_warehouse_id\").strip()\n",
+        "arize_project_name = dbutils.widgets.get(\"arize_project_name\").strip()\n",
+        "openai_model = dbutils.widgets.get(\"openai_model\").strip()\n",
+        "demo_user_message = dbutils.widgets.get(\"demo_user_message\").strip()\n",
+        "\n",
+        "if not sql_warehouse_id:\n",
+        "    raise ValueError(\"Set the sql_warehouse_id widget to a warehouse you can use.\")\n",
+        "\n",
+        "os.environ[\"MLFLOW_TRACING_SQL_WAREHOUSE_ID\"] = sql_warehouse_id\n",
+        "\n",
+        "# Default workspace URL when running on Databricks (override with DATABRICKS_HOST if needed)\n",
+        "if not os.environ.get(\"DATABRICKS_HOST\"):\n",
+        "    try:\n",
+        "        os.environ[\"DATABRICKS_HOST\"] = (\n",
+        "            dbutils.notebook.entry_point.getDbutils()\n",
+        "            .notebook()\n",
+        "            .getContext()\n",
+        "            .apiUrl()\n",
+        "            .get()\n",
+        "            .rstrip(\"/\")\n",
+        "        )\n",
+        "    except Exception:\n",
+        "        pass"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "dc7d1981-1699-40f0-b2ba-777ff35e1553",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "## 3. Bind MLflow experiment to Unity Catalog (public preview)\n",
+        "\n",
+        "Creates `{prefix}_otel_spans` (and related tables) and links the experiment for optional trace UI browsing."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "ab470516-b542-4695-883b-dd435ccb7a02",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "outputs": [],
+      "source": [
+        "import mlflow\n",
+        "from mlflow.entities.trace_location import UnityCatalog\n",
+        "\n",
+        "mlflow.set_tracking_uri(\"databricks\")\n",
+        "\n",
+        "experiment = mlflow.set_experiment(\n",
+        "    experiment_name=experiment_name,\n",
+        "    trace_location=UnityCatalog(\n",
+        "        catalog_name=catalog_name,\n",
+        "        schema_name=schema_name,\n",
+        "        table_prefix=table_prefix,\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "uc_spans_table = experiment.trace_location.full_otel_spans_table_name\n",
+        "print(f\"Experiment ID: {experiment.experiment_id}\")\n",
+        "print(f\"UC spans table: {uc_spans_table}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "fe3f39e6-c415-4e3c-b766-54a732ffe094",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "## 4. Configure dual OTLP export\n",
+        "\n",
+        "One `TracerProvider`, two span processors — **Arize (gRPC)** and **Databricks (OTLP HTTP)**."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "61377b1a-40e4-425d-a1be-8102edd2bbe1",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "from typing import Optional\n",
+        "\n",
+        "from opentelemetry import trace\n",
+        "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
+        "from opentelemetry.sdk.resources import Resource\n",
+        "from opentelemetry.sdk.trace import TracerProvider\n",
+        "from opentelemetry.sdk.trace.export import BatchSpanProcessor\n",
+        "\n",
+        "from arize.otel import BatchSpanProcessor as ArizeBatchSpanProcessor\n",
+        "from arize.otel import Endpoint\n",
+        "from arize.otel import GRPCSpanExporter as ArizeGRPCSpanExporter\n",
+        "from arize.otel import HTTPSpanExporter as ArizeHTTPSpanExporter\n",
+        "from arize.otel import Transport\n",
+        "from openinference.semconv.resource import ResourceAttributes\n",
+        "\n",
+        "\n",
+        "def _arize_endpoint():\n",
+        "    raw = (os.environ.get(\"ARIZE_COLLECTOR_ENDPOINT\") or \"\").strip()\n",
+        "    if \"eu-west\" in raw:\n",
+        "        return Endpoint.ARIZE_EUROPE\n",
+        "    if raw.startswith(\"http://\") or raw.startswith(\"https://\"):\n",
+        "        return raw.rstrip(\"/\")\n",
+        "    return Endpoint.ARIZE\n",
+        "\n",
+        "\n",
+        "def _arize_transport():\n",
+        "    mode = (os.environ.get(\"ARIZE_TRANSPORT\") or \"grpc\").strip().lower()\n",
+        "    return Transport.HTTP if mode == \"http\" else Transport.GRPC\n",
+        "\n",
+        "\n",
+        "def _require(name: str, value: Optional[str]) -> str:\n",
+        "    if not value or not str(value).strip():\n",
+        "        raise ValueError(f\"Missing required configuration: {name}\")\n",
+        "    return str(value).strip()\n",
+        "\n",
+        "\n",
+        "def configure_dual_export(\n",
+        "    *,\n",
+        "    project_name: str,\n",
+        "    uc_spans_table: str,\n",
+        "    service_name: str = \"langchain-external-agent-demo\",\n",
+        ") -> TracerProvider:\n",
+        "    project_name = _require(\"project_name\", project_name)\n",
+        "    space_id = _require(\n",
+        "        \"arize_space_id\",\n",
+        "        os.environ.get(\"ARIZE_SPACE_ID\") or os.environ.get(\"ARIZE_SPACE\"),\n",
+        "    )\n",
+        "    api_key = _require(\"arize_api_key\", os.environ.get(\"ARIZE_API_KEY\"))\n",
+        "    host = _require(\"databricks_host\", os.environ.get(\"DATABRICKS_HOST\")).rstrip(\"/\")\n",
+        "    token = _require(\"databricks_token\", os.environ.get(\"DATABRICKS_TOKEN\"))\n",
+        "\n",
+        "    resource = Resource.create(\n",
+        "        {\n",
+        "            ResourceAttributes.PROJECT_NAME: project_name,\n",
+        "            \"openinference.project.name\": project_name,\n",
+        "            \"service.name\": service_name,\n",
+        "            \"model_id\": project_name,\n",
+        "        }\n",
+        "    )\n",
+        "    provider = TracerProvider(resource=resource)\n",
+        "\n",
+        "    endpoint = _arize_endpoint()\n",
+        "    transport = _arize_transport()\n",
+        "    if transport == Transport.GRPC:\n",
+        "        arize_exporter = ArizeGRPCSpanExporter(\n",
+        "            space_id=space_id, api_key=api_key, endpoint=endpoint\n",
+        "        )\n",
+        "    else:\n",
+        "        arize_exporter = ArizeHTTPSpanExporter(\n",
+        "            space_id=space_id, api_key=api_key, endpoint=endpoint\n",
+        "        )\n",
+        "\n",
+        "    provider.add_span_processor(ArizeBatchSpanProcessor(span_exporter=arize_exporter))\n",
+        "    print(\n",
+        "        f\"Arize export: transport={transport.value}, endpoint={endpoint}, project={project_name}\"\n",
+        "    )\n",
+        "\n",
+        "    dbx_exporter = OTLPSpanExporter(\n",
+        "        endpoint=f\"{host}/api/2.0/otel/v1/traces\",\n",
+        "        headers={\n",
+        "            \"content-type\": \"application/x-protobuf\",\n",
+        "            \"X-Databricks-UC-Table-Name\": uc_spans_table,\n",
+        "            \"Authorization\": f\"Bearer {token}\",\n",
+        "        },\n",
+        "    )\n",
+        "    provider.add_span_processor(BatchSpanProcessor(dbx_exporter))\n",
+        "    trace.set_tracer_provider(provider)\n",
+        "    return provider\n",
+        "\n",
+        "\n",
+        "def shutdown_tracer(provider: TracerProvider) -> None:\n",
+        "    provider.force_flush()\n",
+        "    provider.shutdown()\n",
+        "\n",
+        "\n",
+        "tracer_provider = configure_dual_export(\n",
+        "    project_name=arize_project_name,\n",
+        "    uc_spans_table=uc_spans_table,\n",
+        "    service_name=\"langchain-external-agent-demo\",\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "15fd24ed-39f9-4f72-8115-11b9e929ea13",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "## 5. Instrument LangChain and run the demo agent"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "62b6fc4d-f6b9-4f9e-9aaa-a0655c4ada47",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "outputs": [],
+      "source": [
+        "from langchain.agents import create_agent\n",
+        "from langchain_core.tools import tool\n",
+        "from langchain_openai import ChatOpenAI\n",
+        "from openinference.instrumentation.langchain import LangChainInstrumentor\n",
+        "\n",
+        "LangChainInstrumentor().instrument(tracer_provider=tracer_provider)\n",
+        "\n",
+        "@tool\n",
+        "def lookup_policy(topic: str) -> str:\n",
+        "    \"\"\"Return a short internal policy snippet for the given topic.\"\"\"\n",
+        "    policies = {\n",
+        "        \"travel\": \"Demo travel expenses under $500 are pre-approved for partner workshops.\",\n",
+        "        \"security\": \"All agent outputs must stay within approved data boundaries.\",\n",
+        "    }\n",
+        "    return policies.get(topic.lower(), f\"No policy on file for '{topic}'.\")\n",
+        "\n",
+        "llm = ChatOpenAI(model=openai_model, temperature=0)\n",
+        "tools = [lookup_policy]\n",
+        "\n",
+        "agent = create_agent(\n",
+        "    llm,\n",
+        "    tools=tools,\n",
+        "    system_prompt=(\n",
+        "        \"You are an enterprise assistant. Use tools when you need policy details. Be concise.\"\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "print(\"Running demo agent...\")\n",
+        "result = agent.invoke({\"messages\": [{\"role\": \"user\", \"content\": demo_user_message}]})\n",
+        "\n",
+        "messages = result.get(\"messages\", [])\n",
+        "print(\"\\n--- Agent response ---\")\n",
+        "print(messages[-1].content if messages else result)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "28818788-c04b-48f1-b91c-b407a1fd351f",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "## 6. Flush spans\n",
+        "\n",
+        "Ensures OTLP batches are delivered before verification (required for short notebook runs)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "38db3010-e5bc-497d-b4a5-cb6f402dff08",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "outputs": [],
+      "source": [
+        "shutdown_tracer(tracer_provider)\n",
+        "print(\"Tracer shut down and spans flushed.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "b56b7d8f-d90f-4015-910f-a5811447b69f",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "## 7. Verify Unity Catalog ingest (Databricks SQL)\n",
+        "\n",
+        "Spans should appear in `{catalog}.{schema}.{prefix}_otel_spans` within a short delay after export."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "01f18282-3610-4266-8b68-2336d7a683a2",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "outputs": [],
+      "source": [
+        "import time\n",
+        "time.sleep(15)\n",
+        "\n",
+        "display(\n",
+        "    spark.sql(f\"\"\"\n",
+        "        SELECT\n",
+        "          trace_id,\n",
+        "          span_id,\n",
+        "          name,\n",
+        "          kind,\n",
+        "          start_time_unix_nano,\n",
+        "          end_time_unix_nano,\n",
+        "          (end_time_unix_nano - start_time_unix_nano) / 1e6 AS duration_ms\n",
+        "        FROM {uc_spans_table}\n",
+        "        ORDER BY start_time_unix_nano DESC\n",
+        "        LIMIT 10\n",
+        "    \"\"\")\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "55366966-0572-4377-ba1c-909f998647aa",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "## 8. Verify Arize AX\n",
+        "\n",
+        "Open your Arize project (widget: `arize_project_name`) in the AX UI. You should see the same agent run with LLM and tool spans.\n",
+        "\n",
+        "If traces are missing:\n",
+        "- Confirm `ARIZE_SPACE_ID` and `ARIZE_API_KEY`\n",
+        "- Confirm `arize_project_name` is set (required resource attribute)\n",
+        "- Re-run after checking cluster env vars"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "6ed12488-1de6-4c1f-a2a5-6ab8be6b1165",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "outputs": [],
+      "source": [
+        "print(\n",
+        "    f\"Check Arize AX → project '{arize_project_name}' for traces from service \"\n",
+        "    \"'langchain-external-agent-demo'.\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "11699cce-0d1f-4b31-9e91-76a7317ce3db",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "## 9. Optional: MLflow Experiment UI\n",
+        "\n",
+        "In the workspace **Experiments** page, open `{experiment_name}` → **Traces** tab (select your SQL warehouse). This is optional; SQL on the UC spans table is the primary governed-store proof."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "6f84c5ab-5af8-44cc-8629-54770317dcd7",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "outputs": [],
+      "source": [
+        "print(f\"MLflow experiment: {experiment_name}\")\n",
+        "print(f\"Experiment ID: {experiment.experiment_id}\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "application/vnd.databricks.v1+notebook": {
+      "computePreferences": null,
+      "dashboards": [],
+      "environmentMetadata": null,
+      "inputWidgetPreferences": null,
+      "language": "python",
+      "notebookMetadata": {
+        "mostRecentlyExecutedCommandWithImplicitDF": {
+          "commandId": -1,
+          "dataframes": [
+            "_sqldf"
+          ]
+        },
+        "pythonIndentUnit": 4
+      },
+      "notebookName": "dual_ingest_external_otel",
+      "widgets": {
+        "arize_project_name": {
+          "currentValue": "databricks-dual-ingest-demo",
+          "nuid": "4b27e6cd-e805-4f7b-bc1f-1d033492576c",
+          "typedWidgetInfo": {
+            "autoCreated": false,
+            "defaultValue": "databricks-dual-ingest-demo",
+            "dynamic": false,
+            "label": "Arize project",
+            "name": "arize_project_name",
+            "options": {
+              "validationRegex": null,
+              "widgetDisplayType": "Text"
+            },
+            "parameterDataType": "String"
+          },
+          "widgetInfo": {
+            "defaultValue": "databricks-dual-ingest-demo",
+            "label": "Arize project",
+            "name": "arize_project_name",
+            "options": {
+              "autoCreated": null,
+              "validationRegex": null,
+              "widgetType": "text"
+            },
+            "widgetType": "text"
+          }
+        },
+        "catalog_name": {
+          "currentValue": "ry_test",
+          "nuid": "923b09df-78cf-4081-bd0e-5e6f7cc52a69",
+          "typedWidgetInfo": {
+            "autoCreated": false,
+            "defaultValue": "main",
+            "dynamic": false,
+            "label": "UC catalog",
+            "name": "catalog_name",
+            "options": {
+              "validationRegex": null,
+              "widgetDisplayType": "Text"
+            },
+            "parameterDataType": "String"
+          },
+          "widgetInfo": {
+            "defaultValue": "main",
+            "label": "UC catalog",
+            "name": "catalog_name",
+            "options": {
+              "autoCreated": null,
+              "validationRegex": null,
+              "widgetType": "text"
+            },
+            "widgetType": "text"
+          }
+        },
+        "demo_user_message": {
+          "currentValue": "What does our travel policy say about entertainment expenses?",
+          "nuid": "1900e7a0-8621-4fae-98ee-6103d55f9174",
+          "typedWidgetInfo": {
+            "autoCreated": false,
+            "defaultValue": "What does our travel policy say about demo expenses?",
+            "dynamic": false,
+            "label": "Demo prompt",
+            "name": "demo_user_message",
+            "options": {
+              "validationRegex": null,
+              "widgetDisplayType": "Text"
+            },
+            "parameterDataType": "String"
+          },
+          "widgetInfo": {
+            "defaultValue": "What does our travel policy say about demo expenses?",
+            "label": "Demo prompt",
+            "name": "demo_user_message",
+            "options": {
+              "autoCreated": null,
+              "validationRegex": null,
+              "widgetType": "text"
+            },
+            "widgetType": "text"
+          }
+        },
+        "experiment_name": {
+          "currentValue": "/Shared/partner-dual-ingest-demo",
+          "nuid": "0cd674e8-57d4-4415-a7b7-3ef343698ab7",
+          "typedWidgetInfo": {
+            "autoCreated": false,
+            "defaultValue": "/Shared/partner-dual-ingest-demo",
+            "dynamic": false,
+            "label": "MLflow experiment",
+            "name": "experiment_name",
+            "options": {
+              "validationRegex": null,
+              "widgetDisplayType": "Text"
+            },
+            "parameterDataType": "String"
+          },
+          "widgetInfo": {
+            "defaultValue": "/Shared/partner-dual-ingest-demo",
+            "label": "MLflow experiment",
+            "name": "experiment_name",
+            "options": {
+              "autoCreated": null,
+              "validationRegex": null,
+              "widgetType": "text"
+            },
+            "widgetType": "text"
+          }
+        },
+        "openai_model": {
+          "currentValue": "gpt-4o-mini",
+          "nuid": "557d1ad2-525a-4e6c-aa7d-05f078973642",
+          "typedWidgetInfo": {
+            "autoCreated": false,
+            "defaultValue": "gpt-4o-mini",
+            "dynamic": false,
+            "label": "OpenAI model",
+            "name": "openai_model",
+            "options": {
+              "validationRegex": null,
+              "widgetDisplayType": "Text"
+            },
+            "parameterDataType": "String"
+          },
+          "widgetInfo": {
+            "defaultValue": "gpt-4o-mini",
+            "label": "OpenAI model",
+            "name": "openai_model",
+            "options": {
+              "autoCreated": null,
+              "validationRegex": null,
+              "widgetType": "text"
+            },
+            "widgetType": "text"
+          }
+        },
+        "schema_name": {
+          "currentValue": "arize",
+          "nuid": "57366c76-8a30-44d6-afb0-16910103ba12",
+          "typedWidgetInfo": {
+            "autoCreated": false,
+            "defaultValue": "otel_traces",
+            "dynamic": false,
+            "label": "UC schema",
+            "name": "schema_name",
+            "options": {
+              "validationRegex": null,
+              "widgetDisplayType": "Text"
+            },
+            "parameterDataType": "String"
+          },
+          "widgetInfo": {
+            "defaultValue": "otel_traces",
+            "label": "UC schema",
+            "name": "schema_name",
+            "options": {
+              "autoCreated": null,
+              "validationRegex": null,
+              "widgetType": "text"
+            },
+            "widgetType": "text"
+          }
+        },
+        "sql_warehouse_id": {
+          "currentValue": "0737a5babbaf7edd",
+          "nuid": "b4674f2f-c9a1-42d3-b618-da87793ff164",
+          "typedWidgetInfo": {
+            "autoCreated": false,
+            "defaultValue": "default-warehouse-id",
+            "dynamic": false,
+            "label": "SQL warehouse ID",
+            "name": "sql_warehouse_id",
+            "options": {
+              "validationRegex": null,
+              "widgetDisplayType": "Text"
+            },
+            "parameterDataType": "String"
+          },
+          "widgetInfo": {
+            "defaultValue": "default-warehouse-id",
+            "label": "SQL warehouse ID",
+            "name": "sql_warehouse_id",
+            "options": {
+              "autoCreated": null,
+              "validationRegex": null,
+              "widgetType": "text"
+            },
+            "widgetType": "text"
+          }
+        },
+        "table_prefix": {
+          "currentValue": "rytraces",
+          "nuid": "c5b7be74-20d5-4f4e-8754-3b486dfbaed8",
+          "typedWidgetInfo": {
+            "autoCreated": false,
+            "defaultValue": "partner_demo",
+            "dynamic": false,
+            "label": "UC table prefix",
+            "name": "table_prefix",
+            "options": {
+              "validationRegex": null,
+              "widgetDisplayType": "Text"
+            },
+            "parameterDataType": "String"
+          },
+          "widgetInfo": {
+            "defaultValue": "partner_demo",
+            "label": "UC table prefix",
+            "name": "table_prefix",
+            "options": {
+              "autoCreated": null,
+              "validationRegex": null,
+              "widgetType": "text"
+            },
+            "widgetType": "text"
+          }
+        }
+      }
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
For databricks partnerships:

This notebook demonstrates **split-stream tracing** for agents running outside Databricks-native auto-persist:

1. **Arize AX** — sub-second OTLP ingest for trace exploration, evaluation, and monitoring.
2. **Databricks governed storage** — the same spans exported via OTLP to Unity Catalog Delta tables for retention, governance, and SQL analytics.


Instrumentation library update (near-term). Since Arize requires sub-second processing to keep the observability UI responsive, this path splits the telemetry data flow into two concurrent streams. One stream goes directly to Arize for real-time monitoring, while the other hits Databricks ZeroBus—landing telemetry in open lakehouse format in approximately 5 seconds.

How it works:
Arize creates or updates its OpenTelemetry instrumentation libraries to support dual-destination export
Stream 1 (Arize) — OTel traces are sent directly to Arize’s OTLP endpoint for sub-second ingestion, powering real-time trace explorer, dashboards, and alerts
Stream 2 (Databricks) — The same OTel traces are simultaneously sent to Databricks ZeroBus, which lands them in governed Delta tables under Unity Catalog in ~5 seconds
Both streams receive identical telemetry data—no lossy fan-out

Customer value:
Real-time speed for interactive debugging and monitoring (Arize) plus long-term governed persistence (Databricks)
Customers get both the specialized AI observability UX and the open lakehouse benefits without choosing one over the other
ZeroBus-ingested traces are available for Databricks-native analytics, compliance queries, and cross-platform joins
Arize ingested traces are available in Arize for real time agent troubleshooting, evaluation, improvement workflows
