### PR TITLE
ci(check-models): run on Node 24

### DIFF
--- a/.github/workflows/check-models.yml
+++ b/.github/workflows/check-models.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Scan touched files for outdated models
         id: scan


### PR DESCRIPTION
Bumps the `check-models` workflow's `actions/setup-node` from Node **20 → 24**.

The scanner (`scan-models.mjs`) runs fine on Node 24; this just keeps CI on a current LTS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)