### PR TITLE
fix(deps): patch form-data + @opentelemetry/core Dependabot alerts in beeai tutorial

### DIFF
--- a/typescript/llm/tracing/beeai/package.json
+++ b/typescript/llm/tracing/beeai/package.json
@@ -43,7 +43,9 @@
     "@grpc/grpc-js": ">=1.14.4",
     "@opentelemetry/sdk-node": ">=0.217.0",
     "@opentelemetry/exporter-prometheus": ">=0.217.0",
+    "@opentelemetry/core": ">=2.8.0",
     "fast-uri": ">=3.1.2",
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "form-data": ">=4.0.6"
   }
 }

--- a/typescript/llm/tracing/beeai/yarn.lock
+++ b/typescript/llm/tracing/beeai/yarn.lock
@@ -580,19 +580,12 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz#24381ef388bc28d53fa8dad72dfd1429acc82016"
   integrity sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==
 
-"@opentelemetry/core@2.8.0":
+"@opentelemetry/core@2.8.0", "@opentelemetry/core@>=2.8.0", "@opentelemetry/core@^1.25.1":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.8.0.tgz#f6e86de3688bdb54a6ca8f4935363a5b588ae91c"
   integrity sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==
   dependencies:
     "@opentelemetry/semantic-conventions" "^1.29.0"
-
-"@opentelemetry/core@^1.25.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.30.1.tgz#a0b468bb396358df801881709ea38299fc30ab27"
-  integrity sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==
-  dependencies:
-    "@opentelemetry/semantic-conventions" "1.28.0"
 
 "@opentelemetry/exporter-logs-otlp-grpc@0.219.0":
   version "0.219.0"
@@ -862,11 +855,6 @@
     "@opentelemetry/context-async-hooks" "2.8.0"
     "@opentelemetry/core" "2.8.0"
     "@opentelemetry/sdk-trace-base" "2.8.0"
-
-"@opentelemetry/semantic-conventions@1.28.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz#337fb2bca0453d0726696e745f50064411f646d6"
-  integrity sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==
 
 "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0":
   version "1.41.1"
@@ -1443,16 +1431,16 @@ follow-redirects@>=1.16.0, follow-redirects@^1.16.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
-form-data@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
-  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
+form-data@>=4.0.6, form-data@^4.0.5:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
-    mime-types "^2.1.12"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 fraction.js@^5.2.1:
   version "5.3.4"
@@ -1523,7 +1511,7 @@ has-tostringtag@^1.0.2:
   dependencies:
     has-symbols "^1.0.3"
 
-hasown@^2.0.2, hasown@^2.0.3:
+hasown@^2.0.2, hasown@^2.0.3, hasown@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
   integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
@@ -1674,7 +1662,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12:
+mime-types@^2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==


### PR DESCRIPTION
## Summary
Fixes the patchable Dependabot alerts in `typescript/llm/tracing/beeai` by extending the project's existing `resolutions` block and regenerating `yarn.lock`.

| # | Package | Severity | Was → Now | Status |
|---|---------|----------|-----------|--------|
| #79 | `form-data` | **high** | 4.0.5 → **4.0.6** | ✅ Fixed — CRLF injection via unescaped multipart field names/filenames |
| #80 | `@opentelemetry/core` | medium | 1.30.1 → **2.8.0** | ✅ Fixed — unbounded memory allocation in W3C Baggage propagation |
| #67 | `@ai-sdk/provider-utils` | low | 3.0.25 | ⚠️ No patched release available |

### Notes
- **#80:** `@arizeai/openinference-core@2.2.0` (latest) pins `@opentelemetry/core@^1.25.1`, but the entire 1.x line is unpatched — only 2.8.0 fixes the advisory. A `>=2.8.0` resolution forces it, which aligns core with the rest of the project's already-2.x OTel stack (`sdk-trace-base`, `resources`, `sdk-trace-node`) rather than leaving a 1.x/2.x split.
- **#67 (left as-is):** Dependabot reports `first_patched_version: null` — there is no fixed release in the 3.x line, and `@ai-sdk/openai@2.x` + `ollama-ai-provider-v2` both require 3.x. Forcing the 4.x line would break those at runtime. Recommend dismissing or waiting for an upstream fix.

## Testing
- `yarn install` — clean
- `npx tsc --noEmit` — passes
- `yarn start` against local Ollama (llama3.2) — app boots, instrumentation initializes, `@opentelemetry/core@2.8.0` loads without error, connects to Ollama. The agent's subsequent `NoObjectGeneratedError` is llama3.2 returning an empty structured-output response (model flakiness), reproducible independent of these bumps — the lockfile diff touches only `form-data` and `@opentelemetry/core`, nothing in the `beeai-framework`/`ai`/`@ai-sdk`/`ollama` runtime path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)